### PR TITLE
Refactor `Domainic::Type::Constraint::InclusionConstraint`

### DIFF
--- a/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
@@ -138,11 +138,7 @@ module Domainic
         # @return [EnumerableBehavior] self for method chaining
         # @rbs (*untyped entries) -> EnumerableBehavior
         def containing(*entries)
-          entries.each do |entry|
-            includes = @constraints.prepare :self, :inclusion, nil, entry
-            constrain :self, :and, includes, concerning: :inclusion, description: ''
-          end
-          self
+          constrain :self, :inclusion, entries
         end
 
         # Validate that the enumerable's size is at most a given value.

--- a/domainic-type/lib/domainic/type/constraint/behavior.rb
+++ b/domainic-type/lib/domainic/type/constraint/behavior.rb
@@ -292,7 +292,7 @@ module Domainic
         # @return [String] The full description.
         # @rbs (String description) -> String?
         def full_description_for(description)
-          return if quantifier_description.nil? || quantifier_description.to_s.include?('not_described')
+          return if quantifier_description.to_s.include?('not_described')
 
           if quantifier_description.is_a?(Symbol)
             "#{quantifier_description.to_s.split('_').join(' ')} #{description}"

--- a/domainic-type/sig/domainic/type/constraint/constraints/inclusion_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/inclusion_constraint.rbs
@@ -1,23 +1,37 @@
 module Domainic
   module Type
     module Constraint
-      # A constraint for validating that a collection includes a specific value.
+      # A constraint for validating that a collection includes one or more values.
       #
-      # This constraint verifies that a collection contains an expected value by using
+      # This constraint verifies that a collection contains expected values by using
       # the collection's #include? method. It works with any object that responds to
-      # #include?, such as Arrays, Sets, Strings, and Ranges.
+      # #include?, such as Arrays, Sets, Strings, and Ranges. The constraint can be
+      # configured to check for a single value or multiple values, and supports
+      # incremental addition of values to check.
       #
-      # @example Array inclusion validation
+      # @example Single value inclusion
       #   constraint = InclusionConstraint.new(:self, 2)
       #   constraint.satisfied?([1, 2, 3])  # => true
       #   constraint.satisfied?([1, 3, 4])  # => false
       #
-      # @example String inclusion validation
+      # @example Multiple value inclusion
+      #   constraint = InclusionConstraint.new(:self)
+      #   constraint.expecting([1, 2])
+      #   constraint.satisfied?([1, 2, 3])  # => true
+      #   constraint.satisfied?([1, 3])     # => false
+      #
+      # @example Incremental value addition
+      #   constraint = InclusionConstraint.new(:self)
+      #   constraint.expecting(1).expecting(2)
+      #   constraint.satisfied?([1, 2, 3])  # => true
+      #   constraint.satisfied?([1, 3])     # => false
+      #
+      # @example String inclusion
       #   constraint = InclusionConstraint.new(:self, 'b')
       #   constraint.satisfied?('abc')  # => true
       #   constraint.satisfied?('ac')   # => false
       #
-      # @example Range inclusion validation
+      # @example Range inclusion
       #   constraint = InclusionConstraint.new(:self, 5)
       #   constraint.satisfied?(1..10)  # => true
       #   constraint.satisfied?(11..20) # => false
@@ -26,33 +40,65 @@ module Domainic
       # @author {https://aaronmallen.me Aaron Allen}
       # @since 0.1.0
       class InclusionConstraint
-        include Behavior[untyped, untyped, { }]
+        include Behavior[Array[untyped], untyped, { }]
 
         # Get a human-readable description of the inclusion requirement.
         #
-        # @example
-        #   constraint = InclusionConstraint.new(:self, 42)
-        #   constraint.description # => "including 42"
+        # When checking for a single value, returns "including <value>". When checking
+        # for multiple values, returns a comma-separated list with "and" before the
+        # final value.
         #
-        # @return [String] A description of the inclusion requirement
+        # @example Single value
+        #   constraint = InclusionConstraint.new(:self, 42)
+        #   constraint.short_description # => "including 42"
+        #
+        # @example Multiple values
+        #   constraint = InclusionConstraint.new(:self)
+        #   constraint.expecting([1, 2, 3])
+        #   constraint.short_description # => "including 1, 2 and 3"
+        #
+        # @return [String] A description of the inclusion requirements
         def short_description: ...
 
         # Get a human-readable description of why inclusion validation failed.
         #
-        # @example
-        #   constraint = InclusionConstraint.new(:self, 42)
-        #   constraint.satisfied?([1, 2, 3])
-        #   constraint.short_violation_description # => "excluding 42"
+        # Returns a description listing only the values that were missing from
+        # the collection. If multiple values were missing, they are joined with
+        # commas and "and".
         #
-        # @return [String] A description of the inclusion failure
+        # @example Single missing value
+        #   constraint = InclusionConstraint.new(:self)
+        #   constraint.expecting(['a', 'b', 'c'])
+        #   constraint.satisfied?(['a', 'b'])
+        #   constraint.short_violation_description # => 'excluding "c"'
+        #
+        # @example Multiple missing values
+        #   constraint = InclusionConstraint.new(:self)
+        #   constraint.expecting(['a', 'b', 'c'])
+        #   constraint.satisfied?(['a'])
+        #   constraint.short_violation_description # => 'excluding "b" and "c"'
+        #
+        # @return [String] A description of which values were missing
         def short_violation_description: ...
 
-        # Check if the collection includes the expected value.
+        # Coerce the expectation into a collection of values to check.
         #
-        # Uses the collection's #include? method to verify that the expected
-        # value is present.
+        # This method handles both single values and collections of values:
+        # - Single values are appended to the existing collection
+        # - Enumerable values are concatenated with the existing collection
+        # This allows for both single-value checking and multiple-value checking,
+        # as well as incremental addition of values through multiple expecting() calls.
         #
-        # @return [Boolean] true if the collection includes the value
+        # @param expectation [Object, Enumerable] The value(s) to check for
+        # @return [Array] The collection of values to check for
+        def coerce_expectation: ...
+
+        # Check if the collection includes all expected values.
+        #
+        # Uses the collection's #include? method to verify that all expected
+        # values are present in the collection being validated.
+        #
+        # @return [Boolean] true if the collection includes all expected values
         def satisfies_constraint?: ...
       end
     end

--- a/domainic-type/spec/domainic/type/constraint/inclusion_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/inclusion_constraint_spec.rb
@@ -7,63 +7,102 @@ RSpec.describe Domainic::Type::Constraint::InclusionConstraint do
   describe '#expecting' do
     subject(:expecting) { constraint.expecting(new_value) }
 
-    let(:constraint) { described_class.new(:self).expecting(42) }
-    let(:new_value) { 100 }
+    context 'with single values' do
+      let(:constraint) { described_class.new(:self).expecting(42) }
+      let(:new_value) { 100 }
 
-    it 'is expected to update the expected value' do
-      expecting
-      expect(constraint.satisfied?([100])).to be true
+      it 'is expected to add to the expected values' do
+        expecting
+        expect(constraint.short_description).to eq('including 42 and 100')
+      end
+    end
+
+    context 'with enumerable values' do
+      let(:constraint) { described_class.new(:self).expecting(42) }
+      let(:new_value) { [100, 200] }
+
+      it 'is expected to add all values' do
+        expecting
+        expect(constraint.short_description).to eq('including 42, 100 and 200')
+      end
+    end
+
+    context 'when adding multiple times' do
+      let(:constraint) { described_class.new(:self) }
+
+      it 'is expected to accumulate values' do
+        constraint.expecting(1).expecting(2).expecting(3)
+        expect(constraint.short_description).to eq('including 1, 2 and 3')
+      end
     end
   end
 
   describe '#satisfied?' do
     subject(:satisfied?) { constraint.satisfied?(actual_value) }
 
-    let(:constraint) { described_class.new(:self).expecting(expected_value) }
+    context 'with single value' do
+      let(:constraint) { described_class.new(:self).expecting(expected_value) }
 
-    context 'with arrays' do
-      let(:expected_value) { 2 }
+      context 'with arrays' do
+        let(:expected_value) { 2 }
 
-      context 'when including the value' do
+        context 'when including the value' do
+          let(:actual_value) { [1, 2, 3] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when not including the value' do
+          let(:actual_value) { [1, 3, 4] }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'with ranges' do
+        let(:expected_value) { 5 }
+
+        context 'when including the value' do
+          let(:actual_value) { 1..10 }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when not including the value' do
+          let(:actual_value) { 11..20 }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'with strings' do
+        let(:expected_value) { 'b' }
+
+        context 'when including the value' do
+          let(:actual_value) { 'abc' }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when not including the value' do
+          let(:actual_value) { 'ac' }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'with multiple values' do
+      let(:constraint) { described_class.new(:self).expecting([1, 2]) }
+
+      context 'when including all values' do
         let(:actual_value) { [1, 2, 3] }
 
         it { is_expected.to be true }
       end
 
-      context 'when not including the value' do
-        let(:actual_value) { [1, 3, 4] }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'with ranges' do
-      let(:expected_value) { 5 }
-
-      context 'when including the value' do
-        let(:actual_value) { 1..10 }
-
-        it { is_expected.to be true }
-      end
-
-      context 'when not including the value' do
-        let(:actual_value) { 11..20 }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'with strings' do
-      let(:expected_value) { 'b' }
-
-      context 'when including the value' do
-        let(:actual_value) { 'abc' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'when not including the value' do
-        let(:actual_value) { 'ac' }
+      context 'when missing some values' do
+        let(:actual_value) { [1, 3] }
 
         it { is_expected.to be false }
       end
@@ -73,18 +112,64 @@ RSpec.describe Domainic::Type::Constraint::InclusionConstraint do
   describe '#short_description' do
     subject(:short_description) { constraint.short_description }
 
-    let(:constraint) { described_class.new(:self).expecting(expected_value) }
-    let(:expected_value) { 42 }
+    context 'with single value' do
+      let(:constraint) { described_class.new(:self).expecting(42) }
 
-    it { is_expected.to eq('including 42') }
+      it { is_expected.to eq('including 42') }
+    end
+
+    context 'with two values' do
+      let(:constraint) { described_class.new(:self).expecting([1, 2]) }
+
+      it { is_expected.to eq('including 1 and 2') }
+    end
+
+    context 'with more than two values' do
+      let(:constraint) { described_class.new(:self).expecting([1, 2, 3]) }
+
+      it { is_expected.to eq('including 1, 2 and 3') }
+    end
   end
 
   describe '#short_violation_description' do
-    subject(:short_violation_description) { constraint.short_violation_description }
+    subject(:short_violation_description) do
+      constraint.satisfied?(actual_value)
+      constraint.short_violation_description
+    end
 
-    let(:constraint) { described_class.new(:self).expecting(expected_value) }
-    let(:expected_value) { 42 }
+    context 'with single value' do
+      let(:constraint) { described_class.new(:self).expecting(42) }
+      let(:actual_value) { [] }
 
-    it { is_expected.to eq('excluding 42') }
+      it { is_expected.to eq('excluding 42') }
+    end
+
+    context 'with multiple values' do
+      let(:constraint) { described_class.new(:self).expecting([1, 2, 3]) }
+
+      context 'when missing one value' do
+        let(:actual_value) { [1, 2] }
+
+        it { is_expected.to eq('excluding 3') }
+      end
+
+      context 'when missing two values' do
+        let(:actual_value) { [1] }
+
+        it { is_expected.to eq('excluding 2 and 3') }
+      end
+
+      context 'when missing all values' do
+        let(:actual_value) { [] }
+
+        it { is_expected.to eq('excluding 1, 2 and 3') }
+      end
+
+      context 'with out of order matches' do
+        let(:actual_value) { [3, 1] }
+
+        it { is_expected.to eq('excluding 2') }
+      end
+    end
   end
 end


### PR DESCRIPTION
Refines the InclusionConstraint's error reporting to only show values that failed the inclusion test rather than all values. This makes the error messages more precise and useful by showing exactly which expected values were missing from the collection.

For example, given a type expecting values "a", "b", and "c", if "c" is the only missing value, the error now shows:
Expected Array(including "a", "b" and "c"), but got Array(excluding "c")

Instead of the previous:
Expected Array(including "a", "b" and "c"), but got Array(excluding "a", "b" and "c")

Key changes:
- Filter expected values in short_violation_description to show only missing ones
- Add tests for various missing value scenarios
- Update documentation with examples of the new behavior
- Add test coverage for edge cases like out-of-order matches

This makes the error messages more helpful for debugging by clearly showing which values need to be added to satisfy the constraint.