### PR TITLE
Manage gems with `domainic-dev`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,13 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.1
 
+Naming/FileName:
+  Exclude:
+    - '**/domainic-*'
+
 RBS:
   Enabled: true
+
+Style/Documentation:
+  Exclude:
+    - '**/*.rbs'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Naming/FileName:
 RBS:
   Enabled: true
 
+RSpec/NestedGroups:
+  AllowedGroups:
+    - describe
+
 Style/Documentation:
   Exclude:
     - '**/*.rbs'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@
 source 'https://rubygems.org'
 gemspec
 
+group :development do
+  gem 'domainic-dev', path: 'domainic-dev'
+end
+
 group :doc do
   gem 'github-markup', '>= 5.0', '< 6'
   gem 'redcarpet', '>= 3.6', '< 4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
   remote: domainic-dev
   specs:
     domainic-dev (0.1.0)
+      semantic (>= 1.6, < 2)
 
 GEM
   remote: https://rubygems.org/
@@ -33,6 +34,7 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.1)
     drb (2.2.1)
+    ffi (1.17.0)
     ffi (1.17.0-arm64-darwin)
     fileutils (1.7.2)
     github-markup (5.0.1)
@@ -113,6 +115,7 @@ GEM
       yard
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
+    semantic (1.6.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,11 @@ PATH
   specs:
     domainic (0.1.0)
 
+PATH
+  remote: domainic-dev
+  specs:
+    domainic-dev (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -147,6 +152,7 @@ PLATFORMS
 
 DEPENDENCIES
   domainic!
+  domainic-dev!
   github-markup (>= 5.0, < 6)
   mdl (>= 0.13, < 1)
   rbs (>= 3.6, < 4)

--- a/Steepfile
+++ b/Steepfile
@@ -3,4 +3,6 @@
 target :domainic_dev do
   check 'domainic-dev/lib/**/*.rb'
   signature 'domainic-dev/sig/**/*.rbs'
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/Steepfile
+++ b/Steepfile
@@ -1,1 +1,6 @@
 # frozen_string_literal: true
+
+target :domainic_dev do
+  check 'domainic-dev/lib/**/*.rb'
+  signature 'domainic-dev/sig/**/*.rbs'
+end

--- a/domainic-dev/LICENSE
+++ b/domainic-dev/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Aaron Allen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/domainic-dev/README.md
+++ b/domainic-dev/README.md
@@ -1,0 +1,3 @@
+# Domainic::Dev
+
+Tools and utilities for developing the Domainic framework.

--- a/domainic-dev/domainic-dev.gemspec
+++ b/domainic-dev/domainic-dev.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => DOMAINIC_DEV_HOME_URL
   }
+
+  spec.add_dependency 'semantic', '>= 1.6', '< 2'
 end

--- a/domainic-dev/domainic-dev.gemspec
+++ b/domainic-dev/domainic-dev.gemspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+DOMAINIC_DEV_GEM_VERSION = '0.1.0'
+DOMAINIC_DEV_SEMVER = '0.1.0'
+DOMAINIC_DEV_REPO_URL = 'https://github.com/domainic/domainic'
+DOMAINIC_DEV_HOME_URL = "#{DOMAINIC_DEV_REPO_URL}/tree/domainic-dev".freeze
+
+Gem::Specification.new do |spec|
+  spec.name     = 'domainic-dev'
+  spec.version  = DOMAINIC_DEV_GEM_VERSION
+  spec.homepage = DOMAINIC_DEV_HOME_URL
+  spec.authors  = ['Aaron Allen']
+  spec.email    = ['hello@aaronmallen.me']
+  spec.summary  = 'Domainic Development Tools'
+  spec.license  = 'MIT'
+
+  spec.required_ruby_version = '>= 3.1'
+
+  spec.files         = Dir['LICENSE', 'README.md', 'lib/**/*', 'sig/**/*']
+  spec.require_paths = ['lib']
+
+  spec.metadata = {
+    'bug_tracker_uri' => "#{DOMAINIC_DEV_REPO_URL}/issues",
+    'homepage_uri' => spec.homepage,
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => DOMAINIC_DEV_HOME_URL
+  }
+end

--- a/domainic-dev/lib/domainic-dev.rb
+++ b/domainic-dev/lib/domainic-dev.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'domainic/dev'

--- a/domainic-dev/lib/domainic/dev.rb
+++ b/domainic-dev/lib/domainic/dev.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'pathname'
 require 'semantic'
 

--- a/domainic-dev/lib/domainic/dev.rb
+++ b/domainic-dev/lib/domainic/dev.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Domainic
+  # Tools and utilities for developing the Domainic framework.
+  #
+  # @api development
+  #
+  # @since 0.1.0
+  module Dev
+  end
+end

--- a/domainic-dev/lib/domainic/dev.rb
+++ b/domainic-dev/lib/domainic/dev.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'semantic'
 
 require_relative 'dev/gem_manager'
 

--- a/domainic-dev/lib/domainic/dev.rb
+++ b/domainic-dev/lib/domainic/dev.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 module Domainic
   # Tools and utilities for developing the Domainic framework.
   #
@@ -7,5 +9,11 @@ module Domainic
   #
   # @since 0.1.0
   module Dev
+    # The root path of the Domainic framework.
+    #
+    # @return [Pathname] the root path.
+    def self.root
+      Pathname.new(File.expand_path('../../../', File.dirname(__FILE__)))
+    end
   end
 end

--- a/domainic-dev/lib/domainic/dev.rb
+++ b/domainic-dev/lib/domainic/dev.rb
@@ -2,6 +2,8 @@
 
 require 'pathname'
 
+require_relative 'dev/gem_manager'
+
 module Domainic
   # Tools and utilities for developing the Domainic framework.
   #

--- a/domainic-dev/lib/domainic/dev/gem_manager.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'gem_manager/version'
+require_relative 'gem_manager/publisher'
 require_relative 'gem_manager/gem'
 
 module Domainic

--- a/domainic-dev/lib/domainic/dev/gem_manager.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'gem_manager/version'
+require_relative 'gem_manager/gem'
 
 module Domainic
   module Dev

--- a/domainic-dev/lib/domainic/dev/gem_manager.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager.rb
@@ -9,6 +9,20 @@ module Domainic
     #
     # @since 0.1.0
     module GemManager
+      # Find a gem by name.
+      #
+      # @param gem_name [String] The name of the gem to find.
+      # @return [Gem, nil] The gem object if found, otherwise nil.
+      def self.gem(gem_name)
+        gems.find { |gem| gem.name == gem_name }
+      end
+
+      # Find all gems in the Domainic repository.
+      #
+      # @return [Array<Gem>] An array of gem objects.
+      def self.gems
+        Dev.root.glob('{*/*.gemspec,domainic.gemspec}').map(&:dirname).map { |path| Gem.new(path) }
+      end
     end
   end
 end

--- a/domainic-dev/lib/domainic/dev/gem_manager.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'gem_manager/version'
+
+module Domainic
+  module Dev
+    # The `GemManager` module is responsible for managing, versioning, building and publishing Domainic gems.
+    #
+    # @since 0.1.0
+    module GemManager
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/dev/gem_manager/gem.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager/gem.rb
@@ -78,6 +78,13 @@ module Domainic
           parts.join('_')
         end
 
+        # Publish the gem to RubyGems.
+        #
+        # @return [void]
+        def publish!
+          Publisher.new(self).publish!
+        end
+
         # Sync the gemspec file with the current {#version}.
         #
         # @return [void]

--- a/domainic-dev/lib/domainic/dev/gem_manager/gem.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager/gem.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Dev
+    module GemManager
+      # The Gem class is responsible for managing the gem's metadata and dependencies.
+      #
+      # @!attribute [r] dependencies
+      #  The dependencies of the gem.
+      #  @return [Array<::Gem::Dependency>]
+      #
+      # @!attribute [r] name
+      #  The name of the gem.
+      #  @return [String]
+      #
+      # @!attribute [r] paths
+      #  The paths of the gem.
+      #  @return [Paths]
+      #
+      # @since 0.1.0
+      class Gem
+        # Important paths for the gem.
+        #
+        # @!attribute [r] gemspec
+        #  The path to the gemspec file of the gem.
+        #  @return [Pathname]
+        #
+        # @!attribute [r] lib
+        #  The path to the lib directory of the gem.
+        #  @return [Pathname]
+        #
+        # @!attribute [r] root
+        #  The path to the root directory of the gem.
+        #  @return [Pathname]
+        #
+        # @!attribute [r] sig
+        #  The path to the signatures directory of the gem.
+        #  @return [Pathname]
+        #
+        # @!attribute [r] test
+        #  The path to the test directory of the gem.
+        #  @return [Pathname]
+        Paths = Struct.new(:gemspec, :lib, :root, :sig, :test, keyword_init: true)
+
+        # @dynamic dependencies
+        # @dynamic name
+        # @dynamic paths
+        attr_reader :dependencies, :name, :paths
+
+        # Initialize a new instance of Gem.
+        #
+        # @param root_directory [Pathname] The path to the root directory of the gem.
+        # @return [Gem] the new instance of Gem.
+        def initialize(root_directory)
+          initialize_paths(root_directory)
+
+          spec = ::Gem::Specification.load(paths.gemspec.to_s)
+          @dependencies = spec.dependencies
+          @name = spec.name
+        end
+
+        # Build the gem and move the built gem file to the `pkg` directory.
+        #
+        # @return [void]
+        def build!
+          sync!
+          system("gem build -V #{paths.gemspec}")
+          built_gem_path = Dir.glob('*.gem').first
+          FileUtils.mkdir_p('pkg')
+          FileUtils.mv(built_gem_path, 'pkg') if built_gem_path
+        end
+
+        # The gem name in a constant friendly format.
+        #
+        # @return [String] the constant friendly name of the gem.
+        def constant_name
+          parts = name.split(/[-_]/).map(&:upcase)
+          parts.join('_')
+        end
+
+        # Sync the gemspec file with the current {#version}.
+        #
+        # @return [void]
+        def sync!
+          paths.gemspec.write(build_gemspec)
+        end
+
+        # The {Version} instance for the gem.
+        #
+        # @raise [RuntimeError] if the gemspec does not contain a SEMVER constant.
+        # @return [Version]
+        def version
+          @version ||= begin
+            semver = paths.gemspec.read.match(/[\w]+_SEMVER\s*=\s*['"]([^'"]+)['"]/)&.[](1)
+            raise "#{name} gemspec does not contain a SEMVER constant." unless semver
+
+            Version.new(semver)
+          end
+        end
+
+        private
+
+        # Build the gemspec file with updated version constants.
+        #
+        # @return [String] the updated gemspec file.
+        def build_gemspec
+          paths.gemspec.read.gsub(/^#{Regexp.escape(constant_name)}_(GEM_VERSION|SEMVER)\s*=\s*['"].*['"]/) do
+            version_type = Regexp.last_match(1)
+            version_value = version_type == 'GEM_VERSION' ? version.to_gem_version : version.to_semver
+            "#{constant_name}_#{version_type} = '#{version_value}'"
+          end
+        end
+
+        # Initialize the {Paths} instance for the gem
+        #
+        # @param root_directory [Pathname] The path to the root directory of the gem.
+        # @return [void]
+        def initialize_paths(root_directory)
+          @paths = Paths.new(
+            gemspec: root_directory.glob('*.gemspec').first,
+            lib: root_directory.join('lib'),
+            root: root_directory,
+            sig: root_directory.join('sig'),
+            test: root_directory.join('spec')
+          )
+        end
+      end
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/dev/gem_manager/publisher.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager/publisher.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Dev
+    module GemManager
+      # Publish Domainic gems to rubygems.org
+      #
+      # @since 0.1.0
+      # @author {https://aaronmallen.me Aaron Allen}
+      class Publisher
+        # Initialize a new instance of Publisher
+        #
+        # @param gem [Gem] The gem to be published.
+        # @return [Publisher]
+        def initialize(gem)
+          @gem = gem
+        end
+
+        # Publish the gem to rubygems.org
+        #
+        # @return [void]
+        def publish!
+          return unless should_publish?
+
+          publish_dependencies
+          prepare_release
+          system("gem push pkg/#{gem.name}-#{gem.version.to_gem_version}.gem")
+        end
+
+        private
+
+        # @dynamic gem
+        attr_reader :gem
+
+        # Generates a git tag for the release, prefixed by the gem name.
+        #
+        # For the main `domainic` gem, the tag is prefixed with `v`. For other gems, the tag is prefixed
+        # with the gem name.
+        #
+        # @return [void]
+        def generate_tags
+          tag_name = gem.name == 'domainic' ? 'v' : "#{gem.name}-v"
+          system("git tag #{tag_name}#{gem.version.to_semver}")
+        end
+
+        # Retrieves the latest release version from the git tags.
+        #
+        # The method filters and processes the git tags to find the latest release tag matching
+        # the gem's versioning pattern.
+        #
+        # @return [String, nil]
+        def latest_release
+          @latest_release ||= `git tag`.split("\n")
+                                       .grep(/^#{gem.name}-v|^v\d/)
+                                       .map { |tag| tag.gsub(/^#{gem.name}-v|^v/, '').strip }
+                                       .max_by { |tag| Semantic::Version.new(tag) }
+        end
+
+        # Prepares the gem for release by building the gem and generating git tags.
+        #
+        # @return [void]
+        def prepare_release
+          puts "== Releasing #{gem.name} #{gem.version.to_semver} =="
+          gem.build!
+          generate_tags
+        end
+
+        # Releases the gem's dependencies by recursively releasing all gems that the current gem depends on.
+        #
+        # @return [void]
+        def publish_dependencies
+          gem.dependencies
+             .map(&:name)
+             .filter_map { |dependency| GemManager.gem(dependency) }
+             .each { |dependency| Publisher.new(dependency).publish! }
+        end
+
+        # Determines if the gem should be released.
+        #
+        # The gem is not released if it is already at the latest version or if it is the `domainic-dev` gem.
+        #
+        # @return [Boolean]
+        def should_publish?
+          return false if gem.name == 'domainic-dev'
+
+          if latest_release == gem.version.to_semver
+            puts "== Skipping #{gem.name} (v#{gem.version.to_semver}) already released =="
+            return false
+          end
+          true
+        end
+      end
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/dev/gem_manager/version.rb
+++ b/domainic-dev/lib/domainic/dev/gem_manager/version.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Dev
+    module GemManager
+      # Manage gem versions
+      #
+      # @since 0.1.0
+      class Version
+        # Initialize a new instance of Version.
+        #
+        # @param version_string [String] The version string to parse.
+        # @return [Version] The new instance of Version.
+        def initialize(version_string)
+          @semantic = Semantic::Version.new(version_string)
+        end
+
+        # @!method build
+        #  The build number of the version.
+        #  @return [String, nil] The build version.
+        #
+        # @!method major
+        #  The major number of the version.
+        #  @return [Integer] The major version.
+        #
+        # @!method minor
+        #  The minor number of the version.
+        #  @return [Integer] The minor version.
+        #
+        # @!method patch
+        #  The patch number of the version.
+        #  @return [Integer] The patch version.
+        #
+        # @!method pre
+        #  The pre-release number of the version.
+        #  @return [String, nil] the pre-release version.
+        #
+        # @dynamic build
+        # @dynamic major
+        # @dynamic minor
+        # @dynamic patch
+        # @dynamic pre
+        %i[build major minor patch pre].each do |method|
+          define_method(method) { @semantic.public_send(method) }
+        end
+
+        # @!method build=(value)
+        #  Set the build version.
+        #  @param value [String, nil] The build version.
+        #  @return [String, nil] The build version.
+        #
+        # @!method pre=(value)
+        #  Set the pre-release version.
+        #  @param value [String, nil] The pre-release version.
+        #  @return [String, nil] The pre-release version.
+        #
+        # @dynamic build=
+        # @dynamic pre=
+        %i[pre build].each do |method|
+          define_method(:"#{method}=") { |value| @semantic.public_send(:"#{method}=", value) }
+        end
+
+        # Increment a version part.
+        #
+        # @param version_part [Symbol] The version part to increment.
+        # @return [self] The incremented version.
+        def increment!(version_part)
+          @semantic = @semantic.increment!(version_part)
+          self
+        end
+
+        # The version as a Gem version friendly string.
+        #
+        # @return [String] The version string.
+        def to_gem_version
+          [major, minor, patch, pre, build].compact.join('.')
+        end
+
+        # The version as a Semantic version friendly string.
+        #
+        # @return [String] The version string.
+        def to_semver
+          @semantic.to_s
+        end
+      end
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/gem_manager.rb
+++ b/domainic-dev/lib/domainic/gem_manager.rb
@@ -6,6 +6,20 @@ module Domainic
     #
     # @since 0.1.0
     module GemManager
+      # Find a gem by name.
+      #
+      # @param gem_name [String] The name of the gem to find.
+      # @return [Gem, nil] The gem object if found, otherwise nil.
+      def self.gem(gem_name)
+        gems.find { |gem| gem.name == gem_name }
+      end
+
+      # Find all gems in the Domainic repository.
+      #
+      # @return [Array<Gem>] An array of gem objects.
+      def self.gems
+        Dev.root.glob('{*/*.gemspec,domainic.gemspec}').map(&:dirname).map { |path| Gem.new(path) }
+      end
     end
   end
 end

--- a/domainic-dev/lib/domainic/gem_manager.rb
+++ b/domainic-dev/lib/domainic/gem_manager.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Dev
+    # Manage, build, version, and publish Domainic gems.
+    #
+    # @since 0.1.0
+    module GemManager
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev.rbs
+++ b/domainic-dev/sig/domainic/dev.rbs
@@ -1,4 +1,5 @@
 module Domainic
   module Dev
+    def self.root: () -> Pathname
   end
 end

--- a/domainic-dev/sig/domainic/dev.rbs
+++ b/domainic-dev/sig/domainic/dev.rbs
@@ -1,0 +1,4 @@
+module Domainic
+  module Dev
+  end
+end

--- a/domainic-dev/sig/domainic/dev/gem_manager.rbs
+++ b/domainic-dev/sig/domainic/dev/gem_manager.rbs
@@ -1,0 +1,9 @@
+module Domainic
+  module Dev
+    module GemManager
+      def self.gem: (String gem_name) -> (Gem | nil)
+
+      def self.gems: () -> Array[Gem]
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev/gem_manager/gem.rbs
+++ b/domainic-dev/sig/domainic/dev/gem_manager/gem.rbs
@@ -1,0 +1,50 @@
+module Gem
+  class Specification
+    def self.load: (String file) -> instance
+
+    attr_reader name: String
+  end
+end
+
+module Domainic
+  module Dev
+    module GemManager
+      class Gem
+        class Paths
+          attr_reader gemspec: Pathname
+          attr_reader lib: Pathname
+          attr_reader root: Pathname
+          attr_reader sig: Pathname
+          attr_reader test: Pathname
+
+          def initialize: (?gemspec: Pathname, ?lib: Pathname, ?root: Pathname, ?sig: Pathname, ?test: Pathname) -> void
+        end
+
+        @dependencies: Array[::Gem::Dependency]
+        @name: String
+        @paths: Paths
+        @version: Version
+
+        attr_reader dependencies: Array[::Gem::Dependency]
+        attr_reader name: String
+        attr_reader paths: Paths
+
+        def initialize: (Pathname root_directory) -> void
+
+        def build!: () -> void
+
+        def constant_name: () -> String
+
+        def sync!: () -> void
+
+        def version: () -> Version
+
+        private
+
+        def build_gemspec: () -> String
+
+        def initialize_paths: (Pathname root_directory) -> void
+      end
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev/gem_manager/gem.rbs
+++ b/domainic-dev/sig/domainic/dev/gem_manager/gem.rbs
@@ -35,6 +35,8 @@ module Domainic
 
         def constant_name: () -> String
 
+        def publish!: () -> void
+
         def sync!: () -> void
 
         def version: () -> Version

--- a/domainic-dev/sig/domainic/dev/gem_manager/publisher.rbs
+++ b/domainic-dev/sig/domainic/dev/gem_manager/publisher.rbs
@@ -1,0 +1,28 @@
+module Domainic
+  module Dev
+    module GemManager
+      class Publisher
+        @gem: Gem
+        @latest_release: (String | nil)
+
+        def initialize: (Gem gem) -> void
+
+        def publish!: () -> void
+
+        private
+
+        attr_reader gem: Gem
+
+        def generate_tags: () -> void
+
+        def latest_release: () -> (String | nil)
+
+        def prepare_release: () -> void
+
+        def publish_dependencies: () -> void
+
+        def should_publish?: () -> bool
+      end
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev/gem_manager/version.rbs
+++ b/domainic-dev/sig/domainic/dev/gem_manager/version.rbs
@@ -1,0 +1,43 @@
+interface _Version
+  def initialize: (String version_string) -> void
+
+  def build: () -> (String | nil)
+
+  def build=: (String | nil value) -> (String | nil)
+
+  def increment!: (:major | :minor | :patch version_part) -> self
+
+  def major: () -> Integer
+
+  def minor: () -> Integer
+
+  def patch: () -> Integer
+
+  def pre: () -> (String | nil)
+
+  def pre=: (String | nil value) -> (String | nil)
+end
+
+class Semantic
+  class Version
+    include _Version
+
+    def public_send: (String | Symbol method, *untyped? arguments, **untyped? keyword_arguments) ? { (?) -> untyped } -> untyped
+  end
+end
+
+module Domainic
+  module Dev
+    module GemManager
+      class Version
+        include _Version
+
+        @semantic: Semantic::Version
+
+        def to_gem_version: () -> String
+
+        def to_semver: () -> String
+      end
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev/gem_manager/version.rbs
+++ b/domainic-dev/sig/domainic/dev/gem_manager/version.rbs
@@ -21,6 +21,7 @@ end
 class Semantic
   class Version
     include _Version
+    include Comparable
 
     def public_send: (String | Symbol method, *untyped? arguments, **untyped? keyword_arguments) ? { (?) -> untyped } -> untyped
   end

--- a/domainic-dev/sig/manifest.yaml
+++ b/domainic-dev/sig/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - pathname

--- a/domainic-dev/spec/domainic/dev/gem_manager/gem_spec.rb
+++ b/domainic-dev/spec/domainic/dev/gem_manager/gem_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Domainic::Dev::GemManager::Gem do
+  describe '#initialize' do
+    subject(:new_instance) { described_class.new(root_directory) }
+
+    before do
+      allow(root_directory).to receive(:glob).with('*.gemspec').and_return([root_directory.join('test.gemspec')])
+      allow(Gem::Specification).to receive(:load).with('fake/root/test/test.gemspec').and_return(mock_specification)
+    end
+
+    let(:root_directory) { Pathname.new('fake/root/test') }
+    let(:mock_specification) { instance_double(Gem::Specification, dependencies: [mock_dependency], name: 'test') }
+    let(:mock_dependency) { instance_double(Gem::Dependency) }
+
+    it 'is expected to have the expected paths' do
+      expect(new_instance.paths).to be_an_instance_of(described_class::Paths)
+        .and(have_attributes(gemspec: root_directory.join('test.gemspec')))
+    end
+
+    it 'is expected to have the name defined in the gemspec' do
+      expect(new_instance.name).to eq(mock_specification.name)
+    end
+
+    it 'is expected to have the dependencies defined in the gemspec' do
+      expect(new_instance.dependencies).to eq(mock_specification.dependencies)
+    end
+  end
+
+  describe '#build!' do
+    subject(:build!) { gem.build! }
+
+    before do
+      allow(root_directory).to receive(:glob).with('*.gemspec').and_return([root_directory.join('test.gemspec')])
+      allow(Gem::Specification).to receive(:load).with('fake/root/test/test.gemspec').and_return(mock_specification)
+      allow(gem.paths.gemspec).to receive_messages(read: '', readlines: [], write: true)
+      allow(gem).to receive(:system)
+      allow(Dir).to receive(:glob).with('*.gem').and_return(['test-0.1.0.gem'])
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(FileUtils).to receive(:mv)
+    end
+
+    let(:root_directory) { Pathname.new('fake/root/test') }
+    let(:mock_specification) { instance_double(Gem::Specification, dependencies: [], name: 'test') }
+    let(:gem) { described_class.new(root_directory) }
+
+    it 'is expected to sync the gemspec' do
+      build!
+
+      expect(gem.paths.gemspec).to have_received(:write)
+    end
+
+    it 'is expected to build the gem' do
+      build!
+
+      expect(gem).to have_received(:system).with("gem build -V #{gem.paths.gemspec}")
+    end
+
+    it 'is expected to move the gem into the pkg directory' do
+      build!
+
+      expect(FileUtils).to have_received(:mv).with('test-0.1.0.gem', 'pkg')
+    end
+  end
+
+  describe '#constant_name' do
+    subject(:constant_name) { gem.constant_name }
+
+    before do
+      allow(root_directory).to receive(:glob).with('*.gemspec').and_return([root_directory.join('test.gemspec')])
+      allow(Gem::Specification).to receive(:load).with('fake/root/test/test.gemspec').and_return(mock_specification)
+    end
+
+    let(:root_directory) { Pathname.new('fake/root/test') }
+    let(:mock_specification) { instance_double(Gem::Specification, dependencies: [], name: 'test-TeSt_test') }
+    let(:gem) { described_class.new(root_directory) }
+
+    it 'is expected to return the name in a constant friendly format' do
+      expect(constant_name).to eq('TEST_TEST_TEST')
+    end
+  end
+
+  describe '#sync!' do
+    subject(:sync!) { gem.sync! }
+
+    before do
+      allow(root_directory).to receive(:glob).with('*.gemspec').and_return([root_directory.join('test.gemspec')])
+      allow(Gem::Specification).to receive(:load).with('fake/root/test/test.gemspec').and_return(mock_specification)
+      allow(gem.paths.gemspec).to receive_messages(read: mock_gemspec, readlines: mock_gemspec.split("\n"), write: true)
+    end
+
+    let(:root_directory) { Pathname.new('fake/root/test') }
+    let(:mock_specification) { instance_double(Gem::Specification, dependencies: [], name: 'test') }
+    let(:mock_gemspec) do
+      <<~GEMSPEC
+        TEST_GEM_VERSION = '0.1.0'
+        TEST_SEMVER = '0.1.0'
+      GEMSPEC
+    end
+    let(:gem) { described_class.new(root_directory) }
+
+    context 'when the gem version has not changed' do
+      it 'is expected not to change the gemspec file' do
+        sync!
+
+        expect(gem.paths.gemspec).to have_received(:write).with(mock_gemspec)
+      end
+    end
+
+    context 'when the gem version has changed' do
+      before { gem.version.increment!(:minor) }
+
+      it 'is expected to update the gemspec file' do
+        sync!
+
+        expect(gem.paths.gemspec).to have_received(:write).with(mock_gemspec.gsub('0.1.0', '0.2.0'))
+      end
+    end
+  end
+
+  describe '#version' do
+    subject(:version) { gem.version }
+
+    before do
+      allow(root_directory).to receive(:glob).with('*.gemspec').and_return([root_directory.join('test.gemspec')])
+      allow(Gem::Specification).to receive(:load).with('fake/root/test/test.gemspec').and_return(mock_specification)
+      allow(gem.paths.gemspec).to receive_messages(read: mock_gemspec)
+    end
+
+    let(:root_directory) { Pathname.new('fake/root/test') }
+    let(:mock_specification) { instance_double(Gem::Specification, dependencies: [], name: 'test') }
+    let(:mock_gemspec) do
+      <<~GEMSPEC
+        TEST_GEM_VERSION = '0.1.0'
+        TEST_SEMVER = '0.1.0'
+      GEMSPEC
+    end
+    let(:gem) { described_class.new(root_directory) }
+
+    it {
+      expect(version).to be_an_instance_of(Domainic::Dev::GemManager::Version)
+        .and(have_attributes(major: 0, minor: 1, patch: 0, pre: nil, build: nil))
+    }
+
+    context 'when the gemspec does not contain a SEMVER constant' do
+      let(:mock_gemspec) do
+        <<~GEMSPEC
+          TEST_GEM_VERSION = '0.1.0'
+        GEMSPEC
+      end
+
+      it { expect { version }.to raise_error(RuntimeError) }
+    end
+  end
+end

--- a/domainic-dev/spec/domainic/dev/gem_manager/gem_spec.rb
+++ b/domainic-dev/spec/domainic/dev/gem_manager/gem_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe Domainic::Dev::GemManager::Gem do
     end
   end
 
+  describe '#publish!' do
+    subject(:publish!) { gem.publish! }
+
+    before do
+      allow(root_directory).to receive(:glob).with('*.gemspec').and_return([root_directory.join('test.gemspec')])
+      allow(Gem::Specification).to receive(:load).with('fake/root/test/test.gemspec').and_return(mock_specification)
+      allow(Domainic::Dev::GemManager::Publisher).to receive(:new).with(gem).and_return(mock_publisher)
+    end
+
+    let(:mock_publisher) { instance_double(Domainic::Dev::GemManager::Publisher, publish!: true) }
+    let(:root_directory) { Pathname.new('fake/root/test') }
+    let(:mock_specification) { instance_double(Gem::Specification, dependencies: [], name: 'test') }
+    let(:gem) { described_class.new(root_directory) }
+
+    it 'is expected to publish the gem' do
+      publish!
+
+      expect(mock_publisher).to have_received(:publish!)
+    end
+  end
+
   describe '#sync!' do
     subject(:sync!) { gem.sync! }
 

--- a/domainic-dev/spec/domainic/dev/gem_manager/publisher_spec.rb
+++ b/domainic-dev/spec/domainic/dev/gem_manager/publisher_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Domainic::Dev::GemManager::Publisher do
+  describe '#publish' do
+    subject(:publish!) { publisher.publish! }
+
+    before do
+      allow(publisher).to receive(:puts) # suppress logging
+      allow(publisher).to receive(:`).with('git tag').and_return("test-v0.1.0\nother_test-v0.1.0")
+      allow(publisher).to receive(:system)
+    end
+
+    let(:publisher) { described_class.new(gem) }
+
+    context 'when the gem has a new version' do
+      let(:gem) do
+        version = instance_double(Domainic::Dev::GemManager::Version, to_gem_version: '0.2.0', to_semver: '0.2.0')
+        instance_double(
+          Domainic::Dev::GemManager::Gem,
+          build!: true,
+          dependencies: [],
+          name: 'test',
+          version:
+        )
+      end
+
+      context 'when the gem has domainic dependencies' do
+        before do
+          allow(gem.dependencies).to receive(:map).and_return(['other_test'])
+          allow(Domainic::Dev::GemManager).to receive(:gem).with('other_test').and_return(dependency)
+          allow(described_class).to receive(:new).with(dependency).and_return(other_publisher)
+        end
+
+        let(:dependency) { instance_double(Domainic::Dev::GemManager::Gem) }
+        let(:other_publisher) { instance_double(described_class, publish!: true) }
+
+        it 'is expected to publish the gems dependencies' do
+          publish!
+
+          expect(other_publisher).to have_received(:publish!)
+        end
+      end
+
+      it 'is expected to build the gem' do
+        publish!
+
+        expect(gem).to have_received(:build!)
+      end
+
+      it 'is expected to generate new git tags' do
+        publish!
+
+        expect(publisher).to have_received(:system).with('git tag test-v0.2.0')
+      end
+
+      it 'is expected to push the gem to rubygems.org' do
+        publish!
+
+        expect(publisher).to have_received(:system).with('gem push pkg/test-0.2.0.gem')
+      end
+    end
+
+    context 'when the gem is domainic-dev' do
+      let(:gem) do
+        instance_double(Domainic::Dev::GemManager::Gem, name: 'domainic-dev', build!: true)
+      end
+
+      it 'is expected not to build the gem' do
+        publish!
+
+        expect(gem).not_to have_received(:build!)
+      end
+    end
+
+    context 'when the gem has no new version' do
+      let(:gem) do
+        version = instance_double(Domainic::Dev::GemManager::Version, to_gem_version: '0.1.0', to_semver: '0.1.0')
+        instance_double(
+          Domainic::Dev::GemManager::Gem,
+          build!: true,
+          name: 'test',
+          version:
+        )
+      end
+
+      it 'is expected not to build the gem' do
+        publish!
+
+        expect(gem).not_to have_received(:build!)
+      end
+    end
+  end
+end

--- a/domainic-dev/spec/domainic/dev/gem_manager/version_spec.rb
+++ b/domainic-dev/spec/domainic/dev/gem_manager/version_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Domainic::Dev::GemManager::Version do
+  describe '#initialize' do
+    subject(:new_instance) { described_class.new('1.2.3-alpha+abc') }
+
+    it 'is expected to properly parse the version string' do
+      expect(new_instance).to have_attributes(major: 1, minor: 2, patch: 3, pre: 'alpha', build: 'abc')
+    end
+  end
+
+  describe '#build' do
+    subject(:build) { version.build }
+
+    context 'when the Version has a build number' do
+      let(:version) { described_class.new('1.2.3+abc') }
+
+      it { is_expected.to eq('abc') }
+    end
+
+    context 'when the Version does not have a build number' do
+      let(:version) { described_class.new('1.2.3') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#build=' do
+    subject(:set_build) { version.build = build_version }
+
+    let(:version) { described_class.new('1.2.3') }
+    let(:build_version) { 'abc' }
+
+    it { expect { set_build }.to change(version, :build).from(nil).to(build_version) }
+  end
+
+  describe '#increment!' do
+    subject(:increment!) { version.increment!(version_part) }
+
+    let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+    context 'when incrementing the major version' do
+      let(:version_part) { :major }
+
+      it { expect { increment! }.to change(version, :major).from(1).to(2) }
+      it { expect { increment! }.to change(version, :minor).from(2).to(0) }
+      it { expect { increment! }.to change(version, :patch).from(3).to(0) }
+      it { expect { increment! }.to change(version, :pre).from('alpha').to(nil) }
+      it { expect { increment! }.to change(version, :build).from('abc').to(nil) }
+    end
+
+    context 'when incrementing the minor version' do
+      let(:version_part) { :minor }
+
+      it { expect { increment! }.not_to change(version, :major) }
+      it { expect { increment! }.to change(version, :minor).from(2).to(3) }
+      it { expect { increment! }.to change(version, :patch).from(3).to(0) }
+      it { expect { increment! }.to change(version, :pre).from('alpha').to(nil) }
+      it { expect { increment! }.to change(version, :build).from('abc').to(nil) }
+    end
+
+    context 'when incrementing the patch version' do
+      let(:version_part) { :patch }
+
+      it { expect { increment! }.not_to change(version, :major) }
+      it { expect { increment! }.not_to change(version, :minor) }
+      it { expect { increment! }.to change(version, :patch).from(3).to(4) }
+      it { expect { increment! }.to change(version, :pre).from('alpha').to(nil) }
+      it { expect { increment! }.to change(version, :build).from('abc').to(nil) }
+    end
+  end
+
+  describe '#major' do
+    subject(:major) { version.major }
+
+    let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe '#minor' do
+    subject(:minor) { version.minor }
+
+    let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+    it { is_expected.to eq(2) }
+  end
+
+  describe '#patch' do
+    subject(:patch) { version.patch }
+
+    let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+    it { is_expected.to eq(3) }
+  end
+
+  describe '#pre' do
+    subject(:pre) { version.pre }
+
+    context 'when the Version has a pre-release version' do
+      let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+      it { is_expected.to eq('alpha') }
+    end
+
+    context 'when the Version does not have a pre-release version' do
+      let(:version) { described_class.new('1.2.3+abc') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#pre=' do
+    subject(:set_pre) { version.pre = pre_version }
+
+    let(:version) { described_class.new('1.2.3') }
+    let(:pre_version) { 'alpha' }
+
+    it { expect { set_pre }.to change(version, :pre).from(nil).to(pre_version) }
+  end
+
+  describe '#to_gem_version' do
+    subject(:to_gem_version) { version.to_gem_version }
+
+    let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+    it { is_expected.to eq('1.2.3.alpha.abc') }
+  end
+
+  describe '#to_semver' do
+    subject(:to_semver) { version.to_semver }
+
+    let(:version) { described_class.new('1.2.3-alpha+abc') }
+
+    it { is_expected.to eq('1.2.3-alpha+abc') }
+  end
+end

--- a/domainic-dev/spec/domainic/dev/gem_manager_spec.rb
+++ b/domainic-dev/spec/domainic/dev/gem_manager_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Domainic::Dev::GemManager do
+  describe '.gem' do
+    subject(:gem) { described_class.gem(gem_name) }
+
+    context 'when the gem exists' do
+      before do
+        mock_root = instance_double(Pathname, glob: [Pathname.new("fake/root/#{gem_name}/#{gem_name}.gemspec")])
+        allow(Domainic::Dev).to receive(:root).and_return(mock_root)
+        allow(Domainic::Dev::GemManager::Gem).to receive(:new)
+          .with(Pathname.new("fake/root/#{gem_name}"))
+          .and_return(mock_gem)
+      end
+
+      let(:gem_name) { 'test' }
+      let(:mock_gem) { instance_double(Domainic::Dev::GemManager::Gem, name: gem_name) }
+
+      it { is_expected.to eq(mock_gem) }
+    end
+
+    context 'when the gem does not exist' do
+      let(:gem_name) { 'nonexistent' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.gems' do
+    subject(:gems) { described_class.gems }
+
+    before do
+      mock_root = instance_double(Pathname, glob: [Pathname.new('fake/root/test/test.gemspec')])
+      allow(Domainic::Dev).to receive(:root).and_return(mock_root)
+      allow(Domainic::Dev::GemManager::Gem).to receive(:new)
+        .with(Pathname.new('fake/root/test'))
+        .and_return(mock_gem)
+    end
+
+    let(:mock_gem) { instance_double(Domainic::Dev::GemManager::Gem, name: 'test') }
+
+    it { is_expected.to contain_exactly(mock_gem) }
+  end
+end

--- a/domainic-dev/spec/domainic/dev_spec.rb
+++ b/domainic-dev/spec/domainic/dev_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Domainic::Dev do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-dev/spec/domainic/dev_spec.rb
+++ b/domainic-dev/spec/domainic/dev_spec.rb
@@ -3,5 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe Domainic::Dev do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.root' do
+    subject(:root) { described_class.root }
+
+    it 'is expected to be equal to the root path of the Domainic monorepo' do
+      expect(root).to eq(Pathname.new(File.expand_path('../../../', File.dirname(__FILE__))))
+    end
+  end
 end

--- a/domainic-dev/spec/spec_helper.rb
+++ b/domainic-dev/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../config/common_spec_helper', __dir__)
+require 'domainic-dev'

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -27,6 +27,7 @@ gems:
     ignore: true
   - name: regexp_parser
     ignore: true
+  - name: rubygems
   - name: simplecov
     ignore: true
   - name: tzinfo


### PR DESCRIPTION
This patch adds the `domainic-dev` gem as well as `Domainic::Dev::GemManager` used to manage, version, build, and publish gems.

Changelog:
  - added `Domainic::Dev::GemManager`

resolves #16 #17