### PR TITLE
Add Parameters

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -7,12 +7,15 @@ target :domainic_dev do
   library 'fileutils'
   library 'pathname'
 
-  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.strict)
 end
 
 target :domainic_type do
   check 'domainic-type/lib/**/*.rb'
   signature 'domainic-type/sig/**/*.rbs'
 
-  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
+  configure_code_diagnostics do |config|
+    # disable this diagnostic pending the resolution of https://github.com/soutaro/steep/issues/1207
+    config[Steep::Diagnostic::Ruby::BlockTypeMismatch] = :hint
+  end
 end

--- a/domainic-type/lib/domainic/type/base_type.rb
+++ b/domainic-type/lib/domainic/type/base_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    # The base class for all Domainic types.
+    #
+    # @abstract
+    # @since 0.1.0
+    class BaseType # rubocop:disable Lint/EmptyClass
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constants.rb
+++ b/domainic-type/lib/domainic/type/constants.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    # Used to indicate that a value is not specified which is different from `nil`.
+    #
+    # @since 0.1.0
+    # @return [Object]
+    UNSPECIFIED = Object.new.freeze
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module Constraint
+      # The base class for all constraints.
+      #
+      # @since 0.1.0
+      class BaseConstraint # rubocop:disable Lint/EmptyClass
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/parameter.rb
+++ b/domainic-type/lib/domainic/type/constraint/parameter.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require_relative '../constants'
+require_relative '../errors'
+
+module Domainic
+  module Type
+    module Constraint
+      # A constraint parameter.
+      #
+      # @!attribute [r] description
+      #  The description of the Parameter.
+      #  @return [String, nil]
+      #
+      # @!attribute [r] name
+      #  The name of the Parameter.
+      #  @return [Symbol]
+      #
+      # @since 0.1.0
+      class Parameter
+        # @dynamic description, name
+        attr_reader :description, :name
+
+        # Initialize a new instance of Parameter.
+        #
+        # @param base [Class<BaseConstraint>, BaseConstraint] The constraint that the Parameter belongs to.
+        # @param options [Hash{Symbol => untyped}] The options for configuring the Parameter.
+        #
+        # @option options [Array<::Proc>] :callbacks ([]) callbacks to execute when the Parameter value changes.
+        # @option options [Array<Boolean, Proc, ::Symbol>] :coercers ([->(value) { value }])
+        #  An array of Booleans, Procs, or Symbols representing methods to coerce the Parameter value before
+        #  validation.
+        #  - When the coercer is `true` and the base constraint responds to `coerce_<name>`, that method will be called
+        #    to coerce the value.
+        #  - When the coercer is a `Proc`, the Proc will be called to coerce the value.
+        #  - When the coercer is a `Symbol` and the base constraint responds to a method matching that symbol, the
+        #    method will be called to coerce the value.
+        # @option options [Object, nil] :default (UNSPECIFIED) The default value for the Parameter.
+        # @option options [String, nil] :description (nil) A description of the Parameter.
+        # @option options [String, Symbol] :name The name of the Parameter.
+        # @option options [Boolean] :required (false) true if the Parameter is required, otherwise false.
+        # @option options [Proc, Symbol] :validator (->(_) { true }) A Proc or Symbol representing a method to validate
+        #  the Parameter value.
+        #  - When the validator is a `Proc`, the Proc will be called to validate the value.
+        #  - When the validator is a `Symbol` and the base constraint responds to a method matching that symbol, the
+        #    method will be called to validate the value.
+        #
+        # @return [Parameter] The new instance of Parameter.
+        def initialize(base, options)
+          @base = base
+          @callbacks = options.fetch(:callbacks, [])
+          @coercers = options.fetch(:coercers, [])
+          @default = options.fetch(:default, UNSPECIFIED)
+          @description = options[:description]
+          @name = options.fetch(:name).to_sym
+          @required = options.fetch(:required, false)
+          @validator = options.fetch(:validator, ->(_) { true })
+          @value = UNSPECIFIED
+        end
+
+        # Get the default value for the Parameter.
+        #
+        # @return [Object, nil] The default value for the Parameter, or nil if no default is provided.
+        def default
+          @default if default?
+        end
+
+        # Check if the Parameter has a default value.
+        #
+        # @return [Boolean] true if the Parameter has a default value, otherwise false.
+        def default?
+          @default != UNSPECIFIED
+        end
+
+        # Duplicate the Parameter with a new base class.
+        #
+        # @param new_base [Class<BaseConstraint>, BaseConstraint] The new base class for the duplicated Parameter.
+        # @return [Parameter] The duplicated Parameter.
+        def dup_with_base(new_base)
+          dup.tap { |duped| duped.instance_variable_set(:@base, new_base) }
+        end
+
+        # Check if the Parameter is required.
+        #
+        # @return [Boolean] true if the Parameter is required, otherwise false.
+        def required?
+          @required
+        end
+
+        # Get the value of the Parameter.
+        #
+        # @return [Object, nil] The value of the Parameter, or nil if the value is not set.
+        def value
+          return @value unless @value == UNSPECIFIED
+
+          default if default?
+        end
+
+        # Set the value of the Parameter.
+        #
+        # @param value [Object, nil] The value to set for the Parameter.
+        # @return [void]
+        def value=(value)
+          coerced_value = coerce_value(value)
+          ensure_value_is_valid!(coerced_value)
+
+          @value = coerced_value
+          callbacks.each { |callback| @base.instance_exec(@value, &callback) }
+        end
+
+        private
+
+        # @dynamic base, callbacks, coercers, validator
+        attr_reader :base, :callbacks, :coercers, :validator
+
+        # Validate the value of the Parameter and raise an error if the value is invalid.
+        #
+        # @param value [Object, nil] The value to validate.
+        # @raise [InvalidParameterError] An error if the value is invalid.
+        # @return [Boolean] true if the value is valid, otherwise false.
+        def ensure_value_is_valid!(value)
+          raise_validation_error!(value) if value.nil? && required?
+
+          valid = validate_value(value)
+
+          raise_validation_error!(value) unless valid
+          valid
+        end
+
+        # Coerce the value using the provided coercers.
+        #
+        # @param result [Object, nil] The result of the previous coercion.
+        # @param coercer [Boolean, Proc, Symbol] The coercer to use.
+        # @return [Object, nil] The coerced value.
+        def coerce_reduced(result, coercer)
+          return base.instance_exec(result, &coercer) if coercer.is_a?(Proc)
+          return base.send(coercer, result) if coercer.is_a?(Symbol) && base.respond_to?(coercer, true)
+          return base.send(:"coerce_#{name}", result) if coercer && base.respond_to?(:"coerce_#{name}", true)
+
+          result
+        end
+
+        # Coerce the value of the Parameter using the provided coercers.
+        #
+        # @param value [Object, nil] The value to coerce.
+        # @return [Object, nil] The coerced value.
+        def coerce_value(value)
+          coercers.reduce(value) { |result, coercer| coerce_reduced(result, coercer) }
+        end
+
+        # Raise an error for an invalid value.
+        #
+        # @param value [Object, nil] The value that is invalid.
+        # @raise [InvalidParameterError] An error for the invalid value.
+        # @return [void]
+        def raise_validation_error!(value)
+          base_name = base.is_a?(Class) ? base.name : base.class.name
+          raise InvalidParameterError, "`#{base_name}`:`#{name}` is required" if value.nil? && required?
+
+          raise InvalidParameterError, "Invalid value `#{value.inspect}` for parameter `#{base_name}:#{name}`"
+        end
+
+        # Validate the value of the Parameter.
+        #
+        # @param value [Object, nil] The value to validate.
+        # @return [Boolean] true if the value is valid, otherwise false.
+        def validate_value(value)
+          # @type var validator: Proc
+          return base.instance_exec(value, &validator) if validator.is_a?(Proc)
+          # @type var validator: Symbol
+          return base.send(validator, value) if validator.is_a?(Symbol) && base.respond_to?(validator, true)
+
+          true
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/parameter_set.rb
+++ b/domainic-type/lib/domainic/type/constraint/parameter_set.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative 'parameter'
+
+module Domainic
+  module Type
+    module Constraint
+      # A collection of Parameters for a {BaseConstraint constraint}.
+
+      # @since 0.1.0
+      class ParameterSet
+        # Initialize a new instance of ParameterSet.
+        #
+        # @param base [Class<BaseConstraint>, BaseConstraint] The {BaseConstraint constraint} that the ParameterSet
+        #  belongs to.
+        # @return [ParameterSet]
+        def initialize(base)
+          @base = base
+          @entries = {}.freeze
+        end
+
+        # Get a parameter by name.
+        #
+        # @param parameter_name [String, Symbol] The name of the parameter to get.
+        # @return [Parameter, nil]
+        def [](parameter_name)
+          @entries[parameter_name.to_sym]
+        end
+
+        # Add a new parameter to the set.
+        #
+        # @see Parameter#initialize
+        #
+        # @param parameter_options [Hash] The options for configuring the parameter.
+        # @return [self]
+        def add(parameter_options)
+          parameter = Parameter.new(@base, parameter_options)
+          @entries = @entries.merge(parameter.name => parameter).freeze
+          self
+        end
+
+        # Duplicate the ParameterSet with a new base class.
+        #
+        # @param new_base [Class<BaseConstraint>, BaseConstraint] The new base class for the duplicated ParameterSet.
+        # @return [ParameterSet]
+        def dup_with_base(new_base)
+          dup.tap do |duped|
+            duped.instance_variable_set(:@base, new_base)
+            duped.instance_variable_set(
+              :@entries,
+              @entries.transform_values { |parameter| parameter.dup_with_base(new_base) }.freeze
+            )
+          end
+        end
+
+        private
+
+        # Define a method to access the parameter values.
+        #
+        # @param method [Symbol] The method name to define.
+        # @return [void]
+        def method_missing(method, ...)
+          return super unless respond_to_missing?(method)
+
+          @entries.fetch(method)
+        end
+
+        # Check if the method is a valid parameter name.
+        #
+        # @param method [Symbol] The method name to check.
+        # @param include_private [Boolean] true if private methods should be included, otherwise false.
+        # @return [Boolean]
+        def respond_to_missing?(method, include_private = false)
+          @entries.key?(method) || super
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/errors.rb
+++ b/domainic-type/lib/domainic/type/errors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    # The base class for all {Domainic::Type} errors.
+    #
+    # @since 0.1.0
+    class Error < StandardError; end
+
+    # Raised when a {Constraint::Parameter} is given an invalid value.
+    #
+    # @since 0.1.0
+    class InvalidParameterError < Error; end
+  end
+end

--- a/domainic-type/sig/domainic/type/base_type.rbs
+++ b/domainic-type/sig/domainic/type/base_type.rbs
@@ -1,0 +1,6 @@
+module Domainic
+  module Type
+    class BaseType
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constants.rbs
+++ b/domainic-type/sig/domainic/type/constants.rbs
@@ -1,0 +1,5 @@
+module Domainic
+  module Type
+    UNSPECIFIED: Object
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/base_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/base_constraint.rbs
@@ -1,0 +1,8 @@
+module Domainic
+  module Type
+    module Constraint
+      class BaseConstraint
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/parameter.rbs
+++ b/domainic-type/sig/domainic/type/constraint/parameter.rbs
@@ -1,0 +1,61 @@
+module Domainic
+  module Type
+    module Constraint
+      class Parameter
+        type options = {
+          ?callbacks: Array[Proc],
+          ?coercers: Array[bool | Proc | Symbol],
+          ?default: Object,
+          ?description: (String | nil),
+          name: (String | Symbol),
+          ?required: bool,
+          ?validator: (Proc | Symbol)
+        }
+
+        @base: (singleton(BaseConstraint) | BaseConstraint)
+        @callbacks: Array[Proc]
+        @coercers: Array[bool | Proc | Symbol]
+        @default: Object
+        @description: (String | nil)
+        @name: Symbol
+        @required: bool
+        @validator: (Proc | Symbol)
+        @value: (Object | nil)
+
+        attr_reader description: (String | nil)
+        attr_reader name: Symbol
+
+        def initialize: (singleton(BaseConstraint) | BaseConstraint base, options options) -> void
+
+        def default: () -> (Object | nil)
+
+        def default?: () -> bool
+
+        def dup_with_base: ((singleton(BaseConstraint) | BaseConstraint) new_base) -> Parameter
+
+        def required?: () -> bool
+
+        def value: () -> (Object | nil)
+
+        def value=: (Object | nil value) -> void
+
+        private
+
+        attr_reader base: (singleton(BaseConstraint) | BaseConstraint)
+        attr_reader callbacks: Array[Proc]
+        attr_reader coercers: Array[bool | Proc | Symbol]
+        attr_reader validator: (Proc | Symbol)
+
+        def coerce_reduced: (Object | nil result, bool | Proc | Symbol coercer) -> (Object | nil)
+
+        def coerce_value: (Object | nil value) -> (Object | nil)
+
+        def ensure_value_is_valid!: (Object | nil value) -> bool
+
+        def raise_validation_error!: (Object | nil value) -> void
+
+        def validate_value: (Object | nil value) -> bool
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/parameter_set.rbs
+++ b/domainic-type/sig/domainic/type/constraint/parameter_set.rbs
@@ -1,0 +1,24 @@
+module Domainic
+  module Type
+    module Constraint
+      class ParameterSet
+        @base: (singleton(BaseConstraint) | BaseConstraint)
+        @entries: Hash[Symbol, Parameter]
+
+        def initialize: (singleton(BaseConstraint) | BaseConstraint base) -> void
+
+        def []: (String | Symbol parameter_name) -> (Parameter | nil)
+
+        def add: (Parameter::options parameter_options) -> self
+
+        def dup_with_base: (singleton(BaseConstraint) | BaseConstraint new_base) -> ParameterSet
+
+        private
+
+        def method_missing: (Symbol method, *untyped) ?{ (?) -> untyped } -> Parameter
+
+        def respond_to_missing?: (Symbol method, ?bool include_private) -> bool
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/errors.rbs
+++ b/domainic-type/sig/domainic/type/errors.rbs
@@ -1,0 +1,9 @@
+module Domainic
+  module Type
+    class Error < StandardError
+    end
+
+    class InvalidParameterError < Error
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/base_type_spec.rb
+++ b/domainic-type/spec/domainic/type/base_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+
+RSpec.describe Domainic::Type::BaseType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/constraint/base_constraint'
+
+RSpec.describe Domainic::Type::Constraint::BaseConstraint do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/constraint/parameter_set_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/parameter_set_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/constraint/base_constraint'
+require 'domainic/type/constraint/parameter_set'
+
+RSpec.describe Domainic::Type::Constraint::ParameterSet do
+  let(:base) { instance_double(Domainic::Type::Constraint::BaseConstraint) }
+
+  describe '#[]' do
+    subject(:get_parameter) { parameter_set[parameter_name] }
+
+    context 'when a parameter with a matching name exists' do
+      before { parameter_set.add(name: parameter_name) }
+
+      let(:parameter_set) { described_class.new(base) }
+      let(:parameter_name) { :test }
+
+      it 'is expected to return the parameter' do
+        expect(get_parameter).to be_an_instance_of(Domainic::Type::Constraint::Parameter)
+          .and(have_attributes(name: parameter_name))
+      end
+    end
+  end
+
+  describe '#add' do
+    subject(:add) { parameter_set.add(**parameter_options) }
+
+    let(:parameter_set) { described_class.new(base) }
+    let(:parameter_options) { { name: :test } }
+
+    it 'is expected to add a new parameter to the set' do
+      expect { add }.to change { parameter_set.instance_variable_get(:@entries).count }.by(1)
+    end
+
+    it 'is expected to respond to the parameter name' do
+      add
+      expect(parameter_set).to respond_to(parameter_options[:name])
+    end
+  end
+
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { parameter_set.dup_with_base(new_base) }
+
+    let(:parameter_set) { described_class.new(base) }
+    let(:new_base) { instance_double(Domainic::Type::Constraint::BaseConstraint) }
+
+    it 'is expected to return a new instance of ParameterSet' do
+      expect(dup_with_base).to be_an_instance_of(described_class)
+    end
+
+    it 'is expected to return a new instance with the new base' do
+      expect(dup_with_base.instance_variable_get(:@base)).to eq(new_base)
+    end
+
+    it 'is expected to return a new instance with the parameters duplicated' do
+      parameter_set.add(name: :test)
+      expect(dup_with_base.test.instance_variable_get(:@base)).to eq(new_base)
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/parameter_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/parameter_spec.rb
@@ -1,0 +1,337 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/base_constraint'
+require 'domainic/type/constraint/parameter'
+
+RSpec.describe Domainic::Type::Constraint::Parameter do
+  let(:constraint) { instance_double(Domainic::Type::Constraint::BaseConstraint) }
+
+  describe '#initialize' do
+    subject(:new_instance) { described_class.new(constraint, **options) }
+
+    context 'when given valid options' do
+      let(:options) { { description: 'A test parameter', name: :test } }
+
+      it 'is expected to have the appropriate attributes' do
+        expect(new_instance).to have_attributes(**options)
+      end
+
+      it 'is expected to default @callbacks to empty array' do
+        expect(new_instance.instance_variable_get(:@callbacks)).to eq([])
+      end
+
+      it 'is expected to default @coercers to empty array' do
+        expect(new_instance.instance_variable_get(:@coercers)).to eq([])
+      end
+
+      it 'is expected to default @default to UNSPECIFIED' do
+        expect(new_instance.instance_variable_get(:@default)).to eq(Domainic::Type::UNSPECIFIED)
+      end
+
+      it 'is expected to default @required to false' do
+        expect(new_instance.instance_variable_get(:@required)).to be(false)
+      end
+
+      it 'is expected to default @validator to a Proc that always returns true' do
+        expect(new_instance.instance_variable_get(:@validator).call(nil)).to be(true)
+      end
+
+      it 'is expected to default @value to UNSPECIFIED' do
+        expect(new_instance.instance_variable_get(:@value)).to eq(Domainic::Type::UNSPECIFIED)
+      end
+    end
+
+    context 'when given callbacks' do
+      let(:callback) { ->(value) { value } }
+
+      let(:options) { { callbacks: [callback], description: 'A test parameter', name: :test } }
+
+      it 'is expected to set @callbacks to the given callbacks' do
+        expect(new_instance.instance_variable_get(:@callbacks)).to eq([callback])
+      end
+    end
+
+    context 'when given coercers' do
+      let(:coercer) { ->(value) { value } }
+
+      let(:options) { { coercers: [coercer], description: 'A test parameter', name: :test } }
+
+      it 'is expected to set @coercers to the given coercers' do
+        expect(new_instance.instance_variable_get(:@coercers)).to eq([coercer])
+      end
+    end
+
+    context 'when given a default' do
+      let(:options) { { default: 'default value', description: 'A test parameter', name: :test } }
+
+      it 'is expected to set @default to the given default' do
+        expect(new_instance).to have_attributes(default?: true, default: 'default value')
+      end
+    end
+
+    context 'when required' do
+      let(:options) { { description: 'A test parameter', name: :test, required: true } }
+
+      it 'is expected to set @required to true' do
+        expect(new_instance.required?).to be true
+      end
+    end
+
+    context 'when given a validator' do
+      let(:validator) { ->(value) { value } }
+
+      let(:options) { { description: 'A test parameter', name: :test, validator: } }
+
+      it 'is expected to set @validator to the given validator' do
+        expect(new_instance.instance_variable_get(:@validator)).to eq(validator)
+      end
+    end
+  end
+
+  describe '#default' do
+    subject(:default) { parameter.default }
+
+    context 'when given a default' do
+      let(:parameter) { described_class.new(constraint, default: 'default value', name: :test) }
+
+      it { is_expected.to eq('default value') }
+    end
+
+    context 'when not given a default' do
+      let(:parameter) { described_class.new(constraint, name: :test) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#default?' do
+    subject(:default?) { parameter.default? }
+
+    context 'when given a default' do
+      let(:parameter) { described_class.new(constraint, default: 'default value', name: :test) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when not given a default' do
+      let(:parameter) { described_class.new(constraint, name: :test) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { parameter.dup_with_base(new_base) }
+
+    let(:parameter) { described_class.new(constraint, name: :test) }
+    let(:new_base) { instance_double(Domainic::Type::Constraint::BaseConstraint) }
+
+    it 'is expected to return a new instance' do
+      expect(dup_with_base).to be_an_instance_of(described_class)
+    end
+
+    it 'is expected to have the appropriate base class' do
+      expect(dup_with_base.instance_variable_get(:@base)).to eq(new_base)
+    end
+  end
+
+  describe '#required?' do
+    subject(:required?) { parameter.required? }
+
+    context 'when required' do
+      let(:parameter) { described_class.new(constraint, name: :test, required: true) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when not required' do
+      let(:parameter) { described_class.new(constraint, name: :test) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#value' do
+    subject(:value) { parameter.value }
+
+    context 'when given a value' do
+      let(:parameter) { described_class.new(constraint, name: :test) }
+
+      before { parameter.instance_variable_set(:@value, 'value') }
+
+      it { is_expected.to eq('value') }
+    end
+
+    context 'when not given a value' do
+      context 'when given a default' do
+        let(:parameter) { described_class.new(constraint, default: 'default value', name: :test) }
+
+        it { is_expected.to eq('default value') }
+      end
+
+      context 'when not given a default' do
+        let(:parameter) { described_class.new(constraint, name: :test) }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
+  describe '#value=' do
+    subject(:set_value) { parameter.value = new_value }
+
+    let(:parameter) { described_class.new(constraint, name: :test) }
+    let(:new_value) { 'new value' }
+
+    it 'is expected to set the value' do
+      expect { set_value }.to change(parameter, :value).from(nil).to(new_value)
+    end
+
+    context 'when given change callbacks' do
+      before do
+        allow(constraint).to receive(:instance_exec)
+          .with(anything, &parameter.instance_variable_get(:@validator))
+          .and_return(true)
+        allow(constraint).to receive(:instance_exec).with(anything, &callback)
+      end
+
+      let(:parameter) { described_class.new(constraint, callbacks: [callback], name: :test) }
+      let(:callback) { ->(value) { value } }
+      let(:new_value) { 'new value' }
+
+      it 'is expected to call the callback' do
+        set_value
+
+        expect(constraint).to have_received(:instance_exec).with(anything, &callback).twice
+      end
+    end
+
+    context 'when given a coercer' do
+      let(:parameter) { described_class.new(constraint, name: :test, coercers: [coercer]) }
+      let(:new_value) { 1 }
+
+      context 'when the coercer is a Proc' do
+        let(:coercer) { lambda(&:to_s) }
+
+        it 'is expected to coerce the value' do
+          expect { set_value }.to change(parameter, :value).from(nil).to('1')
+        end
+      end
+
+      context 'when the coercer is a Symbol and the constraint responds to the method' do
+        let(:constraint) do
+          klass = Class.new(Domainic::Type::Constraint::BaseConstraint) do
+            def self.name
+              'TestConstraint'
+            end
+
+            private
+
+            def coerce_test(value)
+              value.to_s
+            end
+          end
+          klass.new
+        end
+
+        let(:coercer) { :coerce_test }
+
+        it 'is expected to coerce the value' do
+          expect { set_value }.to change(parameter, :value).from(nil).to('1')
+        end
+      end
+
+      context 'when the coercer is true and the constraint responds to the method matching the parameter name' do
+        let(:constraint) do
+          klass = Class.new(Domainic::Type::Constraint::BaseConstraint) do
+            def self.name
+              'TestConstraint'
+            end
+
+            private
+
+            def coerce_test(value)
+              value.to_s
+            end
+          end
+          klass.new
+        end
+
+        let(:coercer) { true }
+
+        it 'is expected to coerce the value' do
+          expect { set_value }.to change(parameter, :value).from(nil).to('1')
+        end
+      end
+    end
+
+    context 'when given a validator' do
+      let(:parameter) { described_class.new(constraint, name: :test, validator:) }
+      let(:new_value) { 1 }
+
+      context 'when the validator is a Proc and the value is valid' do
+        let(:validator) { ->(value) { value.is_a?(Integer) } }
+
+        it 'is expected to set the value' do
+          expect { set_value }.to change(parameter, :value).from(nil).to(new_value)
+        end
+      end
+
+      context 'when the validator is a Proc and the value is invalid' do
+        let(:validator) { ->(value) { value.is_a?(String) } }
+
+        it 'is expected to raise an InvalidParameterError' do
+          expect { set_value }.to raise_error(Domainic::Type::InvalidParameterError)
+        end
+      end
+
+      context 'when the validator is a Symbol and the base responds to the method and the value is valid' do
+        let(:constraint) do
+          klass = Class.new(Domainic::Type::Constraint::BaseConstraint) do
+            def self.name
+              'TestConstraint'
+            end
+
+            private
+
+            def validate_test(value)
+              value.is_a?(Integer)
+            end
+          end
+          klass.new
+        end
+
+        let(:validator) { :validate_test }
+
+        it 'is expected to set the value' do
+          expect { set_value }.to change(parameter, :value).from(nil).to(new_value)
+        end
+      end
+
+      context 'when the validator is a Symbol and the base responds to the method and the value is invalid' do
+        let(:constraint) do
+          klass = Class.new(Domainic::Type::Constraint::BaseConstraint) do
+            def self.name
+              'TestConstraint'
+            end
+
+            private
+
+            def validate_test(value)
+              value.is_a?(String)
+            end
+          end
+          klass.new
+        end
+
+        let(:validator) { :validate_test }
+
+        it 'is expected to raise an InvalidParameterError' do
+          expect { set_value }.to raise_error(Domainic::Type::InvalidParameterError)
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type_spec.rb
+++ b/domainic-type/spec/domainic/type_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'domainic/type/constants'
 
 RSpec.describe Domainic::Type do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '::UNSPECIFIED' do
+    subject(:unspecified) { described_class::UNSPECIFIED }
+
+    it { is_expected.to be_an_instance_of(Object).and(be_frozen) }
+  end
 end


### PR DESCRIPTION
This adds `Domainic::Type::Constraint::Parameter` and `Domainic::Type::Constraint::ParameterSet`

Changelog:
  - added `Domainic::Type::BaseType`
  - added `Domainic::Type::Constraint::BaseConstraint`
  - added `Domainic::Type::Constraint::Parameter`
  - added `Domainic::Type::Constraint::ParameterSet`
  - added `Domainic::Type::Error`
  - added `Domainic::Type::InvalidParameterError`
  - added `Domainic::Type::UNSPECIFIED`
  
note: this disables steep `BlockTypeMismatch` from raising an error pending the resolution of: https://github.com/soutaro/steep/issues/1207

see #32
resolves #33
resolves #34
see #35