### PR TITLE
Add `Domainic::Type::DuckType` and related constraints

### DIFF
--- a/domainic-type/lib/domainic/type/constraint/constraints/method_presence_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/method_presence_constraint.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'domainic/type/constraint/behavior'
+
+module Domainic
+  module Type
+    module Constraint
+      # A constraint that validates whether an object responds to a specified method
+      #
+      # This constraint checks if an object implements a particular interface by verifying
+      # it responds to a given method name. The method name must be provided as a Symbol.
+      #
+      # @example
+      #   constraint = MethodPresenceConstraint.new(:to_s)
+      #   constraint.satisfied_by?(Object.new)  # => true
+      #   constraint.satisfied_by?(BasicObject.new)  # => false
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class MethodPresenceConstraint
+        include Behavior #[Symbol, untyped, {}]
+
+        # Get a short description of what this constraint expects
+        #
+        # @return [String] description of the expected method
+        # @rbs override
+        def short_description
+          "responding to #{@expected}"
+        end
+
+        # Get a short description of why the constraint was violated
+        #
+        # @return [String] description of the missing method
+        # @rbs override
+        def short_violation_description
+          "not responding to #{@expected}"
+        end
+
+        protected
+
+        # Coerce the expectation into a symbol
+        #
+        # @param expectation [Symbol] the method name to check
+        #
+        # @return [Symbol] coerced method name
+        # @rbs override
+        def coerce_expectation(expectation)
+          expectation.to_sym
+        end
+
+        # Check if the actual value satisfies the constraint
+        #
+        # @return [Boolean] true if the object responds to the expected method
+        # @rbs override
+        def satisfies_constraint?
+          @actual.respond_to?(@expected)
+        end
+
+        # Validate that the expectation is a Symbol
+        #
+        # @param expectation [Object] the expectation to validate
+        #
+        # @raise [ArgumentError] if the expectation is not a Symbol
+        # @return [void]
+        # @rbs override
+        def validate_expectation!(expectation)
+          raise ArgumentError, 'Expectation must be a Symbol' unless expectation.is_a?(Symbol)
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/types/anything_type.rb
+++ b/domainic-type/lib/domainic/type/types/anything_type.rb
@@ -8,6 +8,7 @@ module Domainic
     class AnythingType
       include Behavior
 
+      # @rbs (*untyped types) -> self
       def but(*types)
         not_types = types.map do |type|
           @constraints.prepare(:self, :not, @constraints.prepare(:self, :type, type))

--- a/domainic-type/lib/domainic/type/types/duck_type.rb
+++ b/domainic-type/lib/domainic/type/types/duck_type.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+
+module Domainic
+  module Type
+    # A type that validates objects based on their method interface
+    #
+    # This type implements duck typing validation by checking whether objects respond
+    # to specific methods. It supports both positive validation (must respond to methods)
+    # and negative validation (must not respond to methods).
+    #
+    # @example Validating a simple interface
+    #   type = DuckType.responding_to(:to_s).not_responding_to(:to_h)
+    #   type.validate("string")  # => true
+    #   type.validate(Object.new)  # => true
+    #   type.validate({})  # => false (responds to :to_h)
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class DuckType
+      include Behavior
+
+      # Add method presence constraints to the type
+      #
+      # @example
+      #   type = DuckType.new.responding_to(:foo, :bar)
+      #
+      # @param methods [Array<String, Symbol>] the methods that must be present
+      #
+      # @return [self] the type for method chaining
+      # @rbs (*String | Symbol methods) -> self
+      def responding_to(*methods)
+        methods = methods.map { |method| @constraints.prepare :self, :method_presence, method }
+        constrain :self, :and, methods, concerning: :method_presence
+      end
+
+      # Add method exclusion constraints to the type
+      #
+      # @example
+      #   type = DuckType.new.not_responding_to(:foo, :bar)
+      #
+      # @param methods [Array<String, Symbol>] the methods that must not be present
+      #
+      # @return [self] the type for method chaining
+      # @rbs (*String | Symbol methods) -> self
+      def not_responding_to(*methods)
+        not_methods = methods.map do |method|
+          @constraints.prepare(:self, :not, @constraints.prepare(:self, :method_presence, method))
+        end
+        constrain :self, :and, not_methods, concerning: :method_exclusion
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/constraints/method_presence_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/method_presence_constraint.rbs
@@ -1,0 +1,51 @@
+module Domainic
+  module Type
+    module Constraint
+      # A constraint that validates whether an object responds to a specified method
+      #
+      # This constraint checks if an object implements a particular interface by verifying
+      # it responds to a given method name. The method name must be provided as a Symbol.
+      #
+      # @example
+      #   constraint = MethodPresenceConstraint.new(:to_s)
+      #   constraint.satisfied_by?(Object.new)  # => true
+      #   constraint.satisfied_by?(BasicObject.new)  # => false
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class MethodPresenceConstraint
+        include Behavior[Symbol, untyped, { }]
+
+        # Get a short description of what this constraint expects
+        #
+        # @return [String] description of the expected method
+        def short_description: ...
+
+        # Get a short description of why the constraint was violated
+        #
+        # @return [String] description of the missing method
+        def short_violation_description: ...
+
+        # Coerce the expectation into a symbol
+        #
+        # @param expectation [Symbol] the method name to check
+        #
+        # @return [Symbol] coerced method name
+        def coerce_expectation: ...
+
+        # Check if the actual value satisfies the constraint
+        #
+        # @return [Boolean] true if the object responds to the expected method
+        def satisfies_constraint?: ...
+
+        # Validate that the expectation is a Symbol
+        #
+        # @param expectation [Object] the expectation to validate
+        #
+        # @raise [ArgumentError] if the expectation is not a Symbol
+        # @return [void]
+        def validate_expectation!: ...
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/types/anything_type.rbs
+++ b/domainic-type/sig/domainic/type/types/anything_type.rbs
@@ -4,7 +4,7 @@ module Domainic
     class AnythingType
       include Behavior
 
-      def but: (*untyped types) -> untyped
+      def but: (*untyped types) -> self
 
       alias except but
 

--- a/domainic-type/sig/domainic/type/types/duck_type.rbs
+++ b/domainic-type/sig/domainic/type/types/duck_type.rbs
@@ -1,0 +1,41 @@
+module Domainic
+  module Type
+    # A type that validates objects based on their method interface
+    #
+    # This type implements duck typing validation by checking whether objects respond
+    # to specific methods. It supports both positive validation (must respond to methods)
+    # and negative validation (must not respond to methods).
+    #
+    # @example Validating a simple interface
+    #   type = DuckType.responding_to(:to_s).not_responding_to(:to_h)
+    #   type.validate("string")  # => true
+    #   type.validate(Object.new)  # => true
+    #   type.validate({})  # => false (responds to :to_h)
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class DuckType
+      include Behavior
+
+      # Add method presence constraints to the type
+      #
+      # @example
+      #   type = DuckType.new.responding_to(:foo, :bar)
+      #
+      # @param methods [Array<String, Symbol>] the methods that must be present
+      #
+      # @return [self] the type for method chaining
+      def responding_to: (*String | Symbol methods) -> self
+
+      # Add method exclusion constraints to the type
+      #
+      # @example
+      #   type = DuckType.new.not_responding_to(:foo, :bar)
+      #
+      # @param methods [Array<String, Symbol>] the methods that must not be present
+      #
+      # @return [self] the type for method chaining
+      def not_responding_to: (*String | Symbol methods) -> self
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/constraint/method_presence_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/method_presence_constraint_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/constraint/constraints/method_presence_constraint'
+
+RSpec.describe Domainic::Type::Constraint::MethodPresenceConstraint do
+  let(:test_object) do
+    Class.new do
+      def test_method; end
+    end.new
+  end
+
+  describe '#satisfied?' do
+    subject(:satisfied?) { constraint.satisfied?(test_object) }
+
+    let(:constraint) { described_class.new(:self).expecting(expectation) }
+
+    context 'when the object responds to the method' do
+      let(:expectation) { :test_method }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the object does not respond to the method' do
+      let(:expectation) { :missing_method }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#short_description' do
+    subject(:short_description) { constraint.short_description }
+
+    let(:constraint) { described_class.new(:self).expecting(:test_method) }
+
+    it { is_expected.to eq('responding to test_method') }
+  end
+
+  describe '#short_violation_description' do
+    subject(:short_violation_description) do
+      constraint.satisfied?(test_object)
+      constraint.short_violation_description
+    end
+
+    let(:constraint) { described_class.new(:self).expecting(:missing_method) }
+
+    it { is_expected.to eq('not responding to missing_method') }
+  end
+end

--- a/domainic-type/spec/domainic/type/duck_type_spec.rb
+++ b/domainic-type/spec/domainic/type/duck_type_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/duck_type'
+
+RSpec.describe Domainic::Type::DuckType do
+  describe '#validate' do
+    subject(:validate) { type.validate(test_object) }
+
+    let(:type) { described_class.new }
+    let(:test_object) do
+      Struct.new(:foo, :bar) do
+        def baz; end
+      end.new('foo', 'bar')
+    end
+
+    context 'when checking method presence' do
+      before { type.responding_to(:foo, :baz) }
+
+      context 'when all required methods are present' do
+        it { is_expected.to be true }
+      end
+
+      context 'when a required method is missing' do
+        before { type.responding_to(:missing) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when checking method exclusion' do
+      before { type.not_responding_to(:qux, :quux) }
+
+      context 'when no excluded methods are present' do
+        it { is_expected.to be true }
+      end
+
+      context 'when an excluded method is present' do
+        before { type.not_responding_to(:foo) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when combining presence and exclusion' do
+      before do
+        type.responding_to(:foo, :baz)
+            .not_responding_to(:qux)
+      end
+
+      it { is_expected.to be true }
+
+      context 'when adding an excluded method that exists' do
+        before { type.not_responding_to(:bar) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when adding a required method that is missing' do
+        before { type.responding_to(:missing) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for duck typing validation by introducing two new components:

1. `MethodPresenceConstraint` - A base constraint that validates whether an object responds to a specified method
2. `DuckType` - A type that validates objects based on their method interface, supporting both required and excluded methods

Example usage:
```ruby
# Create a type that requires :foo but must not have :bar
type = Domainic::Type::DuckType.responding_to(:foo).not_responding_to(:bar)

# Test some objects
obj1 = Struct.new(:foo).new('foo')
type.validate(obj1) #=> true  # has :foo but not :bar

obj2 = Struct.new(:foo, :bar).new('foo', 'bar') 
type.validate(obj2) #=> false  # has :bar which is excluded

obj3 = Struct.new(:baz).new('baz')
type.validate(obj3) #=> false  # missing required :foo
```

This implements flexible type validation based on method presence rather than class hierarchy, following Ruby's duck typing principles.

resolves #56 
resolves #60