### PR TITLE
Update Attributer README and CHANGELOG

### DIFF
--- a/domainic-attributer/CHANGELOG.md
+++ b/domainic-attributer/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+## [v0.1.0] - 2024-12-12
+
+* Initial release
+
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Break Versioning]: https://www.taoensso.com/break-versioning
 
 <!-- versions -->
 
-[Unreleased]: https://github.com/domainic/domainic/tree/main/domainic-attributer
+[Unreleased]: https://github.com/domainic/domainic/compare/domainic-attributer-v0.1.0...HEAD
+[v0.1.0]: https://github.com/domainic/domainic/compare/53f3e992ab0e3f0092fd842c4cf89c22e41afa8a...domainic-attributer-v0.1.0

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -26,7 +26,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 29dec1131020400e867aca5d94c8e1a2182b52b6
+    revision: 7ad9c0f4805706e4cc2e840a8fbabfd14cef8e89
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock


### PR DESCRIPTION
The README now explicitly documents that Domainic::Attributer's constraints (type validation, coercion, nullability checks, etc.) are enforced throughout an object's entire lifecycle, not just during initialization.

Key changes:
- Added new "Attribute Constraints and Lifecycle" section with clear examples
- Enhanced type validation examples to show both init and setter validation
- Updated coercion examples to demonstrate consistent behavior
- Added more examples showing constraint enforcement during assignment

This addresses issue #10 where users might incorrectly assume constraints only apply during object creation.

resolves #10