### PR TITLE
Add `Domainic::Type::DSL::ParameterBuilder`

### DIFF
--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../dsl/parameter_builder'
 require_relative 'parameter_set'
 
 module Domainic
@@ -27,11 +28,53 @@ module Domainic
         attr_reader :description, :name, :parameters
 
         class << self
+          # Define a parameter for the constraint.
+          #
+          # @example Define a parameter for the constraint.
+          #  class MyConstraint < BaseConstraint
+          #    parameter :my_parameter do |parameter|
+          #      desc 'My parameter description.'
+          #      coercer lambda(&:to_s)
+          #      default 'default value'
+          #      required
+          #      validator ->(value) { value.is_a?(String) }
+          #      on_change do
+          #        some_other_parameter = my_parameter
+          #      end
+          #    end
+          #  end
+          #
+          # @param parameter_name [Symbol] The name of the parameter.
+          # @yield [DSL::ParameterBuilder] The block to build the parameter.
+          # @return [void]
+          def parameter(parameter_name, &)
+            parameter_builder.define(parameter_name, &).build!
+          end
+
           # The parameters of the constraint.
           #
           # @return [ParameterSet]
           def parameters
             @parameters ||= ParameterSet.new(self)
+          end
+
+          private
+
+          # Ensure the {.parameters} are properly inherited.
+          #
+          # @param subclass [Class<BaseConstraint>] The subclass inheriting from the constraint.
+          # @return [void]
+          def inherited(subclass)
+            super
+            subclass.instance_variable_set(:@parameter_builder, parameter_builder.dup_with_base(subclass))
+            subclass.send(:parameter_builder).build!
+          end
+
+          # The {DSL::ParameterBuilder} for the constraint.
+          #
+          # @return [DSL::ParameterBuilder]
+          def parameter_builder
+            @parameter_builder ||= DSL::ParameterBuilder.new(self)
           end
         end
 

--- a/domainic-type/lib/domainic/type/dsl/parameter_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/parameter_builder.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require_relative '../constants'
+
+module Domainic
+  module Type
+    module DSL
+      # A DSL for defining {Constraint::Parameter parameters} on a {Constraint::BaseConstraint constraint}.
+      #
+      # @see Constraint::Parameter#initialize
+      #
+      # @since 0.1.0
+      class ParameterBuilder
+        # default values for {Constraint::Parameter parameters}
+        #
+        # @return [Hash{Symbol => Object}]
+        PARAMETER_DEFAULTS = {
+          callbacks: [],
+          coercers: [],
+          default: UNSPECIFIED,
+          description: UNSPECIFIED,
+          required: false,
+          validator: UNSPECIFIED
+        }.freeze
+
+        # Initialize a new instance of ParameterBuilder.
+        #
+        # @param base [Class<Constraint::BaseConstraint>] The constraint to build parameters for.
+        # @return [ParameterBuilder] The new instance of ParameterBuilder.
+        def initialize(base)
+          @base = base
+          @data = {}
+        end
+
+        # Inject the defined parameters into the base {Constraint::BaseConstraint constraint} and define
+        #  getter and setter methods for each parameter.
+        #
+        # @return [void]
+        def build!
+          inject_parameters
+          inject_parameter_methods!
+        end
+
+        # Add a coercer to the current {Constraint::Parameter parameter}.
+        #
+        # @param proc_symbol_or_true [Symbol, Proc, true, nil] The proc, symbol, or true to add as a coercer.
+        # @yield the block to add as a coercer.
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [self]
+        def coercer(proc_symbol_or_true = nil, &block)
+          validate_current_parameter!
+
+          @current_parameter[:coercers] << (proc_symbol_or_true || block)
+          self
+        end
+        alias coerce coercer
+
+        # Add a default value to the current {Constraint::Parameter parameter}.
+        #
+        # @param value [Object] The default value to add.
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [self]
+        def default(value)
+          validate_current_parameter!
+
+          @current_parameter[:default] = value
+          self
+        end
+
+        # Define a new {Constraint::Parameter parameter} on the {Constraint::BaseConstraint constraint}.
+        #
+        # @param name [String, Symbol] The name of the parameter.
+        # @yield [self] The block to define the parameter.
+        # @return [self]
+        def define(name, &)
+          @current_parameter = @data[name.to_sym] ||=
+            PARAMETER_DEFAULTS.transform_values { |value| value == UNSPECIFIED ? value : value.dup }
+                              .merge(name: name.to_sym)
+          instance_exec(&) if block_given?
+          self
+        end
+
+        # Add a description to the current {Constraint::Parameter parameter}.
+        #
+        # @param value [String] The description to add.
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [self]
+        def description(value)
+          validate_current_parameter!
+
+          @current_parameter[:description] = value
+          self
+        end
+        alias desc description
+
+        # Duplicate the current ParameterBuilder with a new base {Constraint::BaseConstraint constraint}.
+        #
+        # @param new_base [Class<Constraint::BaseConstraint>] The new base constraint.
+        # @return [ParameterBuilder] The new instance of ParameterBuilder.
+        def dup_with_base(new_base)
+          dup.tap { |duped| duped.instance_variable_set(:@base, new_base) }
+        end
+
+        # Add a callback to the current {Constraint::Parameter parameter}.
+        #
+        # @yield the block to add as a callback.
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [self]
+        def on_change(&block)
+          validate_current_parameter!
+
+          @current_parameter[:callbacks] << block
+          self
+        end
+
+        # Mark the current {Constraint::Parameter parameter} as required.
+        #
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [self]
+        def required
+          validate_current_parameter!
+
+          @current_parameter[:required] = true
+          self
+        end
+
+        # Add a validator to the current {Constraint::Parameter parameter}.
+        #
+        # @param proc_or_symbol [Symbol, Proc, nil] The proc or symbol to add as a validator.
+        # @yield the block to add as a validator.
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [self]
+        def validator(proc_or_symbol = nil, &block)
+          validate_current_parameter!
+
+          @current_parameter[:validator] = proc_or_symbol || block
+          self
+        end
+
+        private
+
+        # Inject the defined parameter methods into the base {Constraint::BaseConstraint constraint}.
+        #
+        # @return [void]
+        def inject_parameter_methods!
+          @data.each_key do |parameter_name|
+            @base.define_method(parameter_name) { parameters.public_send(parameter_name).value }
+            @base.define_method(:"#{parameter_name}=") { |value| parameters.public_send(parameter_name).value = value }
+            @base.define_method(:"#{parameter_name}_default") { parameters.public_send(parameter_name).default }
+          end
+        end
+
+        # Inject the defined parameters into the base {Constraint::BaseConstraint constraint}.
+        #
+        # @return [void]
+        def inject_parameters
+          @data.each_value do |parameter_options|
+            next if @base.parameters.respond_to?(parameter_options[:name])
+
+            @base.parameters.add(parameter_options.reject { |_, value| value == UNSPECIFIED })
+          end
+        end
+
+        # Validate that a parameter is currently being defined.
+        #
+        # @raise [ArgumentError] If no parameter is currently being defined.
+        # @return [void]
+        def validate_current_parameter!
+          return if @current_parameter
+
+          raise "No parameter is currently being defined for #{@base}"
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/base_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/base_constraint.rbs
@@ -3,6 +3,7 @@ module Domainic
     module Constraint
       class BaseConstraint
         self.@parameters: ParameterSet
+        self.@parameter_builder: DSL::ParameterBuilder
 
         @base: BaseType
         @description: (String | nil)
@@ -11,7 +12,17 @@ module Domainic
 
         def self.name: () -> String
 
+        def self.parameter: (String | Symbol parameter_name) ? { (DSL::ParameterBuilder) [self: DSL::ParameterBuilder] -> DSL::ParameterBuilder } -> void
+
         def self.parameters: () -> ParameterSet
+
+        private
+
+        def self.inherited: (singleton(BaseConstraint) subclass) -> void
+
+        def self.parameter_builder: () -> DSL::ParameterBuilder
+
+        public
 
         attr_reader description: (String | nil)
         attr_reader name: Symbol

--- a/domainic-type/sig/domainic/type/dsl/parameter_builder.rbs
+++ b/domainic-type/sig/domainic/type/dsl/parameter_builder.rbs
@@ -1,0 +1,50 @@
+module Domainic
+  module Type
+    module DSL
+      class ParameterBuilder
+        @base: singleton(Constraint::BaseConstraint)
+        @data: Hash[Symbol, untyped]
+        @current_parameter: Hash[Symbol, untyped]
+
+        PARAMETER_DEFAULTS: {
+          callbacks: Array[nil],
+          coercers: Array[nil],
+          default: Object,
+          description: Object,
+          required: false,
+          validator: Object
+        }
+
+        def initialize: (singleton(Constraint::BaseConstraint) base) -> void
+
+        def build!: () -> void
+
+        def coercer: (?(Proc | Symbol | true)? proc_symbol_or_true) ?{ (?) -> void } -> self
+        alias coerce coercer
+
+        def default: (Object value) -> self
+
+        def define: (String | Symbol name) ?{ (ParameterBuilder) [self: ParameterBuilder] -> ParameterBuilder } -> self
+
+        def description: (String value) -> self
+        alias desc description
+
+        def dup_with_base: (singleton(Constraint::BaseConstraint) new_base) -> untyped
+
+        def on_change: () { (?) -> void } -> self
+
+        def required: () -> self
+
+        def validator: (?(Proc | Symbol)? proc_or_symbol) { (?) -> void } -> self
+
+        private
+
+        def inject_parameter_methods!: () -> void
+
+        def inject_parameters: () -> void
+
+        def validate_current_parameter!: () -> void
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -7,6 +7,18 @@ require 'domainic/type/constraint/base_constraint'
 RSpec.describe Domainic::Type::Constraint::BaseConstraint do
   let(:type) { instance_double(Domainic::Type::BaseType) }
 
+  describe '.parameter' do
+    subject(:parameter) { constraint_class.parameter(:test) }
+
+    let(:constraint_class) { Class.new(described_class) }
+
+    it {
+      expect { parameter }.to(
+        change { constraint_class.parameters.instance_variable_get(:@entries).count }.by(1)
+      )
+    }
+  end
+
   describe '.parameters' do
     subject(:parameters) { described_class.parameters }
 

--- a/domainic-type/spec/domainic/type/dsl/parameter_builder_spec.rb
+++ b/domainic-type/spec/domainic/type/dsl/parameter_builder_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/base_constraint'
+require 'domainic/type/dsl/parameter_builder'
+
+RSpec.describe Domainic::Type::DSL::ParameterBuilder do
+  describe '#build!' do
+    subject(:build!) { builder.build! }
+
+    let(:builder) { described_class.new(constraint_class) }
+
+    context 'when parameters have been defined' do
+      before { builder.define(:test) }
+
+      let(:constraint_class) do
+        class_double(Domainic::Type::Constraint::BaseConstraint, parameters:)
+      end
+      let(:parameters) { instance_double(Domainic::Type::Constraint::ParameterSet, add: true) }
+
+      it 'is expected to add the parameters to the constraint' do
+        build!
+
+        expect(parameters).to have_received(:add).with(callbacks: [], coercers: [], name: :test, required: false)
+      end
+
+      it 'is expected to define getter and setter methods for each parameter' do
+        build!
+
+        expect(constraint_class.instance_methods).to include(:test).and(include(:test=)).and(include(:test_default))
+      end
+
+      context 'when the parameter has already been added to the constraint' do
+        before do
+          allow(parameters).to receive(:respond_to?).with(:test).and_return(true)
+        end
+
+        it 'is expected not to add the parameter to the constraint' do
+          build!
+
+          expect(parameters).not_to have_received(:add)
+        end
+      end
+    end
+  end
+
+  describe '#coercer' do
+    subject(:coercer) { builder.coercer(*arguments) }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+    let(:arguments) { [] }
+
+    context 'when a parameter is being defined' do
+      before { builder.define(:test) }
+
+      it { expect { coercer }.not_to raise_error }
+
+      context 'when given a Proc, Symbol, or `true`' do
+        let(:arguments) { [[:test, lambda(&:to_s), true].sample] }
+
+        it "is expected to add the Proc, Symbol, or `true` to the current parameter's constraints" do
+          coercer
+
+          expect(builder.instance_variable_get(:@current_parameter)[:coercers]).to eq([arguments.first])
+        end
+      end
+
+      context 'when given a block' do
+        it {
+          expect { |b| coercer(&b) }.to(
+            change(builder.instance_variable_get(:@current_parameter)[:coercers], :count).by(1)
+          )
+        }
+      end
+    end
+
+    context 'when no parameter is being defined' do
+      it { expect { coercer }.to raise_error(RuntimeError) }
+    end
+  end
+
+  describe '#default' do
+    subject(:default) { builder.default(value) }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+    let(:value) { double }
+
+    context 'when a parameter is being defined' do
+      before { builder.define(:test) }
+
+      it { expect { default }.not_to raise_error }
+
+      it 'is expected to set the default value for the current parameter' do
+        default
+
+        expect(builder.instance_variable_get(:@current_parameter)[:default]).to eq(value)
+      end
+    end
+
+    context 'when no parameter is being defined' do
+      it { expect { default }.to raise_error(RuntimeError) }
+    end
+  end
+
+  describe '#description' do
+    subject(:description) { builder.description(value) }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+    let(:value) { 'test' }
+
+    context 'when a parameter is being defined' do
+      before { builder.define(:test) }
+
+      it { expect { description }.not_to raise_error }
+
+      it 'is expected to set the description for the current parameter' do
+        description
+
+        expect(builder.instance_variable_get(:@current_parameter)[:description]).to eq(value)
+      end
+    end
+
+    context 'when no parameter is being defined' do
+      it { expect { description }.to raise_error(RuntimeError) }
+    end
+  end
+
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { builder.dup_with_base(new_base) }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+    let(:new_base) { class_double(Domainic::Type::Constraint::BaseConstraint) }
+
+    it { expect(dup_with_base).to be_a(described_class) }
+
+    it 'is expected to set the new base constraint' do
+      expect(dup_with_base.instance_variable_get(:@base)).to eq(new_base)
+    end
+  end
+
+  describe '#on_change' do
+    subject(:on_change) { builder.on_change }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+
+    context 'when a parameter is being defined' do
+      before { builder.define(:test) }
+
+      it { expect { on_change }.not_to raise_error }
+
+      it {
+        expect { |b| on_change(&b) }.to(
+          change(builder.instance_variable_get(:@current_parameter)[:callbacks], :count).by(1)
+        )
+      }
+    end
+
+    context 'when no parameter is being defined' do
+      it { expect { on_change }.to raise_error(RuntimeError) }
+    end
+  end
+
+  describe '#required' do
+    subject(:required) { builder.required }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+
+    context 'when a parameter is being defined' do
+      before { builder.define(:test) }
+
+      it { expect { required }.not_to raise_error }
+
+      it 'is expected to mark the current parameter as required' do
+        required
+
+        expect(builder.instance_variable_get(:@current_parameter)[:required]).to be(true)
+      end
+    end
+
+    context 'when no parameter is being defined' do
+      it { expect { required }.to raise_error(RuntimeError) }
+    end
+  end
+
+  describe '#validator' do
+    subject(:validator) { builder.validator(*arguments) }
+
+    let(:builder) { described_class.new(class_double(Domainic::Type::Constraint::BaseConstraint)) }
+    let(:arguments) { [] }
+
+    context 'when a parameter is being defined' do
+      before { builder.define(:test) }
+
+      it { expect { validator }.not_to raise_error }
+
+      context 'when given a Proc or Symbol' do
+        let(:arguments) { [[:test, lambda(&:to_s)].sample] }
+
+        it "is expected to add the Proc or Symbol to the current parameter's constraints" do
+          validator
+
+          expect(builder.instance_variable_get(:@current_parameter)[:validator]).to eq(arguments.first)
+        end
+      end
+
+      context 'when given a block' do
+        it "is expected to add the block to the current parameter's validators" do
+          builder.validator do |value|
+            value.is_a?(String)
+          end
+
+          expect(builder.instance_variable_get(:@current_parameter)[:validator]).to be_a(Proc)
+        end
+      end
+    end
+
+    context 'when no parameter is being defined' do
+      it { expect { validator }.to raise_error(RuntimeError) }
+    end
+  end
+end


### PR DESCRIPTION
This patch adds `Domainic::Type::DSL::ParameterBuilder` which provides a DSL for defining parameters on constraints.

Changelog:
  - added `Domainic::Type::DSL::ParameterBuilder`
  - added `Domainic::Type::Constraint::BaseConstraint.parameter`

resolves #53 