### PR TITLE
Fix Duplicate Validation Errors Raised on Invalid Attribute Values

### DIFF
--- a/domainic-attributer/sig/domainic/attributer/attribute/validator.rbs
+++ b/domainic-attributer/sig/domainic/attributer/attribute/validator.rbs
@@ -30,14 +30,6 @@ module Domainic
 
         include BelongsToAttribute
 
-        # Internal error class used to signal validation failures.
-        # This allows us to differentiate between our intentional validation
-        # failure signals and actual errors that occur during validation.
-        #
-        # @api private
-        class ValidationFailure < Error
-        end
-
         @handlers: Array[handler]
 
         # Initialize a new Validator instance.
@@ -73,14 +65,6 @@ module Domainic
         def handle_undefined!: () -> bool
 
         # Run all configured validations.
-        #
-        # Note on error handling strategy:
-        # We use a custom ValidationFailure error class internally to distinguish between
-        # two types of failures:
-        # 1. Normal validation failures (when a validator returns false) are converted
-        #    to ArgumentError to maintain the public API contract
-        # 2. All other errors that occur during validation execution (including
-        #    ArgumentError) are collected and wrapped in a ValidationExecutionError
         #
         # @param instance [Object] the instance on which to perform validation
         # @param value [Object] the value to validate


### PR DESCRIPTION
This fixes a bug introduced in #18 that would produce a confusing stack trace on validation failure.  This ensures that a single ArgumentError is raised when validation fails while maintaining the intended functionality of ValidationExecutionErrors.

Changelog:
  - fixed #18 Duplicate Validation Errors Raised on Invalid Attribute Values
  - removed `Domainic::Attributer::Validation::ValidationFailure`