### PR TITLE
Improve nil handling in coercer and bump version to 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     domainic (0.1.0)
-      domainic-attributer (>= 0.1, < 0.2)
-    domainic-attributer (0.1.0)
+      domainic-attributer (>= 0.2, < 0.3)
+    domainic-attributer (0.2.0)
 
 PATH
   remote: domainic-dev

--- a/domainic-attributer/CHANGELOG.md
+++ b/domainic-attributer/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+### Changed
+
+* [#18](https://github.com/domainic/domainic/pull/18) `Domainic::Attributer::Attribute::Coercer#call` will no longer
+  attempt to coerce nil values when the attribute is not nilable. While small this is technically a breaking change.
+* [#18](https://github.com/domainic/domainic/pull/18) `Domainic::Attributer::Attribute#apply!` no longer checks if the
+  value is `Undefined` before coercion (the coercer itself now has that responsibility).
+
+### Fixed
+
+* [#18](https://github.com/domainic/domainic/pull/18) Added missing requires for `Domainic::Attributer::Undefined` in
+  the `Domainic::Attributer::Attribute` and `Domainic::Attributer::Attribute::Validator` classes.
+
+### Added
+
+* [#18](https://github.com/domainic/domainic/pull/18) Documentation explaining nil handling in coercion handlers,
+  including explicit guidance for handling nilable vs non-nilable attributes.
+
 ## [v0.1.0] - 2024-12-12
 
 * Initial release

--- a/domainic-attributer/domainic-attributer.gemspec
+++ b/domainic-attributer/domainic-attributer.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-DOMAINIC_ATTRIBUTER_GEM_VERSION = '0.1.0'
-DOMAINIC_ATTRIBUTER_SEMVER = '0.1.0'
+DOMAINIC_ATTRIBUTER_GEM_VERSION = '0.2.0'
+DOMAINIC_ATTRIBUTER_SEMVER = '0.2.0'
 DOMAINIC_ATTRIBUTER_REPO_URL = 'https://github.com/domainic/domainic'
 DOMAINIC_ATTRIBUTER_HOME_URL = "#{DOMAINIC_ATTRIBUTER_REPO_URL}/tree/domainic-attributer-v" \
                                "#{DOMAINIC_ATTRIBUTER_SEMVER}/domainic-attributer".freeze

--- a/domainic-attributer/lib/domainic/attributer/attribute.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute.rb
@@ -119,7 +119,7 @@ module Domainic
         old_value = instance.instance_variable_get(:"@#{name}")
 
         coerced_value = value == Undefined ? generate_default(instance) : value
-        coerced_value = @coercer.call(instance, coerced_value) unless coerced_value == Undefined
+        coerced_value = @coercer.call(instance, coerced_value)
 
         @validator.call(instance, coerced_value)
 

--- a/domainic-attributer/lib/domainic/attributer/attribute/coercer.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute/coercer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'domainic/attributer/attribute/mixin/belongs_to_attribute'
+require 'domainic/attributer/undefined'
 
 module Domainic
   module Attributer
@@ -43,9 +44,12 @@ module Domainic
         # @param instance [Object] the instance on which to perform coercion
         # @param value [Object] the value to coerce
         #
-        # @return [Object] the coerced value
-        # @rbs (untyped instance, untyped value) -> untyped
+        # @return [Object, nil] the coerced value
+        # @rbs (untyped instance, untyped? value) -> untyped?
         def call(instance, value)
+          return value if value == Undefined
+          return value if value.nil? && !@attribute.signature.nilable?
+
           @handlers.reduce(value) { |accumulator, handler| coerce_value(instance, handler, accumulator) }
         end
 

--- a/domainic-attributer/lib/domainic/attributer/attribute/validator.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute/validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'domainic/attributer/attribute/mixin/belongs_to_attribute'
+require 'domainic/attributer/undefined'
 
 module Domainic
   module Attributer

--- a/domainic-attributer/sig/domainic/attributer/attribute/coercer.rbs
+++ b/domainic-attributer/sig/domainic/attributer/attribute/coercer.rbs
@@ -31,8 +31,8 @@ module Domainic
         # @param instance [Object] the instance on which to perform coercion
         # @param value [Object] the value to coerce
         #
-        # @return [Object] the coerced value
-        def call: (untyped instance, untyped value) -> untyped
+        # @return [Object, nil] the coerced value
+        def call: (untyped instance, untyped? value) -> untyped?
 
         private
 

--- a/domainic.gemspec
+++ b/domainic.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
     'wiki_uri' => "#{DOMAINIC_REPO_URL}/wiki"
   }
 
-  spec.add_dependency 'domainic-attributer', '>= 0.1', '< 0.2'
+  spec.add_dependency 'domainic-attributer', '>= 0.2', '< 0.3'
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -26,7 +26,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 7ad9c0f4805706e4cc2e840a8fbabfd14cef8e89
+    revision: 400a2ec166e056f0c6af06e1b2d42177dca0db0a
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -2,7 +2,7 @@
 path: ".gem_rbs_collection"
 gems:
 - name: domainic-attributer
-  version: 0.1.0
+  version: 0.2.0
   source:
     type: rubygems
 - name: domainic-dev


### PR DESCRIPTION
This improves how Domainic::Attributer handles nil values during attribute coercion. Currently, developers must manually handle nil values in coercion handlers, which leads to repetitive boilerplate code and potential inconsistencies in nil handling across attributes.

The solution implements a two-part approach:
1. Prevent coercion attempts on nil values for non-nilable attributes
2. Update documentation to clearly explain the behavior and best practices

Key Changes:
- Move responsibility for nil and Undefined value handling from Attribute to Coercer
- Skip coercion attempts when a value is nil and the attribute is not nilable
- Update documentation with comprehensive guidance for handling nilable vs non-nilable attributes
- Bump version to 0.2.0 to reflect breaking change in coercer behavior

This approach:
- Reduces boilerplate by eliminating need to handle nil in coercers for non-nilable attributes
- Improves type safety by preventing unintended nil transformations
- Maintains flexibility for nilable attributes where nil handling is desired
- Provides clear, documented patterns for working with nil values

Breaking Change:
`Coercer#call` will no longer attempt to coerce nil values when the attribute is not nilable. While this is technically breaking, it's unlikely to affect most codebases as it aligns with expected behavior.

Resolves #13