### PR TITLE
Implement `Domainic::Type::Constraint::BaseConstraint`

### DIFF
--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -1,12 +1,81 @@
 # frozen_string_literal: true
 
+require_relative 'parameter_set'
+
 module Domainic
   module Type
     module Constraint
       # The base class for all constraints.
       #
+      # @abstract Subclass and override {#validate} to implement a new constraint.
+      #
+      # @!attribute [r] description
+      #  The description of the constraint.
+      #  @return [String, nil]
+      #
+      # @!attribute [r] name
+      #  The name of the constraint.
+      #  @return [Symbol]
+      #
+      # @!attribute [r] parameters
+      #  The parameters of the constraint.
+      #  @return [ParameterSet]
+      #
       # @since 0.1.0
-      class BaseConstraint # rubocop:disable Lint/EmptyClass
+      class BaseConstraint
+        # @dynamic description, name, parameters
+        attr_reader :description, :name, :parameters
+
+        class << self
+          # The parameters of the constraint.
+          #
+          # @return [ParameterSet]
+          def parameters
+            @parameters ||= ParameterSet.new(self)
+          end
+        end
+
+        # Initialize a new instance of BaseConstraint.
+        #
+        # @param base [BaseType] The type the constraint is belongs to.
+        # @param description [String, nil] The {#description} of the constraint.
+        # @param name [String, Symbol] The {#name} of the constraint.
+        # @param parameters [Hash{Symbol => Object}] The parameters of the constraint.
+        #
+        # @return [BaseConstraint] the new instance of BaseConstraint.
+        def initialize(base, description: nil, name: '', **parameters)
+          @base = base
+          @description = description
+          @name = name.empty? ? parse_name(self.class.name) : name.to_sym
+          @parameters = self.class.parameters.dup_with_base(self)
+
+          parameters.each do |parameter, value|
+            self.parameters.public_send(parameter)&.value = value
+          end
+        end
+
+        # Validate the subject against the constraint.
+        #
+        # @param subject [Object] The subject to validate.
+        # @return [Boolean] true if the subject is valid, otherwise false.
+        def validate(subject)
+          raise NotImplementedError, "#{self.class} does not implement #{__method__}"
+        end
+
+        private
+
+        # Parse the class name into a symbol.
+        #
+        # @param name [String, Symbol] The name of the class.
+        # @return [Symbol] the parsed name.
+        def parse_name(name)
+          name.to_s.split('::').last
+              .delete_suffix('Constraint')
+              .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+              .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+              .downcase
+              .to_sym
+        end
       end
     end
   end

--- a/domainic-type/sig/domainic/type/constraint/base_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/base_constraint.rbs
@@ -2,6 +2,28 @@ module Domainic
   module Type
     module Constraint
       class BaseConstraint
+        self.@parameters: ParameterSet
+
+        @base: BaseType
+        @description: (String | nil)
+        @name: Symbol
+        @parameters: ParameterSet
+
+        def self.name: () -> String
+
+        def self.parameters: () -> ParameterSet
+
+        attr_reader description: (String | nil)
+        attr_reader name: Symbol
+        attr_reader parameters: ParameterSet
+
+        def initialize: (BaseType base, ?name: (String | Symbol), ?description: (String | nil), **untyped parameters) -> void
+
+        def validate: (Object subject) -> bool
+
+        private
+
+        def parse_name: (String | Symbol name) -> Symbol
       end
     end
   end

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -1,8 +1,58 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'domainic/type/base_type'
 require 'domainic/type/constraint/base_constraint'
 
 RSpec.describe Domainic::Type::Constraint::BaseConstraint do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:type) { instance_double(Domainic::Type::BaseType) }
+
+  describe '.parameters' do
+    subject(:parameters) { described_class.parameters }
+
+    it { is_expected.to be_an_instance_of(Domainic::Type::Constraint::ParameterSet) }
+  end
+
+  describe '#initialize' do
+    subject(:new_instance) { constraint_class.new(type, **options) }
+
+    let(:constraint_class) { described_class }
+    let(:options) { {} }
+
+    it 'is expected to initialize with the base type' do
+      expect(new_instance.instance_variable_get(:@base)).to eq(type)
+    end
+
+    it 'is expected to initialize with parameters' do
+      expect(new_instance.parameters).to be_an_instance_of(Domainic::Type::Constraint::ParameterSet)
+    end
+
+    context 'when name and description is provided' do
+      let(:options) { { name: 'test', description: 'A test constraint' } }
+
+      it { is_expected.to have_attributes(name: options[:name].to_sym, description: options[:description]) }
+    end
+
+    context 'when name is not provided' do
+      it { is_expected.to have_attributes(name: :base) }
+    end
+
+    context 'when parameters are provided' do
+      let(:constraint_class) do
+        Class.new(described_class) do
+          def self.name
+            'TestConstraint'
+          end
+
+          parameters.add(name: :test)
+        end
+      end
+
+      let(:options) { { test: 'test' } }
+
+      it 'is expected to set the parameter value' do
+        expect(new_instance.parameters.test.value).to eq(options[:test])
+      end
+    end
+  end
 end

--- a/domainic-type/spec/domainic/type/constraint/parameter_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/parameter_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Domainic::Type::Constraint::Parameter do
               value.to_s
             end
           end
-          klass.new
+          klass.new(instance_double(Domainic::Type::BaseType))
         end
 
         let(:coercer) { :coerce_test }
@@ -256,7 +256,7 @@ RSpec.describe Domainic::Type::Constraint::Parameter do
               value.to_s
             end
           end
-          klass.new
+          klass.new(instance_double(Domainic::Type::BaseType))
         end
 
         let(:coercer) { true }
@@ -300,7 +300,7 @@ RSpec.describe Domainic::Type::Constraint::Parameter do
               value.is_a?(Integer)
             end
           end
-          klass.new
+          klass.new(instance_double(Domainic::Type::BaseType))
         end
 
         let(:validator) { :validate_test }
@@ -323,7 +323,7 @@ RSpec.describe Domainic::Type::Constraint::Parameter do
               value.is_a?(String)
             end
           end
-          klass.new
+          klass.new(instance_double(Domainic::Type::BaseType))
         end
 
         let(:validator) { :validate_test }


### PR DESCRIPTION
Changelog:
  - added `Domainic::Type::Constraint::BaseConstraint.parameters`
  - added `Domainic::Type::Constraint::BaseConstraint#description`
  - added `Domainic::Type::Constraint::BaseConstraint#name`
  - added `Domainic::Type::Constraint::BaseConstraint#parameters`
  - added `Domainic::Type::Constraint::BaseConstraint#validate`
  - changed `Domainic::Type::Constraint::BaseConstraint` now takes a`Domainic::Type::BaseType` instance, name, description, and parameter options as arguments.

resolves #32