### PR TITLE
Add types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,11 @@ Naming/FileName:
   Exclude:
     - '**/domainic-*'
 
+Metrics/BlockLength:
+  AllowedMethods:
+    - constrain
+    - parameter
+
 RSpec/NestedGroups:
   AllowedGroups:
     - describe

--- a/domainic-type/lib/domainic/type/anything_type.rb
+++ b/domainic-type/lib/domainic/type/anything_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # The `AnythingType` is a type that can be anything excluding the given types.
+    #
+    # @since 0.1.0
+    class AnythingType < BaseType
+      constrain :self do
+        constraint :type, fail_fast: true
+
+        bind_method :excluding do
+          desc 'Constrains the given types from being considered valid'
+          concerning :type
+          aliases :but, :except
+          default_for_parameter :negated, true
+
+          configure { |*types| { expected: (constraints.self&.type&.expected || []).concat(types).uniq } }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/array_type.rb
+++ b/domainic-type/lib/domainic/type/array_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'ordered_enumerable_type'
+
+module Domainic
+  module Type
+    # The `ArrayType` is a type that represents an array.
+    #
+    # @since 0.1.0
+    class ArrayType < OrderedEnumerableType
+      constrain :self do
+        intrinsic_constraint :type, expected: Array, fail_fast: true
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/base_type.rb
+++ b/domainic-type/lib/domainic/type/base_type.rb
@@ -55,9 +55,30 @@ module Domainic
 
       # Initialize a new instance of BaseType.
       #
+      # @param options [Hash{String, Symbol => Object}] the options to initialize the type with.
       # @return [BaseType] the new instance of BaseType.
-      def initialize
+      def initialize(**options)
         @constraints = self.class.constraints.dup_with_base(self)
+        options.transform_keys(&:to_sym).each_pair do |method, arguments|
+          if arguments.is_a?(Hash)
+            public_send(method, **arguments)
+          else
+            public_send(method, *arguments)
+          end
+        end
+      end
+
+      # Validate the subject against the constraints.
+      #
+      # @param subject [Object] the subject to validate.
+      # @return [Boolean] true if the subject satisfies the constraints, false otherwise.
+      def validate(subject)
+        constraints.to_array.all? do |constraint|
+          valid = constraint.validate(subject)
+          break false if !valid && constraint.validation_options.fail_fast?
+
+          valid
+        end
       end
     end
   end

--- a/domainic-type/lib/domainic/type/boolean_type.rb
+++ b/domainic-type/lib/domainic/type/boolean_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # The `BooleanType` class represents the boolean type in Domainic.
+    #
+    # @since 0.1.0
+    class BooleanType < BaseType
+      constrain :self do
+        intrinsic_constraint :type, expected: [TrueClass, FalseClass], expectation_qualifier: :any
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
+++ b/domainic-type/lib/domainic/type/constraint/provisioning/provisioner.rb
@@ -124,7 +124,7 @@ module Domainic
           def provision_intrinsic_constraints
             return if @base.is_a?(Class)
 
-            @staged.select { |_, staged| staged[:intrinsics] }.each_key { |name| provision(name) }
+            @staged.select { |_, staged| staged[:intrinsic] }.each_key { |name| provision(name) }
           end
 
           # Resolve the constraint class by name

--- a/domainic-type/lib/domainic/type/constraint/relational_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/relational_constraint.rb
@@ -96,10 +96,9 @@ module Domainic
 
         # Initialize a new instance of `RelationalConstraint`.
         #
-        # @param base [Class<TypeBase>, TypeBaseType] The base type class.
         # @raise [NotImplementedError] if the subclass does not define an expectation.
         # @return [RelationalConstraint] The new constraint instance.
-        def initialize(base)
+        def initialize(...)
           super
           @expectation = self.class.instance_variable_get(:@expectation)
           raise NotImplementedError, "#{self.class} must define an expectation" if @expectation.nil?

--- a/domainic-type/lib/domainic/type/constraint/responds_to_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/responds_to_constraint.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'relational_constraint'
+
+module Domainic
+  module Type
+    module Constraint
+      # The `RespondsToConstraint` checks if the subject responds to a given method.
+      #
+      # @since 0.1.0
+      class RespondsToConstraint < RelationalConstraint
+        expectation :respond_to?
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/type_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/type_constraint.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'relational_constraint'
+require_relative 'specification/with_access_qualification'
 
 module Domainic
   module Type
@@ -13,6 +14,8 @@ module Domainic
       #
       # @since 0.1.0
       class TypeConstraint < RelationalConstraint
+        include Specification::WithAccessQualification
+
         # Defines the expectation method `:is_type?` for the constraint.
         expectation :is_type?
 

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder/method_injector.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder/method_injector.rb
@@ -31,10 +31,10 @@ module Domainic
           # @return [void]
           def inject!
             @signatures.each_pair do |accessor_name, signatures|
-              signatures.each_pair do |constraint_name, signature_data|
-                inject_singleton_method!(signature_data)
-                inject_instance_method!(accessor_name, constraint_name, signature_data)
-                inject_aliases!(signature_data[:name], signature_data[:aliases])
+              signatures.each_pair do |primary_signature, signature_data|
+                inject_singleton_method!(primary_signature)
+                inject_instance_method!(accessor_name, signature_data[:constraint], primary_signature, signature_data)
+                inject_aliases!(primary_signature, signature_data.fetch(:aliases, []))
               end
             end
           end
@@ -57,11 +57,14 @@ module Domainic
           #
           # @param accessor_name [Symbol] the accessor name.
           # @param constraint_name [Symbol] the constraint name.
+          # @param signature_name [Symbol] the signature name.
           # @param signature_data [Hash{Symbol => Object}] the signature data.
           # @return [void]
-          def inject_instance_method!(accessor_name, constraint_name, signature_data)
-            @base.define_method(signature_data[:name]) do |*arguments, **keyword_arguments|
-              options = signature_data[:definition].call(*arguments, **keyword_arguments)
+          def inject_instance_method!(accessor_name, constraint_name, signature_name, signature_data)
+            return if @base.instance_methods.include?(signature_name)
+
+            @base.define_method(signature_name) do |*arguments, **keyword_arguments|
+              options = instance_exec(*arguments, **keyword_arguments, &signature_data[:definition])
               options = signature_data.fetch(:defaults, {}).merge(options)
               constraints.public_send(accessor_name).public_send(constraint_name, **options)
               self
@@ -70,11 +73,13 @@ module Domainic
 
           # Inject a singleton method onto the {BaseType type}.
           #
-          # @param signature_data [Hash{Symbol => Object}] the signature data.
+          # @param signature_name [Symbol] the signature name.
           # @return [void]
-          def inject_singleton_method!(signature_data)
-            @base.define_singleton_method(signature_data[:name]) do |*arguments, **keyword_arguments|
-              new.public_send(signature_data[:name], *arguments, **keyword_arguments)
+          def inject_singleton_method!(signature_name)
+            return if @base.respond_to?(signature_name)
+
+            @base.define_singleton_method(signature_name) do |*arguments, **keyword_arguments|
+              new.public_send(signature_name, *arguments, **keyword_arguments)
             end
           end
         end

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder/method_injector.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder/method_injector.rb
@@ -64,6 +64,7 @@ module Domainic
               options = signature_data[:definition].call(*arguments, **keyword_arguments)
               options = signature_data.fetch(:defaults, {}).merge(options)
               constraints.public_send(accessor_name).public_send(constraint_name, **options)
+              self
             end
           end
 

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder/signature_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder/signature_builder.rb
@@ -32,14 +32,7 @@ module Domainic
           #
           # @return [Hash{Symbol => Hash{Symbol => Hash{Symbol => Object}}}] the signatures.
           def build
-            @data.each_with_object({}) do |(accessor_name, signatures), result|
-              result[accessor_name] ||= {}
-              signatures.each_pair do |signature_name, signature_data|
-                result[accessor_name][signature_data[:constraint]] = { name: signature_name }.merge(
-                  signature_data.slice(:aliases, :defaults, :definition, :description)
-                )
-              end
-            end
+            @data
           end
 
           # Associate a constraint with the current signature.
@@ -75,7 +68,7 @@ module Domainic
           # @return [self] the SignatureBuilder.
           def define(accessor_name, method_name, &)
             @current_signature_name = method_name.to_sym
-            @data[accessor_name.to_sym] = {}
+            @data[accessor_name.to_sym] ||= {}
             @current_signature = @data[accessor_name.to_sym][@current_signature_name] ||= {}
             instance_exec(&) if block_given?
             self

--- a/domainic-type/lib/domainic/type/dsl/constraint_builder/signature_builder.rb
+++ b/domainic-type/lib/domainic/type/dsl/constraint_builder/signature_builder.rb
@@ -20,7 +20,7 @@ module Domainic
           # @param alias_names [Array<String, Symbol>] the aliases to define.
           # @raise [ArgumentError] if no signature is currently being defined.
           # @return [self] the SignatureBuilder.
-          def aliases(alias_names)
+          def aliases(*alias_names)
             ensure_current_signature!
 
             @current_signature[:aliases] ||= [@current_signature_name]

--- a/domainic-type/lib/domainic/type/duck_type.rb
+++ b/domainic-type/lib/domainic/type/duck_type.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # since 0.1.0
+    class DuckType < BaseType
+      constrain :self do
+        constraint :responds_to, name: :inclusion
+        constraint :responds_to, name: :exclusion
+
+        bind_method :responding_to do
+          desc 'Constrains the subject to respond to the given methods'
+          concerning :inclusion
+          aliases :implementing
+
+          configure { |*methods| { expected: (constraints.self&.inclusion&.expected || []).concat(methods).uniq } }
+        end
+
+        bind_method :not_responding_to do
+          desc 'Constrains the subject to not respond to the given methods'
+          concerning :exclusion
+          default_for_parameter :expectation_qualifier, :none
+          aliases :not_implementing
+
+          configure { |*methods| { excluded: (constraints.self&.exclusion&.excluded || []).concat(methods).uniq } }
+        end
+      end
+
+      def initialize(*methods, **options)
+        super(responding_to: methods, **options)
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/enum_type.rb
+++ b/domainic-type/lib/domainic/type/enum_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class EnumType < BaseType
+      constrain :self do
+        constraint :equality
+
+        bind_method :having_values do
+          desc 'Constrains the value to be one of the given values.'
+          concerning :equality
+          default_for_parameter :expectation_qualifier, :any
+          aliases :with_values
+
+          configure { |*values| { expected: (constraints.self&.equality&.expected || []).concat(values).uniq } }
+        end
+      end
+
+      def initialize(*values, **options)
+        super(expected: values, **options)
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/enumerable_type.rb
+++ b/domainic-type/lib/domainic/type/enumerable_type.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # The `EnumerableType` is a base type for all enumerable types.
+    #
+    # @!method initialize(**options)
+    #  Initialize a new instance of the EnumerableType.
+    #  @param options [Hash] the options to configure the EnumerableType
+    #  @option options [Boolean] :being_duplicative whether the Enumerable should contain duplicate entries.
+    #  @option options [Boolean] :being_empty whether the Enumerable should be empty.
+    #  @option options [Boolean] :being_populated whether the Enumerable should be populated.
+    #  @option options [Boolean] :being_ordered whether the Enumerable should be ordered.
+    #  @option options [Boolean] :being_unique whether the Enumerable should contain unique entries.
+    #  @option options [Array<Object>] :containing the entries that the Enumerable should contain.
+    #  @option options [Array<Object>] :excluding the entries that the Enumerable should not contain.
+    #  @option options [Class, BaseType] :of the type of entries allowed in the Enumerable.
+    #  @option options [Integer] :having_exact_size the size of the Enumerable.
+    #  @option options [Integer] :having_maximum_size the maximum size of the Enumerable.
+    #  @option options [Integer] :having_minimum_size the minimum size of the Enumerable.
+    #  @option options [Hash{Symbol => Integer}] :having_size_between the minimum and maximum size of the Enumerable.
+    #  @return [EnumerableType] the new EnumerableType instance
+    #
+    # @since 0.1.0
+    class EnumerableType < BaseType # rubocop:disable Metrics/ClassLength
+      # @!method being_duplicative
+      #  Constrains the Enumerable to contain duplicate entries
+      #  @!scope class
+      #  @return [void]
+      #
+      # @!method being_duplicative
+      #  Constrains the Enumerable to contain duplicate entries
+      #  @return [void]
+      #
+      # @!method being_empty
+      #  Constrains the Enumerable to be empty
+      #  @!scope class
+      #  @return [void]
+      #
+      # @!method being_empty
+      #  Constrains the Enumerable to be empty
+      #  @return [void]
+      #
+      # @!method being_populated
+      #  Constrains the Enumerable to be populated
+      #  @!scope class
+      #  @return [void]
+      #
+      # @!method being_populated
+      #  Constrains the Enumerable to be populated
+      #  @return [void]
+      #
+      # @!method being_ordered
+      #  Constrains the Enumerable to be ordered
+      #  @!scope class
+      #  @return [void]
+      #
+      # @!method being_ordered
+      #  Constrains the Enumerable to be ordered
+      #  @return [void]
+      #
+      # @!method being_unique
+      #  Constrains the Enumerable to contain unique entries
+      #  @!scope class
+      #  @return [void]
+      #
+      # @!method being_unique
+      #  Constrains the Enumerable to contain unique entries
+      #  @return [void]
+      #
+      # @!method being_unordered
+      #  Constrains the Enumerable to be unordered
+      #  @!scope class
+      #  @return [void]
+      #
+      # @!method being_unordered
+      #  Constrains the Enumerable to be unordered
+      #  @return [void]
+      #
+      # @!method containing(*entries)
+      #  Constrains the Enumerable to contain certain entries
+      #  @!scope class
+      #  @param entries [Array] the entries that the Enumerable should contain
+      #  @return [void]
+      #
+      # @!method containing(*entries)
+      #  Constrains the Enumerable to contain certain entries
+      #  @param entries [Array] the entries that the Enumerable should contain
+      #  @return [void]
+      #
+      # @!method excluding(*entries)
+      #  Constrains the Enumerable not to contain certain entries
+      #  @!scope class
+      #  @param entries [Array] the entries that the Enumerable should not contain
+      #  @return [void]
+      #
+      # @!method excluding(*entries)
+      #  Constrains the Enumerable not to contain certain entries
+      #  @param entries [Array] the entries that the Enumerable should not contain
+      #  @return [void]
+      #
+      # @!method of(type)
+      #  Constrains the type of entries allowed in the Enumerable
+      #  @!scope class
+      #  @param type [Class] the type of entries allowed in the Enumerable
+      #  @return [void]
+      #
+      # @!method of(type)
+      #  Constrains the type of entries allowed in the Enumerable
+      #  @param type [Class] the type of entries allowed in the Enumerable
+      #  @return [void]
+      constrain :self do
+        constraint :inclusion, name: :exclusion
+        constraint :inclusion
+        constraint :ordering
+        constraint :population
+        constraint :type, name: :entry_type
+        constraint :uniqueness
+
+        bind_method :being_duplicative do
+          desc 'Constrains the Enumerable to contain duplicate entries'
+          concerning :uniqueness
+          aliases :being_non_unique, :duplicative, :having_duplicate_entries, :having_duplicate_elements,
+                  :having_duplicate_members, :with_duplicate_entries, :with_duplicate_elements,
+                  :with_duplicate_members
+
+          configure { |boolean = true| { condition: :duplicative, negated: !boolean } }
+        end
+
+        bind_method :being_empty do
+          desc 'Constrains the Enumerable to be empty'
+          concerning :population
+          aliases :empty
+
+          configure { |boolean = true| { condition: :empty, negated: !boolean } }
+        end
+
+        bind_method :being_populated do
+          desc 'Constrains the Enumerable to be populated'
+          concerning :population
+          aliases :populated
+
+          configure { |boolean = true| { condition: :populated, negated: !boolean } }
+        end
+
+        bind_method :being_ordered do
+          desc 'Constrains the Enumerable to be ordered'
+          concerning :ordering
+          aliases :having_ordered_entries, :having_ordered_elements, :having_ordered_members, :with_ordered_entries,
+                  :with_ordered_elements, :with_ordered_members
+
+          configure { |boolean = true| { condition: :ordered, negated: !boolean } }
+        end
+
+        bind_method :being_unique do
+          desc 'Constrains the Enumerable to contain unique entries'
+          concerning :uniqueness
+          aliases :being_distinct, :having_unique_entries, :having_unique_elements, :having_unique_members,
+                  :with_unique_entries, :with_unique_elements, :with_unique_members, :unique
+
+          configure { |boolean = true| { condition: :unique, negated: !boolean } }
+        end
+
+        bind_method :being_unordered do
+          desc 'Constrains the Enumerable to be unordered'
+          concerning :ordering
+          aliases :having_unordered_entries, :having_unordered_elements, :having_unordered_members,
+                  :with_unordered_entries, :with_unordered_elements, :with_unordered_members
+
+          configure { |boolean = true| { condition: :unordered, negated: !boolean } }
+        end
+
+        bind_method :containing do
+          desc 'Constrains the Enumerable to contain certain entries'
+          concerning :inclusion
+          aliases :having_entries, :having_entries, :having_elements, :having_members, :with_entries, :with_elements,
+                  :with_members
+
+          configure { |*entries| { expected: (constraints.self&.inclusion&.expected || []).concat(entries).uniq } }
+        end
+
+        bind_method :excluding do
+          desc 'Constrains the Enumerable not to contain certain entries'
+          concerning :exclusion
+          default_for_parameter :expectation_qualifier, :none
+          aliases :not_having_entries, :not_having_elements, :not_having_members, :without_entries, :without_elements,
+                  :without_members
+
+          configure { |*entries| { expected: (constraints.self&.exclusion&.expected || []).concat(entries).uniq } }
+        end
+
+        bind_method :of do
+          desc 'Constrains the type of entries allowed in the Enumerable'
+          concerning :entry_type
+          aliases :having_entries_of, :having_elements_of, :having_members_of, :with_entries_of, :with_elements_of,
+                  :with_members_of
+
+          configure { |type| { expected: type } }
+        end
+      end
+
+      # @!method having_exact_size(value)
+      #  Constrains the minimum and maximum size of the Enumerable to a single value
+      #  @!scope class
+      #  @param value [Integer] the size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_exact_size(value)
+      #  Constrains the minimum and maximum size of the Enumerable to a single value
+      #  @param value [Integer] the size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_maximum_size(value)
+      #  Constrains the maximum size of the Enumerable
+      #  @!scope class
+      #  @param value [Integer] the maximum size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_maximum_size(value)
+      #  Constrains the maximum size of the Enumerable
+      #  @param value [Integer] the maximum size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_minimum_size(value)
+      #  Constrains the minimum size of the Enumerable
+      #  @!scope class
+      #  @param value [Integer] the minimum size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_minimum_size(value)
+      #  Constrains the minimum size of the Enumerable
+      #  @param value [Integer] the minimum size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_size_between(minimum, maximum)
+      #  Constrains the size of the Enumerable to be within a range
+      #  @!scope class
+      #  @param minimum [Integer] the minimum size of the Enumerable
+      #  @param maximum [Integer] the maximum size of the Enumerable
+      #  @return [void]
+      #
+      # @!method having_size_between(minimum, maximum)
+      #  Constrains the size of the Enumerable to be within a range
+      #  @param minimum [Integer] the minimum size of the Enumerable
+      #  @param maximum [Integer] the maximum size of the Enumerable
+      #  @return [void]
+      constrain :size do
+        constraint :range
+
+        bind_method :having_exact_size do
+          desc 'Constrains the minimum and maximum size of the Enumerable to a single value'
+          concerning :range
+          aliases :having_count, :having_exact_count, :having_exact_length, :having_length, :having_size,
+                  :with_count, :with_exact_count, :with_exact_length, :with_exact_size, :with_length, :with_size
+
+          configure { |value| { minimum: value, maximum: value } }
+        end
+
+        bind_method :having_maximum_size do
+          desc 'Constrains the maximum size of the Enumerable'
+          concerning :range
+          aliases :having_max_count, :having_max_length, :having_max_size, :having_maximum_count,
+                  :having_maximum_length, :with_max_count, :with_max_length, :with_max_size, :with_maximum_count,
+                  :with_maximum_length, :with_maximum_size
+
+          configure { |value| { maximum: value } }
+        end
+
+        bind_method :having_minimum_size do
+          desc 'Constrains the minimum size of the Enumerable'
+          concerning :range
+          aliases :having_min_count, :having_min_length, :having_min_size, :having_minimum_count,
+                  :having_minimum_length, :with_min_count, :with_min_length, :with_min_size, :with_minimum_count,
+                  :with_minimum_length, :with_minimum_size
+
+          configure { |value| { minimum: value } }
+        end
+
+        bind_method :having_size_between do
+          concerning :range
+          default_for_parameter :inclusive, false
+          aliases :having_count_between, :having_length_between, :with_count_between, :with_length_between,
+                  :with_size_between
+
+          configure do |minimum = nil, maximum = nil, **options|
+            minimum = minimum || options[:minimum] || options[:min]
+            maximum = maximum || options[:maximum] || options[:max]
+            { minimum:, maximum: }
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/enumerable_type.rb
+++ b/domainic-type/lib/domainic/type/enumerable_type.rb
@@ -194,6 +194,7 @@ module Domainic
         bind_method :of do
           desc 'Constrains the type of entries allowed in the Enumerable'
           concerning :entry_type
+          default_for_parameter :access_qualifier, :all
           aliases :having_entries_of, :having_elements_of, :having_members_of, :with_entries_of, :with_elements_of,
                   :with_members_of
 

--- a/domainic-type/lib/domainic/type/enumerable_type.rb
+++ b/domainic-type/lib/domainic/type/enumerable_type.rb
@@ -28,89 +28,89 @@ module Domainic
       # @!method being_duplicative
       #  Constrains the Enumerable to contain duplicate entries
       #  @!scope class
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method being_duplicative
       #  Constrains the Enumerable to contain duplicate entries
-      #  @return [void]
+      #  @return [self]
       #
       # @!method being_empty
       #  Constrains the Enumerable to be empty
       #  @!scope class
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method being_empty
       #  Constrains the Enumerable to be empty
-      #  @return [void]
+      #  @return [self]
       #
       # @!method being_populated
       #  Constrains the Enumerable to be populated
       #  @!scope class
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method being_populated
       #  Constrains the Enumerable to be populated
-      #  @return [void]
+      #  @return [self]
       #
       # @!method being_ordered
       #  Constrains the Enumerable to be ordered
       #  @!scope class
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method being_ordered
       #  Constrains the Enumerable to be ordered
-      #  @return [void]
+      #  @return [self]
       #
       # @!method being_unique
       #  Constrains the Enumerable to contain unique entries
       #  @!scope class
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method being_unique
       #  Constrains the Enumerable to contain unique entries
-      #  @return [void]
+      #  @return [self]
       #
       # @!method being_unordered
       #  Constrains the Enumerable to be unordered
       #  @!scope class
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method being_unordered
       #  Constrains the Enumerable to be unordered
-      #  @return [void]
+      #  @return [self]
       #
       # @!method containing(*entries)
       #  Constrains the Enumerable to contain certain entries
       #  @!scope class
       #  @param entries [Array] the entries that the Enumerable should contain
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method containing(*entries)
       #  Constrains the Enumerable to contain certain entries
       #  @param entries [Array] the entries that the Enumerable should contain
-      #  @return [void]
+      #  @return [self]
       #
       # @!method excluding(*entries)
       #  Constrains the Enumerable not to contain certain entries
       #  @!scope class
       #  @param entries [Array] the entries that the Enumerable should not contain
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method excluding(*entries)
       #  Constrains the Enumerable not to contain certain entries
       #  @param entries [Array] the entries that the Enumerable should not contain
-      #  @return [void]
+      #  @return [self]
       #
       # @!method of(type)
       #  Constrains the type of entries allowed in the Enumerable
       #  @!scope class
       #  @param type [Class] the type of entries allowed in the Enumerable
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method of(type)
       #  Constrains the type of entries allowed in the Enumerable
       #  @param type [Class] the type of entries allowed in the Enumerable
-      #  @return [void]
+      #  @return [self]
       constrain :self do
         constraint :inclusion, name: :exclusion
         constraint :inclusion
@@ -205,47 +205,47 @@ module Domainic
       #  Constrains the minimum and maximum size of the Enumerable to a single value
       #  @!scope class
       #  @param value [Integer] the size of the Enumerable
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method having_exact_size(value)
       #  Constrains the minimum and maximum size of the Enumerable to a single value
       #  @param value [Integer] the size of the Enumerable
-      #  @return [void]
+      #  @return [self]
       #
       # @!method having_maximum_size(value)
       #  Constrains the maximum size of the Enumerable
       #  @!scope class
       #  @param value [Integer] the maximum size of the Enumerable
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method having_maximum_size(value)
       #  Constrains the maximum size of the Enumerable
       #  @param value [Integer] the maximum size of the Enumerable
-      #  @return [void]
+      #  @return [self]
       #
       # @!method having_minimum_size(value)
       #  Constrains the minimum size of the Enumerable
       #  @!scope class
       #  @param value [Integer] the minimum size of the Enumerable
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method having_minimum_size(value)
       #  Constrains the minimum size of the Enumerable
       #  @param value [Integer] the minimum size of the Enumerable
-      #  @return [void]
+      #  @return [self]
       #
       # @!method having_size_between(minimum, maximum)
       #  Constrains the size of the Enumerable to be within a range
       #  @!scope class
       #  @param minimum [Integer] the minimum size of the Enumerable
       #  @param maximum [Integer] the maximum size of the Enumerable
-      #  @return [void]
+      #  @return [EnumerableType]
       #
       # @!method having_size_between(minimum, maximum)
       #  Constrains the size of the Enumerable to be within a range
       #  @param minimum [Integer] the minimum size of the Enumerable
       #  @param maximum [Integer] the maximum size of the Enumerable
-      #  @return [void]
+      #  @return [self]
       constrain :size do
         constraint :range
 

--- a/domainic-type/lib/domainic/type/float_type.rb
+++ b/domainic-type/lib/domainic/type/float_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'numeric_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class FloatType < NumericType
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/hash_type.rb
+++ b/domainic-type/lib/domainic/type/hash_type.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative 'enumerable_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class HashType < EnumerableType
+      constrain :keys do
+        constraint :type
+        constraint :inclusion
+        constraint :inclusion, name: :exclusion
+
+        bind_method :having_keys do
+          desc 'Constrains the hash to have the given keys.'
+          concerning :inclusion
+          aliases :with_keys
+
+          configure { |*keys| { expected: (constraints.keys&.inclusion&.expected || []).concat(keys).uniq } }
+        end
+
+        bind_method :having_keys_of do
+          desc 'Constrains the hash to have keys of the given type.'
+          concerning :type
+          aliases :with_keys_of
+
+          configure { |type| { expected: type } }
+        end
+
+        bind_method :not_having_keys do
+          desc 'Constrains the hash to not have the given keys.'
+          concerning :exclusion
+          aliases :without_keys
+
+          configure { |*keys| { expected: (constraints.keys&.exclusion&.expected || []).concat(keys).uniq } }
+        end
+      end
+
+      constrain :values do
+        constraint :type
+        constraint :inclusion
+        constraint :inclusion, name: :exclusion
+
+        bind_method :having_values do
+          desc 'Constrains the hash to have the given values.'
+          concerning :inclusion
+          aliases :with_values
+
+          configure { |*values| { expected: (constraints.values&.inclusion&.expected || []).concat(values).uniq } }
+        end
+
+        bind_method :having_values_of do
+          desc 'Constrains the hash to have values of the given type.'
+          concerning :type
+          aliases :with_values_of
+
+          configure { |type| { expected: type } }
+        end
+
+        bind_method :not_having_values do
+          desc 'Constrains the hash to not have the given values.'
+          concerning :exclusion
+          aliases :without_values
+
+          configure { |*values| { expected: (constraints.values&.exclusion&.expected || []).concat(values).uniq } }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/integer_type.rb
+++ b/domainic-type/lib/domainic/type/integer_type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative 'numeric_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class IntegerType < NumericType
+      constrain :self do
+        intrinsic_constraint :type, expected: Integer, fail_fast: true
+
+        constraint :parity
+        constraint :polarity
+
+        bind_method :being_even do
+          desc 'Constrains the integer to be even.'
+          concerning :parity
+
+          configure { |boolean = true| { condition: :even, negated: !boolean } }
+        end
+
+        bind_method :being_odd do
+          desc 'Constrains the integer to be odd.'
+          concerning :parity
+
+          configure { |boolean = true| { condition: :odd, negated: !boolean } }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/numeric_type.rb
+++ b/domainic-type/lib/domainic/type/numeric_type.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class NumericType < BaseType
+      constrain :self do
+        constraint :divisibility
+        constraint :equality
+        constraint :finiteness
+        constraint :polarity
+        constraint :range
+
+        bind_method :being_divisible_by do
+          desc 'Constrains the value to be divisible by the given number.'
+          concerning :divisibility
+          aliases :being_multiple_of
+
+          configure { |value| { expected: value } }
+        end
+
+        bind_method :being_equal_to do
+          desc 'Constrains the value to be equal to the given number.'
+          concerning :equality
+
+          configure { |value| { expected: value } }
+        end
+
+        bind_method :being_finite do
+          desc 'Constrains the value to be finite.'
+          concerning :finiteness
+
+          configure { |boolean = true| { condition: :finite, negated: !boolean } }
+        end
+
+        bind_method :being_infinite do
+          desc 'Constrains the value to be infinite.'
+          concerning :finiteness
+
+          configure { |boolean = true| { condition: :infinite, negated: !boolean } }
+        end
+
+        bind_method :being_greater_than do
+          desc 'Constrains the value to be greater than the given number.'
+          concerning :range
+          aliases :being_more_than, :gt, :greater_than
+
+          configure { |value| { minimum: value, inclusive: false } }
+        end
+
+        bind_method :being_greater_than_or_equal_to do
+          desc 'Constrains the value to be greater than or equal to the given number.'
+          concerning :range
+          aliases :being_more_than_or_equal_to, :gte, :gteq, :greater_than_or_equal_to
+
+          configure { |value| { minimum: value, inclusive: true } }
+        end
+
+        bind_method :being_less_than do
+          desc 'Constrains the value to be less than the given number.'
+          concerning :range
+          aliases :being_less_than, :lt, :less_than
+
+          configure { |value| { maximum: value, inclusive: false } }
+        end
+
+        bind_method :being_less_than_or_equal_to do
+          desc 'Constrains the value to be less than or equal to the given number.'
+          concerning :range
+          aliases :being_less_than_or_equal_to, :lte, :lteq, :less_than_or_equal_to
+
+          configure { |value| { maximum: value, inclusive: true } }
+        end
+
+        bind_method :being_positive do
+          desc 'Constrains the value to be positive.'
+          concerning :polarity
+
+          configure { |boolean = true| { condition: :positive, negated: !boolean } }
+        end
+
+        bind_method :being_negative do
+          desc 'Constrains the value to be negative.'
+          concerning :polarity
+
+          configure { |boolean = true| { condition: :negative, negated: !boolean } }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/ordered_enumerable_type.rb
+++ b/domainic-type/lib/domainic/type/ordered_enumerable_type.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative 'enumerable_type'
+
+module Domainic
+  module Type
+    # The `OrderedEnumerableType` is the base class for all ordered enumerable types.
+    #
+    # @!method initialize(**options)
+    #  Initialize a new instance of the OrderedEnumerableType.
+    #  @param options [Hash] the options to configure the EnumerableType
+    #  @option options [Boolean] :being_duplicative whether the Enumerable should contain duplicate entries.
+    #  @option options [Boolean] :being_empty whether the Enumerable should be empty.
+    #  @option options [Boolean] :being_populated whether the Enumerable should be populated.
+    #  @option options [Boolean] :being_ordered whether the Enumerable should be ordered.
+    #  @option options [Boolean] :being_unique whether the Enumerable should contain unique entries.
+    #  @option options [Array<Object>] :containing the entries that the Enumerable should contain.
+    #  @option options [Array<Object>] :excluding the entries that the Enumerable should not contain.
+    #  @option options [Class, BaseType] :of the type of entries allowed in the Enumerable.
+    #  @option options [Integer] :having_exact_size the size of the Enumerable.
+    #  @option options [Integer] :having_maximum_size the maximum size of the Enumerable.
+    #  @option options [Integer] :having_minimum_size the minimum size of the Enumerable.
+    #  @option options [Hash{Symbol => Integer}] :having_size_between the minimum and maximum size of the Enumerable.
+    #  @option options [Object] :having_first_entry the first entry of the Enumerable.
+    #  @option options [Object] :having_last_entry the last entry of the Enumerable.
+    #  @return [OrderedEnumerableType] the new EnumerableType instance
+    #
+    # @since 0.1.0
+    class OrderedEnumerableType < EnumerableType
+      # @!method having_first_entry(entry)
+      #  Constrains the Enumerable to have the first entry
+      #  @!scope class
+      #  @param entry [Object] the expected first entry
+      #  @return [OrderedEnumerableType]
+      #
+      # @!method having_first_entry(entry)
+      #  Constrains the Enumerable to have the first entry
+      #  @param entry [Object] the expected first entry
+      #  @return [self]
+      constrain :first do
+        constraint :equality
+
+        bind_method :having_first_entry do
+          desc 'Constrains the Enumerable to have the first entry'
+          concerning :equality
+          aliases :having_first_element, :having_head, :having_first_member,
+                  :with_first_element, :with_first_entry, :with_head, :with_first_member
+
+          configure { |entry| { expected: entry } }
+        end
+      end
+
+      # @!method having_last_entry(entry)
+      #  Constrains the Enumerable to have the last entry
+      #  @!scope class
+      #  @param entry [Object] the expected last entry
+      #  @return [OrderedEnumerableType]
+      #
+      # @!method having_last_entry(entry)
+      #  Constrains the Enumerable to have the last entry
+      #  @param entry [Object] the expected last entry
+      #  @return [self]
+      constrain :last do
+        constraint :equality
+
+        bind_method :having_last_entry do
+          desc 'Constrains the Enumerable to have the last entry'
+          concerning :equality
+          aliases :having_last_element, :having_tail, :having_last_member,
+                  :with_last_element, :with_last_entry, :with_tail, :with_last_member
+
+          configure { |entry| { expected: entry } }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/range_type.rb
+++ b/domainic-type/lib/domainic/type/range_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative 'ordered_enumerable_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class RangeType < OrderedEnumerableType
+      constrain :self do
+        intrinsic_constraint :type, expected: Range, fail_fast: true
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/string_type.rb
+++ b/domainic-type/lib/domainic/type/string_type.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class StringType < BaseType
+      constrain :self do
+        intrinsic_constraint :type, expected: String, fail_fast: true
+
+        constraint :inclusion, name: :exclusion
+        constraint :inclusion
+        constraint :match
+        constraint :ordering
+        constraint :presence
+        constraint :uniqueness
+
+        bind_method :being_blank do
+          desc 'Constrains the string to be blank.'
+          concerning :presence
+
+          configure { { condition: :absent } }
+        end
+
+        bind_method :being_duplicative do
+          desc 'Constrains the string to be duplicative.'
+          concerning :uniqueness
+
+          configure { |boolean = true| { condition: :duplicative, negated: !boolean } }
+        end
+
+        bind_method :being_ordered do
+          desc 'Constrains the string to be ordered.'
+          concerning :ordering
+
+          configure { |boolean = true| { condition: :ordered, negated: !boolean } }
+        end
+
+        bind_method :being_unique do
+          desc 'Constrains the string to be unique.'
+          concerning :uniqueness
+
+          configure { |boolean = true| { condition: :unique, negated: !boolean } }
+        end
+
+        bind_method :containing do
+          desc 'Constrains the string to include the given substring.'
+          concerning :inclusion
+          aliases :including
+
+          configure { |*values| { expected: (constraints.self&.inclusion&.expected || []).concat(values).uniq } }
+        end
+
+        bind_method :excluding do
+          desc 'Constrains the string to not include the given substring.'
+          concerning :exclusion
+          default_for_parameter :expectation_qualifier, :none
+          aliases :without
+
+          configure { |*values| { expected: (constraints.self&.exclusion&.expected || []).concat(values).uniq } }
+        end
+
+        bind_method :matching do
+          desc 'Constrains the string to match the given pattern.'
+          concerning :match
+          aliases :matching_pattern
+
+          configure { |pattern| { expected: pattern } }
+        end
+
+        bind_method :not_being_blank do
+          desc 'Constrains the string to not be blank.'
+          concerning :presence
+
+          configure { { condition: :present } }
+        end
+      end
+
+      constrain :length do
+        constraint :range
+
+        bind_method :having_exact_length do
+          desc 'Constrains the length of the string to be exactly the given length.'
+          concerning :range
+          aliases :with_exact_length
+
+          configure { |value| { minimum: value, maximum: value } }
+        end
+
+        bind_method :having_maximum_length do
+          desc 'Constrains the length of the string to be at most the given length.'
+          concerning :range
+          aliases :with_maximum_length
+
+          configure { |value| { maximum: value } }
+        end
+
+        bind_method :having_minimum_length do
+          desc 'Constrains the length of the string to be at least the given length.'
+          concerning :range
+          aliases :with_minimum_length
+
+          configure { |value| { minimum: value } }
+        end
+
+        bind_method :having_length_between do
+          desc 'Constrains the length of the string to be between the given minimum and maximum lengths.'
+          concerning :range
+          default_for_parameter :inclusive, false
+          aliases :with_length_between
+
+          configure do |minimum = nil, maximum = nil, **options|
+            minimum = minimum || options[:minimum] || options[:min]
+            maximum = maximum || options[:maximum] || options[:max]
+            { minimum:, maximum: }
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/union_type.rb
+++ b/domainic-type/lib/domainic/type/union_type.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class UnionType < BaseType
+      constrain :self do
+        constraint :type
+
+        bind_method :being do
+          desc 'Constrains the type to be one of the given types.'
+          concerning :type
+          default_for_parameter :expectation_qualifier, :any
+
+          configure { |*types| { expected: (consraints.self&.type&.expected || []).concat(types).uniq } }
+        end
+      end
+
+      def initialize(*types, **options)
+        super(being: types, **options)
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/void_type.rb
+++ b/domainic-type/lib/domainic/type/void_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'base_type'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class VoidType < BaseType
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/anything_type_spec.rb
+++ b/domainic-type/spec/domainic/type/anything_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/anything_type'
+
+RSpec.describe Domainic::Type::AnythingType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/array_type_spec.rb
+++ b/domainic-type/spec/domainic/type/array_type_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/array_type'
+
+RSpec.describe Domainic::Type::ArrayType do
+  describe '#validate' do
+    subject(:validate) { array_type.validate(subject_value) }
+
+    let(:array_type) { described_class.new }
+
+    context 'when the subject is not an array' do
+      let(:subject_value) { '' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the subject is an array' do
+      let(:subject_value) { [1, 2, 3] }
+
+      it { is_expected.to be true }
+
+      context 'when constrained to be duplicative' do
+        before { array_type.being_duplicative }
+
+        context 'when the subject is an array with duplicate values' do
+          let(:subject_value) { [1, 1, 2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is an array without duplicate values' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to be empty' do
+        before { array_type.being_empty }
+
+        context 'when the subject is an empty array' do
+          let(:subject_value) { [] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is a populated array' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to be populated' do
+        before { array_type.being_populated }
+
+        context 'when the subject is a populated array' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is an empty array' do
+          let(:subject_value) { [] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to be ordered' do
+        before { array_type.being_ordered }
+
+        context 'when the subject is an ordered array' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is an unordered array' do
+          let(:subject_value) { [3, 2, 1] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to be unique' do
+        before { array_type.being_unique }
+
+        context 'when the subject is an array with unique values' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is an array with duplicate values' do
+          let(:subject_value) { [1, 2, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to be unordered' do
+        before { array_type.being_unordered }
+
+        context 'when the subject is an unordered array' do
+          let(:subject_value) { [3, 2, 1] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject is an ordered array' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to contain certain entries' do
+        before { array_type.containing(1, 2) }
+
+        context 'when the subject contains all specified entries' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject does not contain all specified entries' do
+          let(:subject_value) { [1, 3, 4] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to have an exact size' do
+        before { array_type.having_exact_size(3) }
+
+        context 'when the subject has the exact size' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject has a different size' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to have a maximum size' do
+        before { array_type.having_maximum_size(3) }
+
+        context 'when the subject size is below the maximum' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject size equals the maximum' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject size exceeds the maximum' do
+          let(:subject_value) { [1, 2, 3, 4] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to have a minimum size' do
+        before { array_type.having_minimum_size(2) }
+
+        context 'when the subject size is above the minimum' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject size equals the minimum' do
+          let(:subject_value) { [1, 2] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject size is below the minimum' do
+          let(:subject_value) { [1] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to have size between a range' do
+        before { array_type.having_size_between(2, 4) }
+
+        context 'when the subject size is within the range' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the subject size is below the range' do
+          let(:subject_value) { [1] }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the subject size is above the range' do
+          let(:subject_value) { [1, 2, 3, 4, 5] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to have a first entry' do
+        before { array_type.having_first_entry(1) }
+
+        context 'when the first entry matches' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the first entry does not match' do
+          let(:subject_value) { [2, 1, 3] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when constrained to have a last entry' do
+        before { array_type.having_last_entry(3) }
+
+        context 'when the last entry matches' do
+          let(:subject_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the last entry does not match' do
+          let(:subject_value) { [1, 3, 2] }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/boolean_type_spec.rb
+++ b/domainic-type/spec/domainic/type/boolean_type_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/boolean_type'
+
+RSpec.describe Domainic::Type::BooleanType do
+  describe '#validate' do
+    subject(:validate) { described_class.new.validate(subject_value) }
+
+    context 'when the value is true' do
+      let(:subject_value) { true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is false' do
+      let(:subject_value) { false }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not a boolean' do
+      let(:subject_value) { 1 }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/responds_to_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/responds_to_constraint_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/constraint/responds_to_constraint'
+
+RSpec.describe Domainic::Type::Constraint::RespondsToConstraint do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/duck_type_spec.rb
+++ b/domainic-type/spec/domainic/type/duck_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/duck_type'
+
+RSpec.describe Domainic::Type::DuckType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/enum_type_spec.rb
+++ b/domainic-type/spec/domainic/type/enum_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/enum_type'
+
+RSpec.describe Domainic::Type::EnumType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/float_type_spec.rb
+++ b/domainic-type/spec/domainic/type/float_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/float_type'
+
+RSpec.describe Domainic::Type::FloatType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/hash_type_spec.rb
+++ b/domainic-type/spec/domainic/type/hash_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/hash_type'
+
+RSpec.describe Domainic::Type::HashType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/integer_type_spec.rb
+++ b/domainic-type/spec/domainic/type/integer_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/integer_type'
+
+RSpec.describe Domainic::Type::IntegerType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/range_type_spec.rb
+++ b/domainic-type/spec/domainic/type/range_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/range_type'
+
+RSpec.describe Domainic::Type::RangeType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/string_type_spec.rb
+++ b/domainic-type/spec/domainic/type/string_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/string_type'
+
+RSpec.describe Domainic::Type::StringType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/union_type_spec.rb
+++ b/domainic-type/spec/domainic/type/union_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/union_type'
+
+RSpec.describe Domainic::Type::UnionType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/domainic-type/spec/domainic/type/void_type_spec.rb
+++ b/domainic-type/spec/domainic/type/void_type_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/void_type'
+
+RSpec.describe Domainic::Type::VoidType do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This implements various types and introduces various fixes

Changelog:
  - added `Domainic::Type::AnythingType`
  - added `Domainic::Type::ArrayType`
  - added `Domainic::Type::BooleanType`
  - added `Domainic::Type::DuckType`
  - added `Domainic::Type::EnumerableType`
  - added `Domainic::Type::EnumType`
  - added `Domainic::Type::FloatType`
  - added `Domainic::Type::HashType`
  - added `Domainic::Type::IntegerType`
  - added `Domainic::Type::NumericType`
  - added `Domainic::Type::OrderedEnumerableType`
  - added `Domainic::Type::RangeType`
  - added `Domainic::Type::StringType`
  - added `Domainic::Type::UnionType`
  - added `Domainic::Type::VoidType`
  - added `Domainic::Type::BaseType#validate`
  - added `Domainic::Type::Constraint::TypeConstraint#access_qualifier`
  - changed `Domainic::Type::BaseType#initialize` now accepts options to configure constraints with
  - fixed `Domainic::Type::Constraint::Provisioning::Provisioner` now properly provisions intrinsic constraints
  - fixed `Domainic::Type::Constraint::RelationalConstraint#initialize` no longer raises `ArgumentError`
  - fixed `Domainic::Type::DSL::ConstraintBuilder::SignatureBuilder#aliases` now accepts multiple aliases
  - fixed  `Domainic::Type::DSL::ConstraintBuilder::MethodInjector#inject!` now injects chainable methods

resolves #55
resolves #56
resolves #57 
resolves #58 
resolves #59 
resolves #60 
resolves #61 
resolves #62 
resolves #63 
resolves #64 
resolves #65 
resolves #66 
resolves #67 
resolves #68 
resolves #69