### PR TITLE
Add `Domainic::Type::AnythingType`

### DIFF
--- a/domainic-type/lib/domainic/type/constraint/constraints/and_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/and_constraint.rb
@@ -36,7 +36,11 @@ module Domainic
         # @return [String] a description combining all constraint descriptions with 'and'
         # @rbs override
         def short_description
-          @expected.map(&:short_description).join(' and ')
+          descriptions = @expected.map(&:short_description)
+          return descriptions.first if descriptions.size == 1
+
+          *first, last = descriptions
+          "#{first.join(', ')} and #{last}"
         end
 
         # @rbs! def expecting: (Behavior[untyped, untyped, untyped]) -> self
@@ -49,7 +53,12 @@ module Domainic
         # @return [String] The combined violation descriptions from all constraints
         # @rbs override
         def short_violation_description
-          @expected.map(&:short_violation_description).join(' and ')
+          violations = @expected.reject { |constraint| constraint.satisfied?(@actual) }
+          descriptions = violations.map(&:short_violation_description)
+          return descriptions.first if descriptions.size == 1
+
+          *first, last = descriptions
+          "#{first.join(', ')} and #{last}"
         end
 
         protected
@@ -62,9 +71,9 @@ module Domainic
         # @param expectation [Behavior] the constraint to add
         #
         # @return [Array<Behavior>] the updated array of constraints
-        # @rbs (Behavior[untyped, untyped, untyped] expectation) -> Array[Behavior[untyped, untyped, untyped]]
+        # @rbs (untyped expectation) -> Array[Behavior[untyped, untyped, untyped]]
         def coerce_expectation(expectation)
-          @expected.is_a?(Array) ? @expected.push(expectation) : [expectation]
+          expectation.is_a?(Array) ? (@expected || []).concat(expectation) : (@expected || []) << expectation
         end
 
         # Check if the value satisfies all expected constraints.

--- a/domainic-type/lib/domainic/type/constraint/constraints/not_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/not_constraint.rb
@@ -45,7 +45,7 @@ module Domainic
         # @return [String] The description of the constraint when it fails.
         # @rbs override
         def short_violation_description
-          "not #{@expected.short_description}"
+          @expected.short_description
         end
 
         protected

--- a/domainic-type/lib/domainic/type/types/anything_type.rb
+++ b/domainic-type/lib/domainic/type/types/anything_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+
+module Domainic
+  module Type
+    # @since 0.1.0
+    class AnythingType
+      include Behavior
+
+      def but(*types)
+        not_types = types.map do |type|
+          @constraints.prepare(:self, :not, @constraints.prepare(:self, :type, type))
+        end
+        constrain :self, :and, not_types, concerning: :exclusion
+      end
+      alias except but
+      alias excluding but
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/constraints/and_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/and_constraint.rbs
@@ -50,7 +50,7 @@ module Domainic
         # @param expectation [Behavior] the constraint to add
         #
         # @return [Array<Behavior>] the updated array of constraints
-        def coerce_expectation: (Behavior[untyped, untyped, untyped] expectation) -> Array[Behavior[untyped, untyped, untyped]]
+        def coerce_expectation: (untyped expectation) -> Array[Behavior[untyped, untyped, untyped]]
 
         # Check if the value satisfies all expected constraints.
         #

--- a/domainic-type/sig/domainic/type/types/anything_type.rbs
+++ b/domainic-type/sig/domainic/type/types/anything_type.rbs
@@ -1,0 +1,10 @@
+module Domainic
+  module Type
+    # @since 0.1.0
+    class AnythingType
+      include Behavior
+
+      def but: (*untyped types) -> untyped
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/anything_type_spec.rb
+++ b/domainic-type/spec/domainic/type/anything_type_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/anything_type'
+
+RSpec.describe Domainic::Type::AnythingType do
+  describe '#validate' do
+    subject(:validate) { type.validate(value) }
+
+    let(:type) { described_class.new }
+    let(:value) { 'anything' }
+
+    it { is_expected.to be true }
+
+    context 'when excluding a type' do
+      before { type.but(String) }
+
+      context 'with an invalid value' do
+        it { is_expected.to be false }
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/and_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/and_constraint_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Domainic::Type::Constraint::AndConstraint do
     before { constraint.satisfied?(actual_value) }
 
     context 'when no constraints are satisfied' do
-      let(:actual_value) { 123 }
+      let(:actual_value) { [] }
 
       it 'joins violation short_descriptions with and' do
         expect(short_violation_description).to eq('was not a string and was empty')

--- a/domainic-type/spec/domainic/type/constraint/not_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/not_constraint_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Domainic::Type::Constraint::NotConstraint do
     before { constraint.satisfied?(value) }
 
     it 'negates the inner constraint failure short_description' do
-      expect(short_violation_description).to eq('not be a string')
+      expect(short_violation_description).to eq('be a string')
     end
   end
 end


### PR DESCRIPTION
This commit introduces a new `AnythingType` that validates successfully for all values except explicitly excluded ones. Additionally, it refines error messaging in the `AndConstraint` and `NotConstraint` classes to improve clarity.

Changelog:
  - added `Domainic::Type::AnythingType`
  - changed `Domainic::Type::Constraint::NotConstraint` to no longer prefix violation messages with "not"
  - changed `Domainic::Type::Constraint::AndConstraint` to only use "and" before the final expectation
  - fixed `Domainic::Type::Constraint::AndConstraint` to accept a single constraint as an argument for `#expecting`

resolves #59