### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A suite of Ruby libraries crafted to arm engineers with the magic of domain-driv
 Domainic is an ecosystem of Ruby gems designed to provide a comprehensive toolkit for domain-driven design. The v0.1.0
 release will include:
 
-* [domainic-attributer](https://github.com/domainic/domainic-attributer) - Type-safe, self-documenting class attributes
+* [domainic-attributer](https://github.com/domainic/domainic/tree/main/domainic-attributer) - Type-safe,
+  self-documenting class attributes
 * domainic-boundary - Clean interfaces between domain boundaries
 * domainic-command - First-class command objects for business operations
 * domainic-type - Sophisticated type constraints and validation

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -26,7 +26,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 400a2ec166e056f0c6af06e1b2d42177dca0db0a
+    revision: 56038c8a383c25bae14a891e3c0cc5c2e5a9c976
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock


### PR DESCRIPTION
This fixes a broken link to domainic-attributer in the main README.md file.

fixes #63