### PR TITLE
Add `Domainic::Type::DSL::ConstraintBuilder`

### DIFF
--- a/domainic-type/lib/domainic/type/base_type.rb
+++ b/domainic-type/lib/domainic/type/base_type.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'constraint/provisioning/constraint_set'
+require_relative 'dsl/constraint_builder'
 
 module Domainic
   module Type
@@ -16,11 +17,39 @@ module Domainic
       attr_reader :constraints
 
       class << self
+        # Provision a constraint for the type.
+        #
+        # @param accessor_name [String, Symbol] the name of the accessor.
+        # @yield [DSL::ConstraintBuilder] the block to define constraints.
+        # @return [void]
+        def constrain(accessor_name, &)
+          constraint_builder.define(accessor_name, &).build
+        end
+
         # The constraints for the type.
         #
         # @return [Constraint::Provisioning::ConstraintSet]
         def constraints
           @constraints ||= Constraint::Provisioning::ConstraintSet.new(self)
+        end
+
+        private
+
+        # The constraint builder for the type.
+        #
+        # @return [DSL::ConstraintBuilder]
+        def constraint_builder
+          @constraint_builder ||= DSL::ConstraintBuilder.new(self)
+        end
+
+        # Ensure constraints are properly inherited.
+        #
+        # @param subclass [Class<BaseType>] the subclass inheriting from BaseType.
+        # @return [void]
+        def inherited(subclass)
+          super
+          subclass.instance_variable_set(:@constraint_builder, constraint_builder.dup_with_base(subclass))
+          subclass.send(:constraint_builder).build
         end
       end
 

--- a/domainic-type/lib/domainic/type/base_type.rb
+++ b/domainic-type/lib/domainic/type/base_type.rb
@@ -20,7 +20,7 @@ module Domainic
         #
         # @return [Constraint::Provisioning::ConstraintSet]
         def constraints
-          @constraints = Constraint::Provisioning::ConstraintSet.new(self)
+          @constraints ||= Constraint::Provisioning::ConstraintSet.new(self)
         end
       end
 

--- a/domainic-type/lib/domainic/type/constraint/base_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/base_constraint.rb
@@ -10,10 +10,6 @@ module Domainic
       #
       # @abstract Subclass and override {#validate} to implement a new constraint.
       #
-      # @!attribute [r] description
-      #  The description of the constraint.
-      #  @return [String, nil]
-      #
       # @!attribute [r] name
       #  The name of the constraint.
       #  @return [Symbol]
@@ -31,7 +27,7 @@ module Domainic
         # @return [Array<Symbol>]
         VALID_ACCESSORS = %i[begin count end first keys last length self size values].freeze
 
-        attr_reader :description, :name, :parameters
+        attr_reader :name, :parameters
 
         class << self
           # Define a parameter for the constraint.
@@ -127,14 +123,12 @@ module Domainic
         # Initialize a new instance of BaseConstraint.
         #
         # @param base [BaseType] The type the constraint is belongs to.
-        # @param description [String, nil] The {#description} of the constraint.
         # @param name [String, Symbol] The {#name} of the constraint.
         # @param parameters [Hash{Symbol => Object}] The parameters of the constraint.
         #
         # @return [BaseConstraint] the new instance of BaseConstraint.
-        def initialize(base, description: nil, name: '', **parameters)
+        def initialize(base, name: '', **parameters)
           @base = base
-          @description = description
           @name = name.empty? ? parse_name(self.class.name) : name.to_sym
           @parameters = self.class.parameters.dup_with_base(self)
 

--- a/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
@@ -33,6 +33,7 @@ module Domainic
                 :@provisioned,
                 @provisioned.transform_values { |provisioned| provisioned.dup_with_base(new_base) }
               )
+              duped.send(:provision_intrinsic_constraints)
             end
           end
 
@@ -59,15 +60,31 @@ module Domainic
 
           # Stage a constraint that can later be provisioned.
           #
-          # @param type [String, Symbol] the type of the constraint.
-          # @param defaults [Hash{String, Symbol => Object}] the default parameters for the constraint.
-          # @param description [String] the description of the constraint.
-          # @param name [String, Symbol] the name of the constraint.
-          # @param validation_options [Hash{String, Symbol => Object}] the validation options for the constraint.
+          # @param options [Hash{Symbol => Object}] the options for the constraint.
+          # @option options [Hash{Symbol => Object}] :defaults ({ accessor: @accessor_name }) the default options for
+          #  the constraint.
+          # @option options [String, Symbol] :description the description of the constraint. If this is provided, it
+          #  will override the `:desc` option.
+          # @option options [String, Symbol] :desc the description of the constraint. If `:description` is not provided,
+          #  this will be used instead.
+          # @option options [Boolean] :intrinsic (false) whether the constraint is intrinsic. Intrinsic constraints
+          #  are not automatically provisioned when the type is instantiated.
+          # @option options [String, Symbol] :name the name of the constraint. If this is not provided, it will default
+          #  to the `:type` option.
+          # @option options [String, Symbol] :type the type of the constraint.
+          # @option options [Hash{Symbol => Object}] :validation_options ({}) the options for the validation.
+          #
           # @return [void]
-          def stage(type:, defaults: {}, description: nil, name: nil, validation_options: {})
-            name = (name || type).to_sym
-            @staged[name] = { type:, defaults:, description:, name:, validation_options: }
+          def stage(**options)
+            name = (options[:name] || options.fetch(:type)).to_sym
+            @staged[name] = {
+              defaults: { accessor: @accessor_name }.merge(options.fetch(:defaults, {})),
+              description: options[:description] || options[:desc],
+              intrinsic: options.fetch(:intrinsic, false),
+              name:,
+              type: options.fetch(:type),
+              validation_options: options.fetch(:validation_options, {})
+            }
           end
 
           # Convert the provisioner to an array of provisioned constraints.
@@ -105,6 +122,15 @@ module Domainic
                                                   .merge(name: staged[:name], description: staged[:description])
             constraint = constraint_class.new(@base, **constraint_options)
             @provisioned[constraint.name] = ProvisionedConstraint.new(constraint, **staged[:validation_options])
+          end
+
+          # Provision intrinsic constraints.
+          #
+          # @return [void]
+          def provision_intrinsic_constraints
+            return if @base.is_a?(Class)
+
+            @staged.select { |_, staged| staged[:intrinsics] }.each_key { |name| provision(name) }
           end
 
           # Resolve the constraint class by name

--- a/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
@@ -63,10 +63,6 @@ module Domainic
           # @param options [Hash{Symbol => Object}] the options for the constraint.
           # @option options [Hash{Symbol => Object}] :defaults ({ accessor: @accessor_name }) the default options for
           #  the constraint.
-          # @option options [String, Symbol] :description the description of the constraint. If this is provided, it
-          #  will override the `:desc` option.
-          # @option options [String, Symbol] :desc the description of the constraint. If `:description` is not provided,
-          #  this will be used instead.
           # @option options [Boolean] :intrinsic (false) whether the constraint is intrinsic. Intrinsic constraints
           #  are not automatically provisioned when the type is instantiated.
           # @option options [String, Symbol] :name the name of the constraint. If this is not provided, it will default
@@ -79,7 +75,6 @@ module Domainic
             name = (options[:name] || options.fetch(:type)).to_sym
             @staged[name] = {
               defaults: { accessor: @accessor_name }.merge(options.fetch(:defaults, {})),
-              description: options[:description] || options[:desc],
               intrinsic: options.fetch(:intrinsic, false),
               name:,
               type: options.fetch(:type),
@@ -118,8 +113,7 @@ module Domainic
           def provision_constraint(name, options)
             staged = @staged[name]
             constraint_class = resolve_constraint_class!(staged[:type])
-            constraint_options = staged[:defaults].merge(options)
-                                                  .merge(name: staged[:name], description: staged[:description])
+            constraint_options = staged[:defaults].merge(options).merge(name: staged[:name])
             constraint = constraint_class.new(@base, **constraint_options)
             @provisioned[constraint.name] = ProvisionedConstraint.new(constraint, **staged[:validation_options])
           end

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module DSL
+      # A DSL for defining {Constraint::BaseConstraint constraints} on a {BaseType type}.
+      #
+      # @since 0.1.0
+      class ConstraintBuilder
+        # Defaults for a constraint.
+        #
+        # @return [Hash{Symbol => Hash{Symbol => Object}}]
+        CONSTRAINT_DEFAULTS = { defaults: {}, validation_options: {} }.freeze
+
+        # Initialize a new instance of ConstraintBuilder.
+        #
+        # @param base [Class<BaseType>] the {BaseType type} to define constraints for.
+        # @return [ConstraintBuilder] the new instance of ConstraintBuilder.
+        def initialize(base)
+          @base = base
+          @data = {}
+        end
+
+        # Provision the constraints onto the {BaseType type}.
+        #
+        # @return [void]
+        def build
+          @data.each_pair do |accessor_name, constraints|
+            constraints.each_pair do |constraint_name, constraint_data|
+              @base.constraints.stage(accessor_name, constraint_name, **constraint_data)
+            end
+          end
+        end
+
+        # Define a constraint.
+        #
+        # @param constraint_type [String, Symbol] the type of the constraint.
+        # @param name [String, Symbol] the name of the constraint.
+        # @param fail_fast [Boolean] whether to fail fast on validation.
+        # @raise [ArgumentError] if no accessor is currently being defined.
+        # @return [self] the ConstraintBuilder.
+        def constraint(constraint_type, name: nil, fail_fast: false)
+          ensure_current_accessor!
+
+          name = (name || constraint_type).to_sym
+          @current_accessor[name] =
+            CONSTRAINT_DEFAULTS.transform_values(&:dup).merge(name:, type: constraint_type.to_sym)
+          @current_accessor[name][:validation_options][:fail_fast] = fail_fast
+          self
+        end
+
+        # Define an accessor.
+        #
+        # @param accessor_name [String, Symbol] the name of the accessor.
+        # @yield [self] the block to define constraints.
+        # @return [self] the ConstraintBuilder.
+        def define(accessor_name, &)
+          @current_accessor_name = accessor_name.to_sym
+          @current_accessor = @data[@current_accessor_name] = {}
+          instance_exec(&) if block_given?
+          self
+        end
+
+        # Duplicate the constraint builder with a new base.
+        #
+        # @param new_base [Class<BaseType>] the new base for the constraint builder.
+        # @return [ConstraintBuilder] the duplicated constraint builder.
+        def dup_with_base(new_base)
+          dup.tap { |duped| duped.instance_variable_set(:@base, new_base) }
+        end
+
+        # Define an intrinsic constraint.
+        #
+        # @param constraint_type [String, Symbol] the type of the constraint.
+        # @param name [String, Symbol] the name of the constraint.
+        # @param fail_fast [Boolean] whether to fail fast on validation.
+        # @param options [Hash{String, Symbol => Object}] the options for the constraint.
+        #  @see Constraint::Provisioning::Provisioner#stage
+        # @raise [ArgumentError] if no accessor is currently being defined.
+        # @return [self] the ConstraintBuilder.
+        def intrinsic_constraint(constraint_type, name: nil, fail_fast: false, **options)
+          ensure_current_accessor!
+
+          name = (name || constraint_type).to_sym
+          @current_accessor[name] =
+            CONSTRAINT_DEFAULTS.transform_values(&:dup).merge(name:, type: constraint_type.to_sym, intrinsic: true)
+          @current_accessor[name][:defaults].merge!(options)
+          @current_accessor[name][:validation_options][:fail_fast] = fail_fast
+          self
+        end
+
+        private
+
+        # Ensure that an accessor is defined.
+        #
+        # @raise [ArgumentError] if no accessor is currently being defined.
+        # @return [void]
+        def ensure_current_accessor!
+          return if @current_accessor
+
+          raise ArgumentError, 'No accessor currently being defined.'
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'constraint_builder/method_injector'
+require_relative 'constraint_builder/signature_builder'
+
 module Domainic
   module Type
     module DSL
@@ -21,15 +24,25 @@ module Domainic
           @data = {}
         end
 
-        # Provision the constraints onto the {BaseType type}.
+        # Stage the constraints and inject methods onto the {BaseType type}.
         #
         # @return [void]
         def build
-          @data.each_pair do |accessor_name, constraints|
-            constraints.each_pair do |constraint_name, constraint_data|
-              @base.constraints.stage(accessor_name, constraint_name, **constraint_data)
-            end
-          end
+          stage_constraints
+          MethodInjector.new(@base, signature_builder.build).inject!
+        end
+
+        # Bind a method to an accessor.
+        #
+        # @param method_name [String, Symbol] the name of the method to bind.
+        # @yield [SignatureBuilder] the block to define the method signature.
+        # @raise [ArgumentError] if no accessor is currently being defined.
+        # @return [self] the ConstraintBuilder.
+        def bind_method(method_name, &)
+          ensure_current_accessor!
+
+          signature_builder.define(@current_accessor_name, method_name, &)
+          self
         end
 
         # Define a constraint.
@@ -99,6 +112,21 @@ module Domainic
           return if @current_accessor
 
           raise ArgumentError, 'No accessor currently being defined.'
+        end
+
+        # Returns the signature builder instance, initializing it if it doesn't already exist.
+        #
+        # @return [SignatureBuilder] the signature builder instance
+        def signature_builder
+          @signature_builder ||= SignatureBuilder.new
+        end
+
+        def stage_constraints
+          @data.each_pair do |accessor_name, constraints|
+            constraints.each_pair do |constraint_name, constraint_data|
+              @base.constraints.stage(accessor_name, constraint_name, **constraint_data)
+            end
+          end
         end
       end
     end

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder/method_injector.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder/method_injector.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module DSL
+      class ConstraintBuilder
+        # Inject methods onto a {BaseType type} class.
+        #
+        # @since 0.1.0
+        class MethodInjector
+          # Initialize a new instance of MethodInjector.
+          #
+          # @param base [Class<BaseType>] the {BaseType type} to inject methods onto.
+          # @param signatures [Hash{Symbol => Hash{Symbol => Hash{Symbol => Object}}}] the signatures to inject.
+          # @return [MethodInjector] the new instance of MethodInjector.
+          def initialize(base, signatures)
+            @base = base
+            @signatures = signatures
+          end
+
+          # Duplicate the instance with a new base.
+          #
+          # @param new_base [Class<BaseType>] the new base to inject methods onto.
+          # @return [MethodInjector] the new instance of MethodInjector.
+          def dup_with_base(new_base)
+            dup.tap { |duped| duped.instance_variable_set(:@base, new_base) }
+          end
+
+          # Inject the methods onto the {BaseType type}.
+          #
+          # @return [void]
+          def inject!
+            @signatures.each_pair do |accessor_name, signatures|
+              signatures.each_pair do |constraint_name, signature_data|
+                inject_singleton_method!(signature_data)
+                inject_instance_method!(accessor_name, constraint_name, signature_data)
+                inject_aliases!(signature_data[:name], signature_data[:aliases])
+              end
+            end
+          end
+
+          private
+
+          # Inject aliases onto the {BaseType type}.
+          #
+          # @param primary_signature [Symbol] the primary signature to alias.
+          # @param aliases [Array<Symbol>] the aliases to inject.
+          # @return [void]
+          def inject_aliases!(primary_signature, aliases)
+            aliases.each do |alias_name|
+              @base.singleton_class.alias_method(alias_name, primary_signature) unless @base.respond_to?(alias_name)
+              @base.alias_method(alias_name, primary_signature) unless @base.instance_methods.include?(alias_name)
+            end
+          end
+
+          # Inject an instance method onto the {BaseType type}.
+          #
+          # @param accessor_name [Symbol] the accessor name.
+          # @param constraint_name [Symbol] the constraint name.
+          # @param signature_data [Hash{Symbol => Object}] the signature data.
+          # @return [void]
+          def inject_instance_method!(accessor_name, constraint_name, signature_data)
+            @base.define_method(signature_data[:name]) do |*arguments, **keyword_arguments|
+              options = signature_data[:definition].call(*arguments, **keyword_arguments)
+              options = signature_data.fetch(:defaults, {}).merge(options)
+              constraints.public_send(accessor_name).public_send(constraint_name, **options)
+            end
+          end
+
+          # Inject a singleton method onto the {BaseType type}.
+          #
+          # @param signature_data [Hash{Symbol => Object}] the signature data.
+          # @return [void]
+          def inject_singleton_method!(signature_data)
+            @base.define_singleton_method(signature_data[:name]) do |*arguments, **keyword_arguments|
+              new.public_send(signature_data[:name], *arguments, **keyword_arguments)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder/signature_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder/signature_builder.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module DSL
+      class ConstraintBuilder
+        # A DSL for defining method signatures on a {BaseType type}.
+        #
+        # @since 0.1.0
+        class SignatureBuilder
+          # Initialize a new instance of SignatureBuilder.
+          #
+          # @return [SignatureBuilder] the new instance of SignatureBuilder.
+          def initialize
+            @data = {}
+          end
+
+          # Define aliases for the current signature.
+          #
+          # @param alias_names [Array<String, Symbol>] the aliases to define.
+          # @raise [ArgumentError] if no signature is currently being defined.
+          # @return [self] the SignatureBuilder.
+          def aliases(alias_names)
+            ensure_current_signature!
+
+            @current_signature[:aliases] ||= [@current_signature_name]
+            @current_signature[:aliases] = @current_signature[:aliases].concat(alias_names).map(&:to_sym).uniq
+            self
+          end
+
+          # Build the signatures.
+          #
+          # @return [Hash{Symbol => Hash{Symbol => Hash{Symbol => Object}}}] the signatures.
+          def build
+            @data.each_with_object({}) do |(accessor_name, signatures), result|
+              result[accessor_name] ||= {}
+              signatures.each_pair do |signature_name, signature_data|
+                result[accessor_name][signature_data[:constraint]] = { name: signature_name }.merge(
+                  signature_data.slice(:aliases, :defaults, :definition, :description)
+                )
+              end
+            end
+          end
+
+          # Associate a constraint with the current signature.
+          #
+          # @param constraint_name [String, Symbol] the name of the constraint.
+          # @raise [ArgumentError] if no signature is currently being defined.
+          # @return [self] the SignatureBuilder.
+          def concerning(constraint_name)
+            ensure_current_signature!
+
+            @current_signature[:constraint] = constraint_name.to_sym
+            self
+          end
+
+          # Define the method that returns the configuration for the constraint.
+          #
+          # @param proc_or_symbol [Proc, Symbol] the method that returns the configuration.
+          # @param block [Proc] the method that returns the configuration.
+          # @raise [ArgumentError] if no signature is currently being defined.
+          # @return [self] the SignatureBuilder.
+          def configure(proc_or_symbol = nil, &block)
+            ensure_current_signature!
+
+            @current_signature[:definition] = (proc_or_symbol || block)
+            self
+          end
+
+          # Define a signature.
+          #
+          # @param accessor_name [String, Symbol] the name of the accessor.
+          # @param method_name [String, Symbol] the name of the method.
+          # @yield [self] the block to define the signature.
+          # @return [self] the SignatureBuilder.
+          def define(accessor_name, method_name, &)
+            @current_signature_name = method_name.to_sym
+            @data[accessor_name.to_sym] = {}
+            @current_signature = @data[accessor_name.to_sym][@current_signature_name] ||= {}
+            instance_exec(&) if block_given?
+            self
+          end
+
+          # Define a default parameter value for the current signature.
+          #
+          # @param parameter_name [String, Symbol] the name of the parameter.
+          # @param default_value [Object] the default value for the parameter.
+          # @raise [ArgumentError] if no signature is currently being defined.
+          # @return [self] the SignatureBuilder.
+          def default_for_parameter(parameter_name, default_value)
+            ensure_current_signature!
+
+            @current_signature[:defaults] ||= {}
+            @current_signature[:defaults][parameter_name.to_sym] = default_value
+            self
+          end
+
+          # Define a description for the current signature.
+          #
+          # @param description_string [String] the description for the signature.
+          # @raise [ArgumentError] if no signature is currently being defined.
+          # @return [self] the SignatureBuilder.
+          def description(description_string)
+            ensure_current_signature!
+
+            @current_signature[:description] = description_string
+            self
+          end
+          alias desc description
+
+          private
+
+          # Ensure that a signature is currently being defined.
+          #
+          # @raise [ArgumentError] if no signature is currently being defined.
+          # @return [void]
+          def ensure_current_signature!
+            return if @current_signature
+
+            raise ArgumentError, 'No signature currently being defined.'
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/base_constraint_spec.rb
@@ -121,10 +121,10 @@ RSpec.describe Domainic::Type::Constraint::BaseConstraint do
       expect(new_instance.parameters).to be_an_instance_of(Domainic::Type::Constraint::Specification::ParameterSet)
     end
 
-    context 'when name and description is provided' do
-      let(:options) { { name: 'test', description: 'A test constraint' } }
+    context 'when name is provided' do
+      let(:options) { { name: 'test' } }
 
-      it { is_expected.to have_attributes(name: options[:name].to_sym, description: options[:description]) }
+      it { is_expected.to have_attributes(name: options[:name].to_sym) }
     end
 
     context 'when name is not provided' do


### PR DESCRIPTION
This adds `Domainic::Type::DSL::ConstraintBuilder` which provides a DSL for defining constraints on types.

Changelog:
  - added `Domainic::Type::DSL::ConstraintBuilder`
  - added `Domainic::Type::DSL::ConstraintBuilder::MethodInjector`
  - added `Domainic::Type::DSL::ConstraintBuilder::SignatureBuilder`
  - added `Domainic::Type::BaseType.constrain`
  - fixed `Domainic::Type::BaseType.constraints` are now properly memoized
  - changed `Domainic::Type::Constraint::Provisioning::Provisioner` now accepts the `intrinsic` option
  - removed `Domainic::Type::Constraint::BaseConstraint#description`

resolves #70 
resolves #71