### PR TITLE
Fix `Domainic::Attributer::Builder#default`

### DIFF
--- a/domainic-attributer/lib/domainic/attributer/attribute.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute.rb
@@ -186,7 +186,7 @@ module Domainic
       # @param coercer [Proc, Symbol, true] The coercer to apply
       # @param value [Object] The value to coerce
       # @return [Object] The coerced value
-      # @rbs (^(untyped value) -> untyped | Symbol | true coercer, untyped value) -> untyped
+      # @rbs (Proc | Symbol | true coercer, untyped value) -> untyped
       def coerce_value(coercer, value)
         case coercer
         when Proc

--- a/domainic-attributer/lib/domainic/attributer/builder.rb
+++ b/domainic-attributer/lib/domainic/attributer/builder.rb
@@ -3,6 +3,7 @@
 require 'domainic/attributer/attribute'
 require 'domainic/attributer/attribute_definition'
 require 'domainic/attributer/method_injector'
+require 'domainic/attributer/undefined'
 
 module Domainic
   module Attributer
@@ -65,9 +66,9 @@ module Domainic
       # @rbs (
       #   ^() -> untyped | untyped value_or_proc,
       #   ) ?{ (?) -> void } -> self
-      def default(value_or_proc = nil, &block)
+      def default(value_or_proc = Undefined, &block)
         ensure_current_definition!
-        current_definition[:attribute_options][:default] = (value_or_proc || block)
+        current_definition[:attribute_options][:default] = value_or_proc == Undefined ? block : value_or_proc
         self
       end
 

--- a/domainic-attributer/lib/domainic/attributer/builder.rb
+++ b/domainic-attributer/lib/domainic/attributer/builder.rb
@@ -48,9 +48,7 @@ module Domainic
       # @param proc_symbol_or_true [Proc, Symbol, true, nil] The coercer to add
       # @yield An optional block to use as the coercer
       # @return [self] the Builder instance
-      # @rbs (
-      #   ^(untyped value) -> untyped | Symbol | true proc_symbol_or_true
-      #   ) ?{ (?) -> void } -> self
+      # @rbs (?(Proc | Symbol | true) proc_symbol_or_true) ?{ (?) -> void } -> self
       def coerce_with(proc_symbol_or_true = nil, &block)
         ensure_current_definition!
         current_definition[:attribute_options][:coercers] << (proc_symbol_or_true || block)
@@ -63,9 +61,7 @@ module Domainic
       # @param value_or_proc [Object, Proc, nil] The default value or a proc to generate it
       # @yield An optional block to generate the default value
       # @return [self] the Builder instance
-      # @rbs (
-      #   ^() -> untyped | untyped value_or_proc,
-      #   ) ?{ (?) -> void } -> self
+      # @rbs (?(Proc | untyped) value_or_proc) ?{ (?) -> void } -> self
       def default(value_or_proc = Undefined, &block)
         ensure_current_definition!
         current_definition[:attribute_options][:default] = value_or_proc == Undefined ? block : value_or_proc
@@ -81,7 +77,7 @@ module Domainic
       # @return [self] the Builder instance
       # @rbs (
       #   String | Symbol attribute_name,
-      #   Class | Module | ^(untyped value) -> bool type_validator,
+      #   ?(Class | Module | Proc) type_validator,
       #   **untyped options,
       #   ) ?{ (?) [self: Builder] -> void } -> self
       def define(attribute_name, type_validator = nil, **options, &block)
@@ -119,7 +115,7 @@ module Domainic
       # @param proc [Proc, nil] The callback to execute
       # @yield An optional block to use as the callback
       # @return [self] the Builder instance
-      # @rbs (^(untyped value) -> void proc) ?{ (?) -> void } -> self
+      # @rbs (?Proc proc) ?{ (?) -> void } -> self
       def on_change(proc = nil, &block)
         ensure_current_definition!
         current_definition[:attribute_options][:callbacks] << (proc || block)
@@ -141,9 +137,7 @@ module Domainic
       # @param case_equality_or_proc [#===, Proc, nil] The validator to add
       # @yield An optional block to use as the validator
       # @return [self] the Builder instance
-      # @rbs (
-      #   Class | Module | ^(untyped value) -> bool case_equality_or_proc,
-      #   ) ?{ (?) -> void } -> self
+      # @rbs (?(Class | Module | Proc) case_equality_or_proc) ?{ (?) -> void } -> self
       def validate_with(case_equality_or_proc = nil, &block)
         ensure_current_definition!
         current_definition[:attribute_options][:validators] << (case_equality_or_proc || block)
@@ -167,11 +161,7 @@ module Domainic
       # @param type_validator [Class, Module, Proc] Optional type constraint
       # @param options [Hash] Configuration options for the attribute
       # @return [void]
-      # @rbs (
-      #   String | Symbol attribute_name,
-      #   (Class | Module | ^(untyped value) -> bool) type_validator,
-      #   **untyped options
-      #   ) -> void
+      # @rbs (String | Symbol attribute_name, (Class | Module | Proc)? type_validator, **untyped options) -> void
       def build_current_definition(attribute_name, type_validator, **options)
         @current_definition = @data[attribute_name.to_sym] ||= {}
         current_definition.merge!(reader: options.fetch(:reader, :public), writer: options.fetch(:writer, :public))
@@ -188,11 +178,7 @@ module Domainic
       # @param type_validator [Class, Module, Proc] Optional type constraint
       # @param options [Hash] Configuration options for the attribute
       # @return [void]
-      # @rbs (
-      #   String | Symbol attribute_name,
-      #   Class | Module | ^(untyped value) -> bool type_validator,
-      #   **untyped options
-      #   ) -> void
+      # @rbs (String | Symbol attribute_name, (Class | Module | Proc)? type_validator, **untyped options) -> void
       def build_current_definition_attribute_options(attribute_name, type_validator, **options)
         attribute_options = current_definition[:attribute_options] ||=
           Attribute::DEFAULT_OPTIONS.transform_values(&:dup)

--- a/domainic-attributer/lib/domainic/attributer/class_methods.rb
+++ b/domainic-attributer/lib/domainic/attributer/class_methods.rb
@@ -37,8 +37,8 @@ module Domainic
       # @return [Builder] the builder instance for method chaining
       # @rbs (
       #   String | Symbol option_name,
-      #   Class | Module | ^(untyped value) -> bool type_validator,
-      #   **untyped options,
+      #   ?(Class | Module | Proc) type_validator,
+      #   **untyped options
       #   ) ?{ (?) [self: Builder] -> void } -> Builder
       def option(option_name, ...)
         __builder__.define(option_name, ...).build!

--- a/domainic-attributer/sig/domainic/attributer/attribute.rbs
+++ b/domainic-attributer/sig/domainic/attributer/attribute.rbs
@@ -125,7 +125,7 @@ module Domainic
       # @param coercer [Proc, Symbol, true] The coercer to apply
       # @param value [Object] The value to coerce
       # @return [Object] The coerced value
-      def coerce_value: (^(untyped value) -> untyped | Symbol | true coercer, untyped value) -> untyped
+      def coerce_value: (Proc | Symbol | true coercer, untyped value) -> untyped
 
       # Returns a qualified name for error messages.
       #

--- a/domainic-attributer/sig/domainic/attributer/builder.rbs
+++ b/domainic-attributer/sig/domainic/attributer/builder.rbs
@@ -34,7 +34,7 @@ module Domainic
       # @param proc_symbol_or_true [Proc, Symbol, true, nil] The coercer to add
       # @yield An optional block to use as the coercer
       # @return [self] the Builder instance
-      def coerce_with: (^(untyped value) -> untyped | Symbol | true proc_symbol_or_true) ?{ (?) -> void } -> self
+      def coerce_with: (?Proc | Symbol | true proc_symbol_or_true) ?{ (?) -> void } -> self
 
       alias coerce coerce_with
 
@@ -43,7 +43,7 @@ module Domainic
       # @param value_or_proc [Object, Proc, nil] The default value or a proc to generate it
       # @yield An optional block to generate the default value
       # @return [self] the Builder instance
-      def default: (^() -> untyped | untyped value_or_proc) ?{ (?) -> void } -> self
+      def default: (?Proc | untyped value_or_proc) ?{ (?) -> void } -> self
 
       # Begins the definition of a new attribute.
       #
@@ -52,7 +52,7 @@ module Domainic
       # @param options [Hash] Configuration options for the attribute
       # @yield [Builder] An optional block for additional configuration
       # @return [self] the Builder instance
-      def define: (String | Symbol attribute_name, Class | Module | ^(untyped value) -> bool type_validator, **untyped options) ?{ (?) [self: Builder] -> void } -> self
+      def define: (String | Symbol attribute_name, ?Class | Module | Proc type_validator, **untyped options) ?{ (?) [self: Builder] -> void } -> self
 
       # Sets the description for the current attribute.
       #
@@ -73,7 +73,7 @@ module Domainic
       # @param proc [Proc, nil] The callback to execute
       # @yield An optional block to use as the callback
       # @return [self] the Builder instance
-      def on_change: (^(untyped value) -> void proc) ?{ (?) -> void } -> self
+      def on_change: (?Proc proc) ?{ (?) -> void } -> self
 
       # Makes the current attribute required (non-nil).
       #
@@ -85,7 +85,7 @@ module Domainic
       # @param case_equality_or_proc [#===, Proc, nil] The validator to add
       # @yield An optional block to use as the validator
       # @return [self] the Builder instance
-      def validate_with: (Class | Module | ^(untyped value) -> bool case_equality_or_proc) ?{ (?) -> void } -> self
+      def validate_with: (?Class | Module | Proc case_equality_or_proc) ?{ (?) -> void } -> self
 
       alias validates validate_with
 
@@ -102,7 +102,7 @@ module Domainic
       # @param type_validator [Class, Module, Proc] Optional type constraint
       # @param options [Hash] Configuration options for the attribute
       # @return [void]
-      def build_current_definition: (String | Symbol attribute_name, Class | Module | ^(untyped value) -> bool type_validator, **untyped options) -> void
+      def build_current_definition: (String | Symbol attribute_name, (Class | Module | Proc)? type_validator, **untyped options) -> void
 
       # Sets up the options for the current attribute definition.
       #
@@ -110,7 +110,7 @@ module Domainic
       # @param type_validator [Class, Module, Proc] Optional type constraint
       # @param options [Hash] Configuration options for the attribute
       # @return [void]
-      def build_current_definition_attribute_options: (String | Symbol attribute_name, Class | Module | ^(untyped value) -> bool type_validator, **untyped options) -> void
+      def build_current_definition_attribute_options: (String | Symbol attribute_name, (Class | Module | Proc)? type_validator, **untyped options) -> void
 
       # Constructs and injects an attribute from its definition.
       #

--- a/domainic-attributer/sig/domainic/attributer/class_methods.rbs
+++ b/domainic-attributer/sig/domainic/attributer/class_methods.rbs
@@ -34,7 +34,7 @@ module Domainic
       # @param option_name [String, Symbol] The name of the attribute
       # @yield Block for additional attribute configuration
       # @return [Builder] the builder instance for method chaining
-      def option: (String | Symbol option_name, Class | Module | ^(untyped value) -> bool type_validator, **untyped options) ?{ (?) [self: Builder] -> void } -> Builder
+      def option: (String | Symbol option_name, ?Class | Module | Proc type_validator, **untyped options) ?{ (?) [self: Builder] -> void } -> Builder
 
       private
 

--- a/domainic-attributer/spec/domainic/attributer/builder_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/builder_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe Domainic::Attributer::Builder do
       attribute = definitions[:test].attribute
       expect(attribute.default).to eq('test')
     end
+
+    context 'when the value is falsy' do
+      let(:value) { false }
+
+      it 'is expected to set the value' do
+        default.build!
+        attribute = definitions[:test].attribute
+        expect(attribute.default).to be(false)
+      end
+    end
   end
 
   describe '#description' do


### PR DESCRIPTION
This fixes an issue where `Domainic::Attributer::Builder#default` would not accept falsy values. Additionally This relaxes proc types to just be `Proc` and ensures optional positional arguments are actually optional.

resolves #6