### PR TITLE
Add constraints to `Domainic::Type::BaseType`

### DIFF
--- a/domainic-type/lib/domainic/type/base_type.rb
+++ b/domainic-type/lib/domainic/type/base_type.rb
@@ -1,12 +1,35 @@
 # frozen_string_literal: true
 
+require_relative 'constraint/provisioning/constraint_set'
+
 module Domainic
   module Type
     # The base class for all Domainic types.
     #
+    # @!attribute [r] constraints
+    #  The constraints for the type.
+    #  @return [Constraint::Provisioning::ConstraintSet]
+    #
     # @abstract
     # @since 0.1.0
-    class BaseType # rubocop:disable Lint/EmptyClass
+    class BaseType
+      attr_reader :constraints
+
+      class << self
+        # The constraints for the type.
+        #
+        # @return [Constraint::Provisioning::ConstraintSet]
+        def constraints
+          @constraints = Constraint::Provisioning::ConstraintSet.new(self)
+        end
+      end
+
+      # Initialize a new instance of BaseType.
+      #
+      # @return [BaseType] the new instance of BaseType.
+      def initialize
+        @constraints = self.class.constraints.dup_with_base(self)
+      end
     end
   end
 end

--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -143,6 +143,17 @@ module Domainic
           end
         end
 
+        # Duplicate the constraint with a new base.
+        #
+        # @param new_base [BaseType] The new base for the constraint.
+        # @return [BaseConstraint] the duplicated constraint.
+        def dup_with_base(new_base)
+          dup.tap do |duped|
+            duped.instance_variable_set(:@base, new_base)
+            duped.instance_variable_set(:@parameters, parameters.dup_with_base(duped))
+          end
+        end
+
         # Validate the subject against the constraint.
         #
         # @param subject [Object] The subject to validate.

--- a/domainic-type/lib/domainic/type/constraint/provisioning/constraint_set.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/constraint_set.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative 'provisioner'
+
+module Domainic
+  module Type
+    module Constraint
+      module Provisioning
+        # A collection of constraints belonging to a {BaseType type}.
+        #
+        # @since 0.1.0
+        class ConstraintSet
+          # Initialize a new instance of ConstraintSet.
+          #
+          # @param base [Class<BaseType>, BaseType] the base type.
+          # @return [ConstraintSet] the new instance of ConstraintSet.
+          def initialize(base)
+            @base = base
+            @entries = {}
+          end
+
+          # Duplicate the constraint set with a new base.
+          #
+          # @param new_base [BaseType] the new base for the constraint set.
+          # @return [ConstraintSet] the duplicated constraint set.
+          def dup_with_base(new_base)
+            dup.tap do |duped|
+              duped.instance_variable_set(:@base, new_base)
+              duped.instance_variable_set(
+                :@entries,
+                @entries.transform_values { |provisioner| provisioner.dup_with_base(new_base) }
+              )
+            end
+          end
+
+          # Stage a constraint for provisioning.
+          #
+          # @param accessor_name [String, Symbol] the name of the accessor.
+          # @param constraint_name [String, Symbol] the name of the constraint.
+          # @param options [Hash{String, Symbol => Object}] the options for the provisioned constraint.
+          #
+          # @option options [Hash{String, Symbol => Object}] defaults ({}) the default parameter values for the
+          #  constraint.
+          # @option options [String] description (nil) the description of the constraint.
+          # @option options [String, Symbol] name (nil) the name of the constraint.
+          # @option options [String, Symbol] type the type of the constraint.
+          # @option options [Hash{String, Symbol => Object}] validation_options ({}) the validation options for the
+          #  constraint.
+          #
+          # @return [self] the ConstraintSet.
+          def stage(accessor_name, constraint_name, **options)
+            accessor_key = accessor_name.to_sym
+            constraint_key = constraint_name.to_sym
+            @entries[accessor_key] ||= Provisioner.new(@base, accessor_key)
+            @entries[accessor_key].stage(name: constraint_key, **options)
+            self
+          end
+
+          # Convert the set to an array of provisioned constraints.
+          #
+          # @return [Array<ProvisionedConstraint>] the array of provisioned constraints.
+          def to_array
+            @entries.values.flat_map(&:to_array)
+          end
+          alias to_a to_array
+
+          private
+
+          # Delegate all entries hash.
+          #
+          # @param method [Symbol] the method to delegate.
+          # @return [Object] the result of the delegated method.
+          def method_missing(method, ...)
+            return super unless respond_to_missing?(method)
+
+            @entries.fetch(method)
+          end
+
+          # Check if the entries hash responds to the method.
+          #
+          # @param method [Symbol] the method to check.
+          # @param _include_private [Boolean]
+          # @return [Boolean] `true` if the entries hash responds to the method, otherwise `false`.
+          def respond_to_missing?(method, _include_private = false)
+            @entries.key?(method) || super
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/provisioning/provisioned_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/provisioned_constraint.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative 'validation_options'
+
+module Domainic
+  module Type
+    module Constraint
+      module Provisioning
+        # A provisioned or activated constraint for a {BaseType type}.
+        #
+        # @!attribute [r] validation_options
+        #  The validation options for the constraint.
+        #  @return [ValidationOptions] the validation options for the constraint.
+        #
+        # @since 0.1.0
+        class ProvisionedConstraint
+          attr_reader :validation_options
+
+          # Initialize a new instance of ProvisionedConstraint.
+          #
+          # @param constraint [BaseConstraint] the constraint instance.
+          # @param validation_options [Hash{String, Symbol => Object}] the validation options for the constraint.
+          # @return [ProvisionedConstraint] the new instance of ProvisionedConstraint.
+          def initialize(constraint, **validation_options)
+            @constraint = constraint
+            @validation_options = ValidationOptions.new(**validation_options)
+          end
+
+          # Duplicate the constraint with a new base.
+          #
+          # @param new_base [BaseType] the new base for the constraint.
+          # @return [ProvisionedConstraint] the duplicated constraint.
+          def dup_with_base(new_base)
+            dup.tap do |duped|
+              duped.instance_variable_set(:@constraint, @constraint.dup_with_base(new_base))
+            end
+          end
+
+          private
+
+          # Delegate all missing methods to the constraint.
+          #
+          # @param method [Symbol] the method to delegate.
+          # @return [Object] the result of the delegated method.
+          def method_missing(method, ...)
+            return super unless respond_to_missing?(method)
+
+            @constraint.public_send(method, ...)
+          end
+
+          # Check if the constraint responds to the method.
+          #
+          # @param method [Symbol] the method to check.
+          # @param _include_private [Object]
+          # @return [Boolean] `true` if the constraint responds to the method, otherwise `false`.
+          def respond_to_missing?(method, _include_private = false)
+            @constraint.respond_to?(method) || super
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative 'provisioned_constraint'
+
+module Domainic
+  module Type
+    module Constraint
+      module Provisioning
+        # Provision staged {BaseConstraint constraints} for a {BaseType type}.
+        #
+        # @since 0.1.0
+        class Provisioner
+          # Initialize a new instance of Provisioner.
+          #
+          # @param base [BaseType] the base type.
+          # @param accessor_name [String, Symbol] the name of the accessor.
+          # @return [Provisioner] the new instance of Provisioner.
+          def initialize(base, accessor_name)
+            @accessor_name = accessor_name.to_sym
+            @base = base
+            @provisioned = {}
+            @staged = {}
+          end
+
+          # Duplicate the provisioner with a new base.
+          #
+          # @param new_base [BaseType] the new base for the provisioner.
+          # @return [Provisioner] the duplicated provisioner.
+          def dup_with_base(new_base)
+            dup.tap do |duped|
+              duped.instance_variable_set(:@base, new_base)
+              duped.instance_variable_set(
+                :@provisioned,
+                @provisioned.transform_values { |provisioned| provisioned.dup_with_base(new_base) }
+              )
+            end
+          end
+
+          # Provision a constraint.
+          #
+          # @param name [String, Symbol] the name of the constraint.
+          # @param options [Hash{String, Symbol => Object}] the parameters options for the constraint.
+          # @return [ProvisionedConstraint] the provisioned constraint.
+          def provision(name, **options)
+            key = name.to_sym
+
+            if @provisioned.key?(key)
+              constraint = @provisioned[key]
+              options.each_pair { |parameter, value| constraint.public_send(:"#{parameter}=", value) }
+              return constraint
+            end
+
+            unless @staged.key?(key)
+              raise ArgumentError, "#{@base.class} does not constrain `#{key}` on `#{@accessor_name}`"
+            end
+
+            provision_constraint(name, options)
+          end
+
+          # Stage a constraint that can later be provisioned.
+          #
+          # @param type [String, Symbol] the type of the constraint.
+          # @param defaults [Hash{String, Symbol => Object}] the default parameters for the constraint.
+          # @param description [String] the description of the constraint.
+          # @param name [String, Symbol] the name of the constraint.
+          # @param validation_options [Hash{String, Symbol => Object}] the validation options for the constraint.
+          # @return [void]
+          def stage(type:, defaults: {}, description: nil, name: nil, validation_options: {})
+            name = (name || type).to_sym
+            @staged[name] = { type:, defaults:, description:, name:, validation_options: }
+          end
+
+          # Convert the provisioner to an array of provisioned constraints.
+          #
+          # @return [Array<ProvisionedConstraint>] the provisioned constraints.
+          def to_array
+            @provisioned.values
+          end
+          alias to_a to_array
+
+          private
+
+          # Automatically provision constraints just by calling them.
+          #
+          # @param method [Symbol] the method to call.
+          # @param arguments [Array<Object>] the arguments to pass to the method.
+          # @param keyword_arguments [Hash{Symbol => Object}] the keyword arguments to pass to the method.
+          # @return [ProvisionedConstraint] the provisioned constraint.
+          def method_missing(method, *arguments, **keyword_arguments, &)
+            return super unless respond_to_missing?(method)
+
+            options = arguments.first.is_a?(Hash) ? arguments.first : keyword_arguments
+            provision(method, **options)
+          end
+
+          # Provision the given constraint by name
+          #
+          # @param name [String, Symbol] the name of the constraint.
+          # @param options [Hash{String, Symbol => Object}] the parameters options for the constraint.
+          # @return [ProvisionedConstraint] the provisioned constraint.
+          def provision_constraint(name, options)
+            staged = @staged[name]
+            constraint_class = resolve_constraint_class!(staged[:type])
+            constraint_options = staged[:defaults].merge(options)
+                                                  .merge(name: staged[:name], description: staged[:description])
+            constraint = constraint_class.new(@base, **constraint_options)
+            @provisioned[constraint.name] = ProvisionedConstraint.new(constraint, **staged[:validation_options])
+          end
+
+          # Resolve the constraint class by name
+          #
+          # @param name [String, Symbol] the name of the constraint.
+          # @return [Class<Constraint::BaseConstraint>] the constraint class.
+          def resolve_constraint_class!(name)
+            constraint_classname =
+              "Domainic::Type::Constraint::#{name.to_s.split(/[_\-\s]+/).map(&:capitalize).join}Constraint"
+            unless Object.const_defined?(constraint_classname)
+              filepath = Dir.glob(File.expand_path("../#{name}_constraint.rb", __dir__)).first
+              raise ArgumentError, "Invalid constraint type `#{name}` for `#{@base}`" if filepath.nil?
+
+              require filepath
+            end
+
+            Object.const_get(constraint_classname)
+          end
+
+          # Check if the provisioner responds to the method.
+          #
+          # @param method [Symbol] the method to check.
+          # @param _include_private [Boolean]
+          # @return [Boolean] `true` if the provisioner responds to the method, otherwise `false`.
+          def respond_to_missing?(method, _include_private = false)
+            @staged.key?(method) || @provisioned.key?(method) || super
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/provisioning/validation_options.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/validation_options.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module Constraint
+      module Provisioning
+        # Validation options for a {ProvisionedConstraint}.
+        #
+        # @since 0.1.0
+        class ValidationOptions
+          # Initialize a new instance of ValidationOptions.
+          #
+          # @param options [Hash{String, Symbol => Object}]
+          # @return [ValidationOptions] the new instance of ValidationOptions.
+          def initialize(options = {})
+            @fail_fast = options.fetch(:fail_fast, false)
+          end
+
+          # Whether validation should continue on constraint validation failure.
+          #
+          # @return [Boolean] `true` if validation should stop on failure, otherwise `false`.
+          def fail_fast?
+            @fail_fast
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/base_type_spec.rb
+++ b/domainic-type/spec/domainic/type/base_type_spec.rb
@@ -4,5 +4,17 @@ require 'spec_helper'
 require 'domainic/type/base_type'
 
 RSpec.describe Domainic::Type::BaseType do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.constraints' do
+    subject(:constraints) { described_class.constraints }
+
+    it { is_expected.to be_an_instance_of(Domainic::Type::Constraint::Provisioning::ConstraintSet) }
+  end
+
+  describe '#constraints' do
+    subject(:constraints) { type.constraints }
+
+    let(:type) { described_class.new }
+
+    it { is_expected.to be_an_instance_of(Domainic::Type::Constraint::Provisioning::ConstraintSet) }
+  end
 end

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -58,6 +58,22 @@ RSpec.describe Domainic::Type::Constraint::BaseConstraint do
     it { is_expected.to eq(:self) }
   end
 
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { constraint.dup_with_base(new_base) }
+
+    let(:constraint) { described_class.new(type) }
+    let(:new_base) { instance_double(Domainic::Type::BaseType) }
+
+    it 'is expected to duplicate the constraint with the new base' do
+      expect(dup_with_base.instance_variable_get(:@base)).to eq(new_base)
+    end
+
+    it 'is expected to duplicate the constraint with the same parameters' do
+      duped = dup_with_base
+      expect(duped.parameters.instance_variable_get(:@base)).to eq(duped)
+    end
+  end
+
   describe '#negated' do
     subject(:negated) { constraint.negated }
 

--- a/domainic-type/spec/domainic/type/constraint/provisioning/constraint_set_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/provisioning/constraint_set_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/provisioning/constraint_set'
+
+RSpec.describe Domainic::Type::Constraint::Provisioning::ConstraintSet do
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { constraint_set.dup_with_base(new_base) }
+
+    let(:constraint_set) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+    let(:new_base) { instance_double(Domainic::Type::BaseType) }
+
+    it 'is expected to duplicate the constraint set with the new base' do
+      expect(dup_with_base.instance_variable_get(:@base)).to eq(new_base)
+    end
+
+    it 'is expected to duplicate the provisioners with the new base' do
+      provisioner = instance_double(Domainic::Type::Constraint::Provisioning::Provisioner, dup_with_base: true)
+      constraint_set.instance_variable_set(:@entries, { provisioner: })
+      dup_with_base
+
+      expect(provisioner).to have_received(:dup_with_base).with(new_base)
+    end
+  end
+
+  describe '#stage' do
+    subject(:stage) { constraint_set.stage(accessor_name, constraint_name, **options) }
+
+    let(:constraint_set) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+    let(:accessor_name) { :accessor }
+    let(:constraint_name) { :constraint }
+    let(:options) { { type: :test } }
+
+    it 'is expected to stage the provisioner' do
+      provisioner = instance_double(Domainic::Type::Constraint::Provisioning::Provisioner, stage: true)
+      constraint_set.instance_variable_set(:@entries, { accessor: provisioner })
+      stage
+
+      expect(provisioner).to have_received(:stage).with(name: constraint_name, **options)
+    end
+  end
+
+  describe '#to_array' do
+    subject(:to_array) { constraint_set.to_array }
+
+    let(:constraint_set) { described_class.new(instance_double(Domainic::Type::BaseType)) }
+
+    it { is_expected.to be_an(Array) }
+
+    it 'is expected to return an array of provisioned constraints' do
+      provisioner = instance_double(Domainic::Type::Constraint::Provisioning::Provisioner, to_array: true)
+      constraint_set.instance_variable_set(:@entries, { accessor: provisioner })
+      to_array
+
+      expect(provisioner).to have_received(:to_array)
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/provisioning/provisioned_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/provisioning/provisioned_constraint_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/base_constraint'
+require 'domainic/type/constraint/provisioning/provisioned_constraint'
+
+RSpec.describe Domainic::Type::Constraint::Provisioning::ProvisionedConstraint do
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { provisioned_constraint.dup_with_base(new_base) }
+
+    let(:provisioned_constraint) { described_class.new(constraint) }
+    let(:constraint) { instance_double(Domainic::Type::Constraint::BaseConstraint, dup_with_base: true) }
+    let(:new_base) { instance_double(Domainic::Type::BaseType) }
+
+    it 'is expected to duplicate the constraint with the new base' do
+      dup_with_base
+
+      expect(constraint).to have_received(:dup_with_base).with(new_base)
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/provisioning/provisioner_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/provisioning/provisioner_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/base_type'
+require 'domainic/type/constraint/base_constraint'
+require 'domainic/type/constraint/provisioning/provisioner'
+
+RSpec.describe Domainic::Type::Constraint::Provisioning::Provisioner do
+  describe '#dup_with_base' do
+    subject(:dup_with_base) { provisioner.dup_with_base(new_base) }
+
+    let(:provisioner) { described_class.new(instance_double(Domainic::Type::BaseType), :self) }
+    let(:new_base) { instance_double(Domainic::Type::BaseType) }
+
+    it 'is expected to duplicate the provisioner with the new base' do
+      expect(dup_with_base.instance_variable_get(:@base)).to eq(new_base)
+    end
+
+    it 'is expected to duplicate the provisioned constraints with the new base' do
+      provisioned = instance_double(Domainic::Type::Constraint::Provisioning::ProvisionedConstraint,
+                                    dup_with_base: true)
+      provisioner.instance_variable_set(:@provisioned, { constraint: provisioned })
+      dup_with_base
+
+      expect(provisioned).to have_received(:dup_with_base).with(new_base)
+    end
+  end
+
+  describe '#provisoion' do
+    subject(:provision) { provisioner.provision(constraint_name, **options) }
+
+    let(:provisioner) { described_class.new(instance_double(Domainic::Type::BaseType), :self) }
+    let(:options) { {} }
+
+    context 'when the constraint is already provisioned' do
+      before do
+        provisioner.instance_variable_set(:@provisioned, { provisioned.name => provisioned })
+      end
+
+      let(:constraint_name) { :test }
+      let(:provisioned) do
+        instance_double(Domainic::Type::Constraint::BaseConstraint, name: constraint_name, :negated= => true)
+      end
+
+      it { is_expected.to eq(provisioned) }
+
+      context 'when given options' do
+        let(:options) { { negated: true } }
+
+        it 'is expected to set the options on the provisioned constraint' do
+          provision
+
+          expect(provisioned).to have_received(:negated=).with(true)
+        end
+      end
+    end
+
+    context 'when the constraint has not been provisioned' do
+      context 'when the constraint type exists' do
+        before do
+          provisioner.stage(type: constraint_name)
+          allow(Dir).to receive(:glob)
+            .with(File.expand_path('../../../../../lib/domainic/type/constraint/test_constraint.rb', __dir__))
+            .and_return(['fake/constraint/test_constraint.rb'])
+          allow(provisioner).to receive(:require).with('fake/constraint/test_constraint.rb').and_return(true)
+          allow(Object).to receive(:const_get).with('Domainic::Type::Constraint::TestConstraint')
+                                              .and_return(mock_constraint_class)
+        end
+
+        let(:constraint_name) { :test }
+        let(:mock_constraint_class) { Class.new(Domainic::Type::Constraint::BaseConstraint) }
+
+        it { is_expected.to be_an_instance_of(Domainic::Type::Constraint::Provisioning::ProvisionedConstraint) }
+      end
+
+      context 'when the constraint type does not exist' do
+        before { provisioner.stage(type: constraint_name) }
+
+        let(:constraint_name) { :non_existent }
+
+        it {
+          expect { provision }.to(
+            raise_error(ArgumentError, a_string_including('Invalid constraint type `non_existent` for'))
+          )
+        }
+      end
+
+      context 'when the constraint has not been staged' do
+        let(:constraint_name) { :not_staged }
+
+        it {
+          expect { provision }.to(
+            raise_error(ArgumentError, a_string_including('does not constrain `not_staged` on `self`'))
+          )
+        }
+      end
+    end
+  end
+
+  describe '#stage' do
+    subject(:stage) { provisioner.stage(**options) }
+
+    let(:options) { { type: :test } }
+    let(:provisioner) { described_class.new(instance_double(Domainic::Type::BaseType), :self) }
+
+    it 'is expected to add the constraint to the staged constraints' do
+      stage
+
+      expect(provisioner.instance_variable_get(:@staged)).to have_key(:test)
+    end
+  end
+
+  describe '#to_array' do
+    subject(:to_array) { provisioner.to_array }
+
+    let(:provisioner) { described_class.new(instance_double(Domainic::Type::BaseType), :self) }
+
+    it { is_expected.to be_an(Array) }
+
+    it 'is expected to return the staged constraints' do
+      expect(to_array).to eq(provisioner.instance_variable_get(:@provisioned).values)
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/provisioning/validation_options_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/provisioning/validation_options_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/constraint/provisioning/validation_options'
+
+RSpec.describe Domainic::Type::Constraint::Provisioning::ValidationOptions do
+  describe '#fail_fast?' do
+    subject(:fail_fast?) { validation_options.fail_fast? }
+
+    context 'when fail fast is provided and is `true`' do
+      let(:validation_options) { described_class.new(fail_fast: true) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when fail fast is not provided' do
+      let(:validation_options) { described_class.new }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
This patch adds constraints to `Domainic::Type::BaseType`

Changelog:
  - added `Domainic::Type::Constraint::Provisioning::ConstraintSet`
  - added `Domainic::Type::Constraint::Provisioning::ProvisionedConstraint`
  - added `Domainic::Type::Constraint::Provisioning::Provisioner`
  - added `Domainic::Type::Constraint::Provisioning::ValidationOptions`
  - added `Domainic::Type::BaseType.constraints`
  - added `Domainic::Type::BaseType#constraints`

resolves #35