### PR TITLE
Add `rspec`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,10 @@ group :lint do
   gem 'mdl', '>= 0.13', '< 1'
   gem 'rubocop', '>= 1.65', '< 2'
   gem 'rubocop-performance', '>= 1.21', '< 2'
+  gem 'rubocop-rspec', '>= 3.0', '< 4'
+end
+
+group :test do
+  gem 'rspec', '>= 3.13', '< 4'
+  gem 'simplecov', '>= 0.22', '< 1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,8 @@ GEM
     chef-utils (18.5.0)
       concurrent-ruby
     concurrent-ruby (1.3.4)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
     json (2.7.2)
     kramdown (2.4.0)
       rexml
@@ -35,6 +37,19 @@ GEM
     rainbow (3.1.1)
     regexp_parser (2.9.2)
     rexml (3.3.8)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.1)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -50,7 +65,15 @@ GEM
     rubocop-performance (1.22.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (3.1.0)
+      rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     tomlrb (2.0.3)
     unicode-display_width (2.6.0)
 
@@ -61,8 +84,11 @@ PLATFORMS
 DEPENDENCIES
   domainic!
   mdl (>= 0.13, < 1)
+  rspec (>= 3.13, < 4)
   rubocop (>= 1.65, < 2)
   rubocop-performance (>= 1.21, < 2)
+  rubocop-rspec (>= 3.0, < 4)
+  simplecov (>= 0.22, < 1)
 
 BUNDLED WITH
    2.5.17

--- a/config/common_spec_helper.rb
+++ b/config/common_spec_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+
+SimpleCov.start do
+  enable_coverage :branch
+  coverage_dir File.expand_path('../coverage', __dir__)
+  add_filter '/config/'
+  add_filter '/spec/'
+
+  track_files File.expand_path('../**/*.rb', __dir__)
+end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.disable_monkey_patching!
+  config.warnings = true
+  config.order = :random
+  Kernel.srand config.seed
+end

--- a/config/rspec_client.rb
+++ b/config/rspec_client.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'pathname'
+
+def gem_directories_with_gemspec
+  Dir.glob('*').select do |dir|
+    File.directory?(dir) && Dir.glob("#{dir}/*.gemspec").any?
+  end
+end
+
+gem_paths = gem_directories_with_gemspec.select do |gem_dir|
+  ARGV.any? do |arg|
+    arg.start_with?(gem_dir) ||
+      arg.start_with?(File.join(Dir.getwd, gem_dir)) ||
+      arg.start_with?(File.join('.', gem_dir))
+  end
+end
+
+gem_paths.each do |gem_path|
+  spec_dir = Pathname.new(gem_path).join('spec')
+  $LOAD_PATH << spec_dir.to_s if spec_dir.exist? && !$LOAD_PATH.include?(spec_dir.to_s)
+
+  spec_helper = spec_dir.join('spec_helper.rb')
+  load spec_helper.to_s if spec_helper.exist?
+end


### PR DESCRIPTION
This patch adds `rspec` to the project as well as some support files to allow for gems in the monorepo to manage their own spec files while still being able to run rspec from the root directory

resolves #11 