### PR TITLE
Implement `Domainic::Type::Schema`

### DIFF
--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -20,6 +20,7 @@ Array:
   groups:
     - core
     - enumerable
+    - ruby_core
 Boolean:
   constant: Domainic::Type::BooleanType
   require_path: domainic/type/boolean_type
@@ -63,6 +64,7 @@ Float:
   groups:
     - core
     - numeric
+    - ruby_core
 Hash:
   constant: Domainic::Type::HashType
   require_path: domainic/type/hash_type
@@ -74,6 +76,7 @@ Hash:
   groups:
     - core
     - enumerable
+    - ruby_core
 Integer:
   constant: Domainic::Type::IntegerType
   require_path: domainic/type/integer_type
@@ -87,6 +90,7 @@ Integer:
   groups:
     - core
     - numeric
+    - ruby_core
 Range:
   constant: Domainic::Type::RangeType
   require_path: domainic/type/range_type
@@ -96,6 +100,7 @@ Range:
   groups:
     - core
     - enumerable
+    - ruby_core
 String:
   constant: Domainic::Type::StringType
   require_path: domainic/type/string_type
@@ -107,6 +112,7 @@ String:
   groups:
     - core
     - string
+    - ruby_core
 Union:
   constant: Domainic::Type::UnionType
   require_path: domainic/type/union_type

--- a/domainic-type/lib/domainic/type/constraint/type_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/type_constraint.rb
@@ -34,7 +34,15 @@ module Domainic
         # @param type [Class, Module, Domainic::Type::BaseType] The expected type.
         # @return [Boolean] `true` if the subject is of the expected type, `false` otherwise.
         def is_type?(subject, type) # rubocop:disable Naming/PredicateName
+          type = resolve_type(type)
           type.is_a?(Domainic::Type::BaseType) ? type.validate(subject) : subject.is_a?(type)
+        end
+
+        def resolve_type(type)
+          return type if type.is_a?(Domainic::Type::BaseType)
+          return type.new if type.is_a?(Class) && type < Domainic::Type::BaseType
+
+          type
         end
       end
     end

--- a/domainic-type/lib/domainic/type/definition.rb
+++ b/domainic-type/lib/domainic/type/definition.rb
@@ -11,29 +11,52 @@ module Domainic
       private
 
       def const_missing(symbol)
-        return super unless respond_to?(symbol)
+        super unless respond_to_missing?(symbol)
 
-        public_send(symbol)
+        send(symbol)
       end
 
       def inject_type!(loader)
         loader.load
+        inject_type_constants!(loader)
+        inject_type_methods!(loader)
+      end
 
+      def inject_type_constants!(loader)
         type = Object.const_get(loader.constant)
-        define_method(loader.name) { |*arguments, **keyword_arguments| type.new(*arguments, **keyword_arguments) }
-        loader.aliases.each do |alias_name|
-          next if respond_to?(alias_name)
+        const_set(loader.name, type) unless const_defined?(loader.name) && !loader.in_group?(:ruby_core)
+        loader.aliases.select { |name| name.to_s.match?(/\A[A-Z]/) }.each do |name|
+          next if const_defined?(name)
 
-          alias_method(alias_name, loader.name)
+          const_set(name, type)
+        end
+      end
+
+      def inject_type_methods!(loader)
+        type = Object.const_get(loader.constant)
+
+        unless method_defined?(loader.name)
+          define_method(loader.name) do |*arguments, **keyword_arguments|
+            type.new(*arguments, **keyword_arguments)
+          end
+        end
+
+        loader.aliases.each do |name|
+          next if method_defined?(name)
+
+          alias_method(name, loader.name)
         end
       end
 
       def method_missing(method, ...)
+        return super unless respond_to_missing?(method)
+
         loader = registry.find(method)
-        return super if loader.nil?
+        return super unless loader
 
         inject_type!(loader)
-        public_send(method, ...)
+        type = Object.const_get(loader.constant)
+        type.new(...)
       end
 
       def registry
@@ -43,6 +66,8 @@ module Domainic
       def respond_to_missing?(method, include_private = false)
         registry.find(method) || super
       end
+
+      registry.all.select(&:loaded?).each { |loader| inject_type!(loader) }
     end
   end
 end

--- a/domainic-type/lib/domainic/type/errors.rb
+++ b/domainic-type/lib/domainic/type/errors.rb
@@ -7,6 +7,8 @@ module Domainic
     # @since 0.1.0
     class Error < StandardError; end
 
+    class InvalidObjectError < Error; end
+
     # Raised when a {Constraint::Parameter} is given an invalid value.
     #
     # @since 0.1.0

--- a/domainic-type/lib/domainic/type/schema/attribute.rb
+++ b/domainic-type/lib/domainic/type/schema/attribute.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module Schema
+      # @since 0.1.0
+      class Attribute
+        attr_reader :description, :name
+
+        def initialize(base, name, type_or_description = nil, description_or_type = nil, **options)
+          @base = base
+          @coercer = options.fetch(:coercer, ->(value) { value })
+          @default = options.fetch(:default, UNSPECIFIED)
+          @description = initialize_description(type_or_description, description_or_type, **options)
+          @name = name.to_sym
+          @required = options.fetch(:required, false)
+          @type = initialize_type(type_or_description, description_or_type, **options)
+        end
+
+        def default
+          @default == UNSPECIFIED ? nil : @default
+        end
+
+        def default?
+          @default != UNSPECIFIED
+        end
+
+        def dup_with_base(new_base)
+          dup.tap { |duped| duped.instance_variable_set(:@base, new_base) }
+        end
+
+        def required?
+          @required
+        end
+
+        def validate(subject)
+          value = coerce_value(subject)
+
+          @type.is_a?(Domainic::Type::BaseType) ? @type.validate(value) : value.is_a?(@type)
+        end
+
+        private
+
+        def coerce_value(value)
+          return @coercer.call(value) if @coercer.is_a?(Proc)
+          return @base.send(@coercer, value) if @coercer.is_a?(Symbol) && @base.respond_to?(@coercer, true)
+          if true.equal?(@coercer) && @base.respond_to?(:"coerce_#{name}", true)
+            return @base.send(:"coerce_#{name}", value)
+          end
+
+          value
+        end
+
+        def initialize_description(*arguments, **options)
+          arguments.find { |arg| arg.is_a?(String) } || options[:description] || options[:desc] || ''
+        end
+
+        def initialize_type(*arguments, **options)
+          arguments.find { |arg| arg.is_a?(Class) || arg.is_a?(Domainic::Type::BaseType) } || options[:type]
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/schema/attribute_options_parser.rb
+++ b/domainic-type/lib/domainic/type/schema/attribute_options_parser.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../errors'
+
+module Domainic
+  module Type
+    module Schema
+      # @since 0.1.0
+      class AttributeOptionsParser
+        def initialize(base, attributes, options)
+          @base = base
+          @attributes = attributes
+          @options = options.transform_keys(&:to_sym)
+          @invalid_attributes = []
+          @missing_attributes = []
+          @unknown_attributes = @options.keys
+          @result = {}
+        end
+
+        def parse!
+          parse_attributes
+          aggregate_and_raise_errors!
+          @result
+        end
+
+        private
+
+        def aggregate_and_raise_errors!
+          return if @invalid_attributes.empty? && @missing_attributes.empty? && @unknown_attributes.empty?
+
+          raise InvalidObjectError, build_error_message
+        end
+
+        def build_error_message
+          message = "Invalid #{@base.class.name}\n#{@base.class.name} was given invalid attributes and has the " \
+                    "following errors:\n"
+          build_error_message_lists(message)
+        end
+
+        def build_error_message_lists(message)
+          error_sections = {
+            'Invalid attributes' => @invalid_attributes,
+            'Missing attributes' => @missing_attributes,
+            'Unknown attributes' => @unknown_attributes
+          }
+          error_sections.each do |section_title, attributes|
+            next if attributes.empty?
+
+            message += "#{section_title}:\n  - #{attributes.join("\n  - ")}\n"
+          end
+          message
+        end
+
+        def parse_attribute(attribute)
+          value = @options[attribute.name]
+          value = attribute.default if value.nil? && attribute.default?
+          if value.nil? && attribute.required?
+            @missing_attributes << attribute.name
+          elsif !attribute.validate(value)
+            @invalid_attributes << attribute.name
+          else
+            @result[attribute.name] = value
+          end
+        end
+
+        def parse_attributes
+          @attributes.each_pair do |attribute_name, attribute|
+            if @unknown_attributes.delete(attribute_name)
+              parse_attribute(attribute)
+            elsif attribute.required?
+              @missing_attributes << attribute_name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/schema/object.rb
+++ b/domainic-type/lib/domainic/type/schema/object.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../type'
+require_relative 'attribute'
+require_relative 'attribute_options_parser'
+
+unless Domainic::Type.config.global_prefix_enabled?
+  Domainic::Type.configure { |config| config.eager_load_type_group(:ruby_core) }
+  require_relative '../definition'
+end
+
+module Domainic
+  module Type
+    module Schema
+      # @since 0.1.0
+      class Object
+        extend Definition unless Domainic::Type.config.global_prefix_enabled?
+
+        class << self
+          def attribute(name, type_or_description = nil, description_or_type = nil, **options)
+            attribute = Attribute.new(self, name, type_or_description, description_or_type, **options)
+            @attributes = attributes.merge(attribute.name => attribute)
+            attr_reader attribute.name
+          end
+
+          def attributes
+            @attributes ||= {}.freeze
+          end
+        end
+
+        def initialize(**options)
+          attributes = self.class.attributes.transform_values { |attribute| attribute.dup_with_base(self) }
+          AttributeOptionsParser.new(self, attributes, options).parse!.each_pair do |name, value|
+            instance_variable_set(:"@#{name}", value)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changelog:
  - added `Domainic::Type::InvalidObjectError`
  - added `Domainic::Type::Schema::Attribute`
  - added `Domainic::Type::Schema::AttributeOptionsParser`
  - added `Domainic::Type::Schema::Object`
  - changed `Domainic::Type::Definition` now properly injects types onto itself.
  - changed `Domainic::Type::Constraint::TypeConstraint` can now  properly handle uninitialized references to a type

resolves #94 
resolves #95 
resolves #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new `ruby_core` group for several type definitions, enhancing type categorization.
  - Added `InvalidObjectError` class for better error handling related to invalid objects.
  - New `Attribute` class for managing attributes with various properties and behaviors.
  - Added `AttributeOptionsParser` class for parsing attribute options efficiently.
  - Introduced `Domainic::Type::Schema::Object` class for defining and managing attributes within a schema.

- **Enhancements**
  - Improved type-checking functionality in the `TypeConstraint` class.
  - Enhanced method and constant injection in the `Definition` module. 

- **Bug Fixes**
  - Adjusted error handling and validation processes to ensure clearer reporting of discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->