### PR TITLE
Add property constraints

### DIFF
--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -105,6 +105,25 @@ module Domainic
           required
         end
 
+        # @!method negated
+        #  Indicates whether to negate the constraint.
+        #  @return [Boolean]
+        #
+        # @!method negated=(value)
+        #  Set the constraint to be negated.
+        #  @param value [Boolean] The value to negate the constraint.
+        #  @return [void]
+        #
+        # @!method negated_default
+        #  The default value for the negated constraint.
+        #  @return [false] the default value is `false`.
+        parameter :negated do
+          desc 'Negate the constraint'
+          default false
+          validator ->(value) { true.equal?(value) || false.equal?(value) }
+          required
+        end
+
         # Initialize a new instance of BaseConstraint.
         #
         # @param base [BaseType] The type the constraint is belongs to.

--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -24,6 +24,13 @@ module Domainic
       #
       # @since 0.1.0
       class BaseConstraint
+        # Valid accessors for the constraint.
+        #
+        # @see #accessor
+        #
+        # @return [Array<Symbol>]
+        VALID_ACCESSORS = %i[begin count end first keys last length self size values].freeze
+
         attr_reader :description, :name, :parameters
 
         class << self
@@ -75,6 +82,27 @@ module Domainic
           def parameter_builder
             @parameter_builder ||= DSL::ParameterBuilder.new(self)
           end
+        end
+
+        # @!method accessor
+        #  The accessor for the constraint. The method used to access the constrained value.
+        #  @return [Symbol]
+        #
+        # @!method accessor=(value)
+        #  Set the accessor for the constraint.
+        #  @see VALID_ACCESSORS
+        #  @param value [Symbol] The accessor for the constraint.
+        #  @return [void]
+        #
+        # @!method accessor_default
+        #  The default accessor for the constraint.
+        #  @return [Symbol] the default accessor is `:self`.
+        parameter :accessor do
+          desc 'The method used to access the constrained value'
+          coercer lambda(&:to_sym)
+          default :self
+          validator ->(value) { VALID_ACCESSORS.include?(value) }
+          required
         end
 
         # Initialize a new instance of BaseConstraint.

--- a/domainic-type/lib/domainic/type/constraint/finiteness_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/finiteness_constraint.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'property_constraint'
+require_relative 'with_access_qualification'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `FinitenessConstraint` checks if the subject is infinite or finite. The valid conditions for this
+      # constraint are `:finite` and `:infinite`.
+      #
+      # @since 0.1.0
+      class FinitenessConstraint < PropertyConstraint
+        include WithAccessQualification
+
+        conditions :finite, :infinite
+
+        protected
+
+        def interpret_result(result)
+          !result.nil? && !!result
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/mutability_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/mutability_constraint.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'property_constraint'
+require_relative 'with_access_qualification'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `MutabilityConstraint` checks if the subject is frozen or mutable. The valid conditions for this
+      # constraint are `:immutable` and `:mutable`.
+      #
+      # @since 0.1.0
+      class MutabilityConstraint < PropertyConstraint
+        include WithAccessQualification
+
+        conditions :immutable, :mutable
+
+        private
+
+        def immutable?(subject)
+          subject.frozen?
+        end
+
+        def mutable?(subject)
+          !subject.frozen?
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/ordering_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/ordering_constraint.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative '../errors'
+require_relative 'property_constraint'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `OrderingConstraint` checks if the subject is sorted or unsorted. The valid conditions for this
+      # constraint are `:ordered` and `:unordered`.
+      #
+      # @since 0.1.0
+      class OrderingConstraint < PropertyConstraint
+        conditions :ordered, :unordered
+
+        # @!method reversed
+        #  Allows the constraint to be in reverse order.
+        #  @return [Boolean] `true` if the constraint is reversed, `false` otherwise.
+        #
+        # @!method reversed=(value)
+        #  Sets the constraint to be in reverse order.
+        #  @param value [Boolean] `true` if the constraint is reversed, `false` otherwise.
+        #  @return [void]
+        #
+        # @!method default_reversed
+        #  Returns the default value for the reversed parameter.
+        #  @return [false] the default value for the reversed parameter.
+        parameter :reversed do
+          desc 'Allows the constraint to be in reverse order'
+          validator ->(value) { true.equal?(value) || false.equal?(value) }
+          default false
+          required
+        end
+
+        private
+
+        # Check if the subject is ordered.
+        #
+        # @param subject [Object] The subject to check.
+        # @return [Boolean] `true` if the subject is ordered, `false` otherwise.
+        def ordered?(subject)
+          sorted_subject = sorted_subject(subject)
+          sorted_subject == subject || sorted_subject.join == subject
+        rescue InvalidSubjectError
+          false
+        end
+
+        # Converts the subject to an array if it's a string; otherwise, returns the subject itself.
+        #
+        # @param subject [Object] The subject to check.
+        # @raise [InvalidSubjectError] if the subject is not sortable.
+        # @return [Array<Object>] The subject converted to an array if it's a string, or the subject itself.
+        def sortable_subject(subject)
+          if subject.respond_to?(:sort)
+            subject
+          elsif subject.is_a?(String)
+            subject.chars
+          elsif subject.respond_to?(:to_a)
+            subject.to_a
+          else
+            raise InvalidSubjectError
+          end
+        end
+
+        # Ensure the subject is sorted.
+        #
+        # @param subject [Object] The subject to sort.
+        # @return [Array<Object>] The sorted subject.
+        def sorted_subject(subject)
+          sorted = sortable_subject(subject).sort
+          sorted = sorted.reverse if reversed
+          sorted
+        end
+
+        # Check if the subject is unordered.
+        #
+        # @param subject [Object] The subject to check.
+        # @return [Boolean] `true` if the subject is unordered, `false` otherwise.
+        def unordered?(subject)
+          sorted_subject = sorted_subject(subject)
+          sorted_subject != subject && sorted_subject.join != subject
+        rescue InvalidSubjectError
+          false
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/parity_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/parity_constraint.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'property_constraint'
+require_relative 'with_access_qualification'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `ParityConstraint` checks if the subject is even or odd. The valid conditions for this
+      # constraint are `:even` and `:odd`.
+      #
+      # @since 0.1.0
+      class ParityConstraint < PropertyConstraint
+        include WithAccessQualification
+
+        conditions :even, :odd
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/polarity_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/polarity_constraint.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'property_constraint'
+require_relative 'with_access_qualification'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `PolarityConstraint` checks if the subject is positive, negative. The valid conditions for this constraint
+      #  are `:positive` or `:negative`.
+      #
+      # @since 0.1.0
+      class PolarityConstraint < PropertyConstraint
+        include WithAccessQualification
+
+        conditions :positive, :negative
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/population_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/population_constraint.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'property_constraint'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `PopulationConstraint` checks if the subject is empty, or  populated. The valid conditions for this
+      #  constraint are `:empty`, `:populated`.
+      #
+      # @since 0.1.0
+      class PopulationConstraint < PropertyConstraint
+        conditions :empty, :populated
+
+        private
+
+        def populated?(subject)
+          !subject.empty?
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/presence_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/presence_constraint.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'property_constraint'
+require_relative 'with_access_qualification'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `PresenceConstraint` checks if the subject is absent, or present. The valid conditions for this
+      #  constraint are `:absent`, `:present`.
+      #
+      # @since 0.1.0
+      class PresenceConstraint < PropertyConstraint
+        include WithAccessQualification
+
+        conditions :absent, :present
+
+        private
+
+        # Check if the subject is absent.
+        #
+        # @param subject [::Object] The subject to check.
+        # @return [::Boolean] `true` if the subject is absent, `false` otherwise.
+        def absent?(subject)
+          subject.nil? || (subject.respond_to?(:empty?) && subject.empty?)
+        end
+
+        # Check if the subject is present.
+        #
+        # @param subject [::Object] The subject to check.
+        # @return [::Boolean] `true` if the subject is present, `false` otherwise.
+        def present?(subject)
+          !subject.nil? && !(subject.respond_to?(:empty?) && subject.empty?)
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/property_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/property_constraint.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative 'base_constraint'
+
+module Domainic
+  module Type
+    module Constraint
+      # The base class for all Property based constraints.
+      #
+      # Property based constraints are used to enforce a condition on the subject.  The condition is typically a
+      # predicate method that takes no arguments (i.e. `frozen?`). The constraint will enforce that the condition is met
+      # by the validation subject. Child classes may either define conditions the subject will respond to, or define
+      # custom methods to check the condition.
+      #
+      # @abstract subclasses must define the conditions the constraint supports using the {.conditions .conditions}
+      #  class method.
+      #
+      # @!attribute [r] valid_conditions
+      #  @!scope class
+      #  The conditions the constraint supports.
+      #  @return [Array<Symbol>]
+      #
+      # @since 0.1.0
+      class PropertyConstraint < BaseConstraint
+        class << self
+          attr_reader :valid_conditions
+
+          # Define what conditions the constraint supports
+          #
+          # @param conditions [Array<Symbol>] The predicate methods (ending with `?`) to check.
+          # @return [void]
+          def conditions(*conditions)
+            @valid_conditions = conditions.map do |condition|
+              condition.to_s.end_with?('?') ? condition.to_sym : :"#{condition}?"
+            end.freeze
+          end
+        end
+
+        # @!method condition
+        #  The condition to enforce
+        #  @return [Symbol]
+        #
+        # @!method condition=(value)
+        #  Sets the condition to enforce
+        #  @param value [Symbol] The condition to enforce
+        #  @return [Symbol]
+        #
+        # @!method default_condition
+        #  The default condition to enforce
+        #  @return [nil]
+        parameter :condition do
+          desc 'The condition to enforce'
+          coercer ->(value) { value.to_s.end_with?('?') ? value.to_sym : :"#{value}?" }
+          validator ->(value) { self.class.valid_conditions.include?(value) }
+          required
+        end
+
+        # Validate the subject against the constraint
+        #
+        # @param subject [Object] The subject to validate
+        # @return [Boolean]
+        def validate(subject)
+          constrained_value = accessor == :self ? subject : subject.public_send(accessor)
+
+          result = if respond_to?(:access_qualifier) && !access_qualifier.nil? && constrained_value.is_a?(Enumerable)
+                     constrained_value.public_send(access_qualifier) do |qualified_subject|
+                       check_condition(qualified_subject)
+                     end
+                   else
+                     check_condition(constrained_value)
+                   end
+
+          interpret_result(result) ^ negated
+        end
+
+        protected
+
+        # Interpret the result of the condition check
+        # This is a hook method for subclasses to override to ensure the result is interpreted correctly as a boolean.
+        #
+        # @param result [Object] The result of the condition check
+        # @return [Boolean]
+        def interpret_result(result)
+          !!result
+        end
+
+        private
+
+        # Check the condition against the subject
+        #
+        # @param subject [Object] The subject to check the condition against.
+        # @return [Boolean]
+        def check_condition(subject)
+          if subject.respond_to?(condition)
+            subject.send(condition)
+          else
+            send(condition, subject)
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/uniqueness_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/uniqueness_constraint.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative '../errors'
+require_relative 'property_constraint'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `UniquenessConstraint` checks if the subject is unique or duplicative. The valid conditions for this
+      # constraint are `:duplicative` and `:unique`.
+      #
+      # @since 0.1.0
+      class UniquenessConstraint < PropertyConstraint
+        conditions :duplicative, :unique
+
+        private
+
+        # Check if the subject has duplicative elements.
+        #
+        # @param subject [::Object] The subject to check.
+        # @return [::Boolean] `true` if the subject has any duplicate elements, `false` otherwise.
+        def duplicative?(subject)
+          elements = unique_elements(subject)
+          elements.size != elements.uniq.size
+        rescue InvalidSubjectError
+          false
+        end
+
+        # Check if the subject has unique elements.
+        #
+        # @param subject [::Object] The subject to check.
+        # @return [::Boolean] `true` if the subject has all unique elements, `false` otherwise.
+        def unique?(subject)
+          elements = unique_elements(subject)
+          elements.size == elements.uniq.size
+        rescue InvalidSubjectError
+          false
+        end
+
+        # Converts the subject to an array if it's a string; otherwise, returns the subject itself.
+        #
+        # @param subject [::Object] The subject to check.
+        # @return [::Array<::Object>] The elements of the subject as an array, or raises InvalidSubjectError if not
+        #  applicable.
+        def unique_elements(subject)
+          if subject.is_a?(::String)
+            subject.chars
+          elsif subject.is_a?(::Enumerable)
+            subject.to_a
+          else
+            raise InvalidSubjectError
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/with_access_qualification.rb
+++ b/domainic-type/lib/domainic/type/constraint/with_access_qualification.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module Constraint
+      # A mixin to add the `access_qualifier` parameter to a constraint.
+      #
+      # @!method access_qualifier
+      #  The access qualifier for the constraint. Determines how the constraint is applied to a collection returned by
+      #  the accessor.
+      #  @return [Symbol]
+      #
+      # @!method access_qualifier=(value)
+      #  @see VALID_ACCESS_QUALIFIERS
+      #  Set the access qualifier for the constraint.
+      #  @param value [Symbol] The access qualifier for the constraint.
+      #  @return [void]
+      #
+      # @!method access_qualifier_default
+      #  The default access qualifier for the constraint.
+      #  @return [nil] there is no default access qualifier.
+      #
+      # @since 0.1.0
+      module WithAccessQualification
+        # Valid access qualifiers for the constraint.
+        #
+        # @see #access_qualifier
+        #
+        # @return [Array<Symbol>]
+        VALID_ACCESS_QUALIFIERS = %i[all? any? none? one?].freeze
+
+        class << self
+          private
+
+          # Inject the `access_qualifier` parameter into the base class.
+          #
+          # @param base [Class] The base class to include the parameter in.
+          # @return [void]
+          def included(base) # rubocop:disable Metrics/MethodLength
+            base.parameter :access_qualifier do
+              desc 'Determines how the constraint is applied to a collection returned by the accessor. ' \
+                   'Valid values are :all, :any, :none, or :one.'
+
+              coercer do |value|
+                if value.nil?
+                  value
+                else
+                  value.to_s.end_with?('?') ? value.to_sym : :"#{value}?"
+                end
+              end
+
+              validator ->(value) { value.nil? || VALID_ACCESS_QUALIFIERS.include?(value) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/dsl/parameter_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/parameter_builder.rb
@@ -144,6 +144,8 @@ module Domainic
         # @return [void]
         def inject_parameter_methods!
           @data.each_key do |parameter_name|
+            next if @base.instance_methods.include?(parameter_name)
+
             @base.define_method(parameter_name) { parameters.public_send(parameter_name).value }
             @base.define_method(:"#{parameter_name}=") { |value| parameters.public_send(parameter_name).value = value }
             @base.define_method(:"#{parameter_name}_default") { parameters.public_send(parameter_name).default }

--- a/domainic-type/lib/domainic/type/errors.rb
+++ b/domainic-type/lib/domainic/type/errors.rb
@@ -11,5 +11,10 @@ module Domainic
     #
     # @since 0.1.0
     class InvalidParameterError < Error; end
+
+    # Raised when the subject of a constraint cannot be constrained by the constraint.
+    #
+    # @since 0.1.0
+    class InvalidSubjectError < Error; end
   end
 end

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -58,6 +58,39 @@ RSpec.describe Domainic::Type::Constraint::BaseConstraint do
     it { is_expected.to eq(:self) }
   end
 
+  describe '#negated' do
+    subject(:negated) { constraint.negated }
+
+    let(:constraint) { described_class.new(type) }
+
+    it { is_expected.to be false }
+
+    context 'when set' do
+      before { constraint.negated = expected_value }
+
+      let(:expected_value) { true }
+
+      it { is_expected.to eq(expected_value) }
+    end
+  end
+
+  describe '#negated=' do
+    subject(:set_negated) { constraint.negated = expected_value }
+
+    let(:constraint) { described_class.new(type) }
+    let(:expected_value) { true }
+
+    it { expect { set_negated }.to change(constraint, :negated).to(expected_value) }
+  end
+
+  describe '#negated_default' do
+    subject(:negated_default) { constraint.negated_default }
+
+    let(:constraint) { described_class.new(type) }
+
+    it { is_expected.to be false }
+  end
+
   describe '#initialize' do
     subject(:new_instance) { constraint_class.new(type, **options) }
 

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -25,6 +25,39 @@ RSpec.describe Domainic::Type::Constraint::BaseConstraint do
     it { is_expected.to be_an_instance_of(Domainic::Type::Constraint::ParameterSet) }
   end
 
+  describe '#accessor' do
+    subject(:accessor) { constraint.accessor }
+
+    let(:constraint) { described_class.new(type) }
+
+    it { is_expected.to eq(:self) }
+
+    context 'when set' do
+      before { constraint.accessor = expected_value }
+
+      let(:expected_value) { described_class::VALID_ACCESSORS.reject { |i| i == constraint.accessor_default }.sample }
+
+      it { is_expected.to eq(expected_value) }
+    end
+  end
+
+  describe '#accessor=' do
+    subject(:set_accessor) { constraint.accessor = expected_value }
+
+    let(:constraint) { described_class.new(type) }
+    let(:expected_value) { described_class::VALID_ACCESSORS.reject { |i| i == constraint.accessor_default }.sample }
+
+    it { expect { set_accessor }.to change(constraint, :accessor).to(expected_value) }
+  end
+
+  describe '#accessor_default' do
+    subject(:accessor_default) { constraint.accessor_default }
+
+    let(:constraint) { described_class.new(type) }
+
+    it { is_expected.to eq(:self) }
+  end
+
   describe '#initialize' do
     subject(:new_instance) { constraint_class.new(type, **options) }
 

--- a/domainic-type/spec/domainic/type/constraint/finiteness_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/finiteness_constraint_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/finiteness_constraint'
+
+RSpec.describe Domainic::Type::Constraint::FinitenessConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    context 'when the condition is :finite' do
+      before { constraint.condition = :finite }
+
+      context 'when the subject is finite' do
+        let(:subject_value) { 1 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is infinite' do
+        let(:subject_value) { Float::INFINITY }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all? }
+
+        context 'when all elements are finite' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when some elements are not finite' do
+          let(:subject_value) { [1, 2, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any? }
+
+        context 'when any element is finite' do
+          let(:subject_value) { [1, 2, Float::INFINITY] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are finite' do
+          let(:subject_value) { [Float::INFINITY, Float::INFINITY, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none? }
+
+        context 'when no elements are finite' do
+          let(:subject_value) { [Float::INFINITY, Float::INFINITY, Float::INFINITY] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any element is finite' do
+          let(:subject_value) { [1, 2, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one? }
+
+        context 'when one element is finite' do
+          let(:subject_value) { [1, Float::INFINITY] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are finite' do
+          let(:subject_value) { [Float::INFINITY, Float::INFINITY, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when multiple elements are finite' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is finite' do
+          let(:subject_value) { 1 }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is infinite' do
+          let(:subject_value) { Float::INFINITY }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :infinite' do
+      before { constraint.condition = :infinite }
+
+      context 'when the subject is finite' do
+        let(:subject_value) { 1 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is infinite' do
+        let(:subject_value) { Float::INFINITY }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are infinite' do
+          let(:subject_value) { [Float::INFINITY, Float::INFINITY] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when some elements are not infinite' do
+          let(:subject_value) { [1, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any element is infinite' do
+          let(:subject_value) { [1, 2, Float::INFINITY] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are infinite' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are infinite' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any element is infinite' do
+          let(:subject_value) { [1, 2, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one element is infinite' do
+          let(:subject_value) { [1, Float::INFINITY] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are infinite' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when multiple elements are infinite' do
+          let(:subject_value) { [1, Float::INFINITY, Float::INFINITY, Float::INFINITY] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is finite' do
+          let(:subject_value) { 1 }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is infinite' do
+          let(:subject_value) { Float::INFINITY }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/mutability_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/mutability_constraint_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/mutability_constraint'
+
+RSpec.describe Domainic::Type::Constraint::MutabilityConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    context 'when the condition is :immutable' do
+      before { constraint.condition = :immutable }
+
+      context 'when the subject is frozen' do
+        let(:subject_value) { Object.new.freeze }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is not frozen' do
+        let(:subject_value) { Object.new }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is Enumerable and access_qualifer is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new.freeze] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when not all elements are frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifer is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any elements are frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are frozen' do
+          let(:subject_value) { [Object.new, Object.new] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are frozen' do
+          let(:subject_value) { [Object.new, Object.new] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any elements are frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :one' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one element is frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are frozen' do
+          let(:subject_value) { [Object.new, Object.new] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when more than one element is frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new.freeze] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is frozen' do
+          let(:subject_value) { Object.new.freeze }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is not frozen' do
+          let(:subject_value) { Object.new }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :mutable' do
+      before { constraint.condition = :mutable }
+
+      context 'when the subject is not frozen' do
+        let(:subject_value) { Object.new }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is frozen' do
+        let(:subject_value) { Object.new.freeze }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are not frozen' do
+          let(:subject_value) { [Object.new, Object.new] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when not all elements are not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any elements are not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new.freeze] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new.freeze] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any elements are not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and access_qualifier is :one' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one element is not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are not frozen' do
+          let(:subject_value) { [Object.new.freeze, Object.new.freeze] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when more than one element is not frozen' do
+          let(:subject_value) { [Object.new, Object.new] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is not frozen' do
+          let(:subject_value) { Object.new }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is frozen' do
+          let(:subject_value) { Object.new.freeze }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/ordering_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/ordering_constraint_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/ordering_constraint'
+
+RSpec.describe Domainic::Type::Constraint::OrderingConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+    let(:ordered) { %w[a b c] }
+    let(:unordered) { %w[c a b] }
+
+    context 'when the condition is :ordered' do
+      before { constraint.condition = :ordered }
+
+      context 'when the subject is ordered' do
+        let(:subject_value) { ordered }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is not ordered' do
+        let(:subject_value) { unordered }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is a String and ordered' do
+        let(:subject_value) { 'abc' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is a String and not ordered' do
+        let(:subject_value) { 'cab' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject does not respond to sort' do
+        let(:subject_value) { 123 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is ordered' do
+          let(:subject_value) { ordered }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is not ordered' do
+          let(:subject_value) { unordered }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when the constraint is reversed' do
+        before { constraint.reversed = true }
+
+        context 'when the subject is reverse ordered' do
+          let(:subject_value) { ordered.reverse }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is ordered' do
+          let(:subject_value) { ordered }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is unordered' do
+          let(:subject_value) { unordered }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'when the condition is :unordered' do
+      before { constraint.condition = :unordered }
+
+      context 'when the subject is ordered' do
+        let(:subject_value) { ordered }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is not ordered' do
+        let(:subject_value) { unordered }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is a String and ordered' do
+        let(:subject_value) { 'abc' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is a String and not ordered' do
+        let(:subject_value) { 'cab' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject does not respond to sort' do
+        let(:subject_value) { 123 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is ordered' do
+          let(:subject_value) { ordered }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is not ordered' do
+          let(:subject_value) { unordered }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is reversed' do
+        before { constraint.reversed = true }
+
+        context 'when the subject is reverse ordered' do
+          let(:subject_value) { ordered.reverse }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is ordered' do
+          let(:subject_value) { ordered }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is unordered' do
+          let(:subject_value) { unordered }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/parity_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/parity_constraint_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/parity_constraint'
+
+RSpec.describe Domainic::Type::Constraint::ParityConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    context 'when the condition is :even?' do
+      before { constraint.condition = :even }
+
+      context 'when the subject is even' do
+        let(:subject_value) { 2 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is odd' do
+        let(:subject_value) { 1 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are even' do
+          let(:subject_value) { [2, 4, 6] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when some elements are odd' do
+          let(:subject_value) { [2, 3, 6] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any elements are even' do
+          let(:subject_value) { [1, 3, 6] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when all elements are odd' do
+          let(:subject_value) { [1, 3, 5] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are even' do
+          let(:subject_value) { [1, 3, 5] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any elements are even' do
+          let(:subject_value) { [1, 3, 6] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one element is even' do
+          let(:subject_value) { [1, 3, 6] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are even' do
+          let(:subject_value) { [1, 3, 5] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when more than one element is even' do
+          let(:subject_value) { [1, 2, 6] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is even' do
+          let(:subject_value) { 2 }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is odd' do
+          let(:subject_value) { 1 }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :odd?' do
+      before { constraint.condition = :odd }
+
+      context 'when the subject is even' do
+        let(:subject_value) { 2 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is odd' do
+        let(:subject_value) { 1 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are odd' do
+          let(:subject_value) { [1, 3, 5] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when some elements are even' do
+          let(:subject_value) { [1, 2, 5] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any elements are odd' do
+          let(:subject_value) { [2, 4, 5] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when all elements are even' do
+          let(:subject_value) { [2, 4, 6] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are odd' do
+          let(:subject_value) { [2, 4, 6] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any elements are odd' do
+          let(:subject_value) { [2, 4, 5] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one element is odd' do
+          let(:subject_value) { [2, 3, 6] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are odd' do
+          let(:subject_value) { [2, 4, 6] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when more than one element is odd' do
+          let(:subject_value) { [1, 3, 6] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is even' do
+          let(:subject_value) { 2 }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is odd' do
+          let(:subject_value) { 1 }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/polarity_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/polarity_constraint_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/polarity_constraint'
+
+RSpec.describe Domainic::Type::Constraint::PolarityConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    context 'when the condition is :positive?' do
+      before { constraint.condition = :positive }
+
+      context 'when the subject is positive' do
+        let(:subject_value) { 1 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is negative' do
+        let(:subject_value) { -1 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all values are positive' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when some values are negative' do
+          let(:subject_value) { [1, 2, -3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when some values are positive' do
+          let(:subject_value) { [1, -2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no values are positive' do
+          let(:subject_value) { [-1, -2] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when some values are positive' do
+          let(:subject_value) { [1, -2] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when no values are positive' do
+          let(:subject_value) { [-1, -2] }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one value is positive' do
+          let(:subject_value) { [1, -1] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no value is positive' do
+          let(:subject_value) { [-1, -2] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when more than one value is positive' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is positive' do
+          let(:subject_value) { 1 }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is negative' do
+          let(:subject_value) { -1 }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :negative?' do
+      before { constraint.condition = :negative }
+
+      context 'when the subject is positive' do
+        let(:subject_value) { 1 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is negative' do
+        let(:subject_value) { -1 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all values are negative' do
+          let(:subject_value) { [-1, -2, -3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when some values are positive' do
+          let(:subject_value) { [1, 2, -3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when some values are negative' do
+          let(:subject_value) { [1, -2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no values are negative' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when some values are negative' do
+          let(:subject_value) { [1, -2] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when no values are negative' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when the subject is Enumerable and the access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one value is negative' do
+          let(:subject_value) { [1, -1] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no value is negative' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when more than one value is negative' do
+          let(:subject_value) { [-1, -2] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is positive' do
+          let(:subject_value) { 1 }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is negative' do
+          let(:subject_value) { -1 }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/population_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/population_constraint_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/population_constraint'
+
+RSpec.describe Domainic::Type::Constraint::PopulationConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    context 'when the condition is :empty?' do
+      before { constraint.condition = :empty }
+
+      context 'when the subject is empty' do
+        let(:subject_value) { [] }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is not empty' do
+        let(:subject_value) { [1, 2, 3] }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is empty' do
+          let(:subject_value) { [] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is not empty' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :populated?' do
+      before { constraint.condition = :populated }
+
+      context 'when the subject is empty' do
+        let(:subject_value) { [] }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is not empty' do
+        let(:subject_value) { [1, 2, 3] }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is empty' do
+          let(:subject_value) { [] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is not empty' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/presence_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/presence_constraint_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/presence_constraint'
+
+RSpec.describe Domainic::Type::Constraint::PresenceConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    context 'when the condition is :absent?' do
+      before { constraint.condition = :absent }
+
+      context 'when the subject is nil' do
+        let(:subject_value) { nil }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is empty' do
+        let(:subject_value) { '' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is not empty or nil' do
+        let(:subject_value) { 'a' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are nil' do
+          let(:subject_value) { [nil, nil, nil] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when all elements are empty' do
+          let(:subject_value) { ['', '', ''] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when all elements are not empty or nil' do
+          let(:subject_value) { %w[a b c] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any element is nil' do
+          let(:subject_value) { [nil, nil, nil] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any element is empty' do
+          let(:subject_value) { ['', '', ''] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are empty or nil' do
+          let(:subject_value) { %w[a b c] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are nil' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when no elements are empty' do
+          let(:subject_value) { %w[a b c] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when any elements are empty or nil' do
+          let(:subject_value) { [nil, '', 1] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :one?' do
+        before { constraint.access_qualifier = :one }
+
+        context 'when one element is nil' do
+          let(:subject_value) { [nil, 1, 2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when one element is empty' do
+          let(:subject_value) { ['', 1, 2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when more than one element is empty or nil' do
+          let(:subject_value) { [nil, '', 1] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is nil' do
+          let(:subject_value) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is empty' do
+          let(:subject_value) { '' }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is not empty or nil' do
+          let(:subject_value) { 'a' }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :present?' do
+      before { constraint.condition = :present }
+
+      context 'when the subject is nil' do
+        let(:subject_value) { nil }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is empty' do
+        let(:subject_value) { '' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is not empty or nil' do
+        let(:subject_value) { 'a' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :all?' do
+        before { constraint.access_qualifier = :all }
+
+        context 'when all elements are nil' do
+          let(:subject_value) { [nil, nil, nil] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when all elements are empty' do
+          let(:subject_value) { ['', '', ''] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when all elements are not empty or nil' do
+          let(:subject_value) { %w[a b c] }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :any?' do
+        before { constraint.access_qualifier = :any }
+
+        context 'when any element is nil' do
+          let(:subject_value) { [nil, nil, nil] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when any element is empty' do
+          let(:subject_value) { ['', '', ''] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when no elements are empty or nil' do
+          let(:subject_value) { %w[a b c] }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when the subject is an Enumerable and access_qualifier is :none?' do
+        before { constraint.access_qualifier = :none }
+
+        context 'when no elements are nil' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when no elements are empty' do
+          let(:subject_value) { %w[a b c] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is nil' do
+          let(:subject_value) { nil }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is empty' do
+          let(:subject_value) { '' }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is not empty or nil' do
+          let(:subject_value) { 'a' }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/property_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/property_constraint_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/property_constraint'
+
+RSpec.describe Domainic::Type::Constraint::PropertyConstraint do
+  describe '.conditions' do
+    subject(:conditions) { constraint_class.conditions(*expected_conditions) }
+
+    let(:constraint_class) { Class.new(described_class) }
+    let(:expected_conditions) { %i[condition_one condition_two] }
+
+    it {
+      expect { conditions }.to(
+        change(constraint_class, :valid_conditions).to(expected_conditions.map { |c| :"#{c}?" })
+      )
+    }
+  end
+
+  describe '#condition' do
+    subject(:condition) { constraint.condition }
+
+    let(:constraint) do
+      klass = Class.new(described_class) do
+        def self.name
+          'TestConstraint'
+        end
+
+        conditions :condition_one, :condition_two
+      end
+      klass.new(instance_double(Domainic::Type::BaseType))
+    end
+
+    it { is_expected.to be_nil }
+
+    context 'when set' do
+      subject(:condition) { constraint.condition = :condition_one }
+
+      it { expect { condition }.to change(constraint, :condition).to(:condition_one?) }
+    end
+  end
+
+  describe '#condition=' do
+    subject(:set_condition) { constraint.condition = expected_condition }
+
+    let(:constraint) do
+      klass = Class.new(described_class) do
+        def self.name
+          'TestConstraint'
+        end
+
+        conditions :condition_one, :condition_two
+      end
+      klass.new(instance_double(Domainic::Type::BaseType))
+    end
+
+    context 'when the condition is valid' do
+      let(:expected_condition) { constraint.class.valid_conditions.sample }
+
+      it { expect { set_condition }.to change(constraint, :condition).to(expected_condition) }
+    end
+
+    context 'when the condition is invalid' do
+      let(:expected_condition) { :invalid_condition }
+
+      it { expect { set_condition }.to raise_error(Domainic::Type::InvalidParameterError) }
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/uniqueness_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/uniqueness_constraint_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/uniqueness_constraint'
+
+RSpec.describe Domainic::Type::Constraint::UniquenessConstraint do
+  describe '#validate' do
+    subject(:validate) { constraint.validate(subject_value) }
+
+    let(:constraint) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+    let(:duplicative) { %w[a a b] }
+    let(:unique) { %w[a b c] }
+
+    context 'when the condition is :duplicative' do
+      before { constraint.condition = :duplicative }
+
+      context 'when the subject is duplicative' do
+        let(:subject_value) { duplicative }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is unique' do
+        let(:subject_value) { unique }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is a String and duplicative' do
+        let(:subject_value) { 'aabc' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is a String and unique' do
+        let(:subject_value) { 'abc' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject does not respond to uniq' do
+        let(:subject_value) { 123 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is duplicative' do
+          let(:subject_value) { duplicative }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject is unique' do
+          let(:subject_value) { unique }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the condition is :unique' do
+      before { constraint.condition = :unique }
+
+      context 'when the subject is duplicative' do
+        let(:subject_value) { duplicative }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is unique' do
+        let(:subject_value) { unique }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject is a String and duplicative' do
+        let(:subject_value) { 'aab' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the subject is a String and unique' do
+        let(:subject_value) { 'abc' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the subject does not respond to uniq' do
+        let(:subject_value) { 123 }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the constraint is negated' do
+        before { constraint.negated = true }
+
+        context 'when the subject is duplicative' do
+          let(:subject_value) { duplicative }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is unique' do
+          let(:subject_value) { unique }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changelog:
  - added `Domainic::Type::Constraint::FinitenessConstraint`
  - added `Domainic::Type::Constraint::MutabilityConstraint`
  - added `Domainic::Type::Constraint::OrderingConstraint`
  - added `Domainic::Type::Constraint::ParityConstraint`
  - added `Domainic::Type::Constraint::PolarityConstraint`
  - added `Domainic::Type::Constraint::PopulationConstraint`
  - added `Domainic::Type::Constraint::PresenceConstraint`
  - added `Domainic::Type::Constraint::PropertyConstraint`
  - added `Domainic::Type::Constraint::UniquenessConstraint`
  - added `Domainic::Type::InvalidSubjectError`
  - added `Domainic::Type::Constraint::WithAccessQualification`
  - added `Domainic::Type::Constraint::BaseConstraint#accessor`
  - added `Domainic::Type::Constraint::BaseConstraint#accessor=`
  - added `Domainic::Type::Constraint::BaseConstraint#accessor_default`
  - added `Domainic::Type::Constraint::BaseConstraint#negated`
  - added `Domainic::Type::Constraint::BaseConstraint#negated=`
  - added `Domainic::Type::Constraint::BaseConstraint#negated_default`
  - fixed `Domainic::Type::DSL::ParameterBuilder#build!`

resolves #36 
resolves #37
resolves #38 
resolves #39 
resolves #40 
resolves #41 
resolves #42 
resolves #43
resolves #44 