### PR TITLE
Add type-level coercion support to constraints

### DIFF
--- a/domainic-type/lib/domainic/type/behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior.rb
@@ -113,6 +113,7 @@ module Domainic
         #   String | Symbol constraint_type,
         #   ?untyped expectation,
         #   ?abort_on_failure: bool,
+        #   ?coerce_with: Array[Proc] | Proc,
         #   ?concerning: String | Symbol,
         #   ?description: String | Symbol
         #   ) -> void
@@ -233,6 +234,7 @@ module Domainic
       #   String | Symbol constraint_type,
       #   ?untyped expectation,
       #   ?abort_on_failure: bool,
+      #   ?coerce_with: Array[Proc] | Proc,
       #   ?concerning: String | Symbol,
       #   ?description: String | Symbol
       #   ) -> self

--- a/domainic-type/lib/domainic/type/constraint/set.rb
+++ b/domainic-type/lib/domainic/type/constraint/set.rb
@@ -64,6 +64,8 @@ module Domainic
         # @option options [String, Symbol, nil] description The quantifier description of the constraint when given
         #   a string that ends with "not_described" it will not be included in the constraint set description.
         # @option options [Boolean] :abort_on_failure Whether to stop on failure
+        # @option options [Array<Proc>, Proc] :coerce_with Coercers to run on the value before validating the
+        #   constraint.
         #
         # @return [void]
         # @rbs (
@@ -203,6 +205,8 @@ module Domainic
         # @option options [String, Symbol, nil] description The quantifier description of the constraint when given
         #   a string that ends with "not_described" it will not be included in the constraint set description.
         # @option options [Boolean] :abort_on_failure Whether to stop on failure
+        # @option options [Array<Proc>, Proc] :coerce_with Coercers to run on the value before validating the
+        #   constraint.
         #
         # @return [Behavior] The new constraint instance
         # @rbs (

--- a/domainic-type/sig/domainic/type/behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior.rbs
@@ -90,7 +90,7 @@ module Domainic
         # @see Constraint::Set#add
         #
         # @return [void]
-        def intrinsic: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, ?abort_on_failure: bool, ?concerning: String | Symbol, ?description: String | Symbol) -> void
+        def intrinsic: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, ?abort_on_failure: bool, ?coerce_with: Array[Proc] | Proc, ?concerning: String | Symbol, ?description: String | Symbol) -> void
 
         # Get the set of intrinsic constraints for this type.
         #
@@ -149,7 +149,7 @@ module Domainic
       # @see Constraint::Set#add
       #
       # @return [self]
-      def constrain: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, ?abort_on_failure: bool, ?concerning: String | Symbol, ?description: String | Symbol) -> self
+      def constrain: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, ?abort_on_failure: bool, ?coerce_with: Array[Proc] | Proc, ?concerning: String | Symbol, ?description: String | Symbol) -> self
     end
   end
 end

--- a/domainic-type/sig/domainic/type/constraint/behavior.rbs
+++ b/domainic-type/sig/domainic/type/constraint/behavior.rbs
@@ -43,7 +43,7 @@ module Domainic
       # @author {https://aaronmallen.me Aaron Allen}
       # @since 0.1.0
       module Behavior[Expected < Object, Actual < Object, Options < Hash[Symbol, untyped]]
-        type options = { ?abort_on_failure: bool }
+        type options = { ?abort_on_failure: bool, ?coerce_with: Array[Proc] | Proc }
 
         @result: bool?
 
@@ -146,6 +146,8 @@ module Domainic
         #
         # @param options [Hash{String, Symbol => Object}] Additional options
         # @option options [Boolean] :abort_on_failure (false) Whether to {#abort_on_failure?}
+        # @option options [Array<Proc>, Proc] :coerce_with Coercers to run on the value before validating the
+        #   constraint.
         #
         # @return [self] The constraint instance.
         def with_options: (?options & Options options) -> self
@@ -164,7 +166,18 @@ module Domainic
         # @param actual [Object] The actual value to coerce.
         #
         # @return [Object] The coerced value.
-        def coerce_actual: (Actual actual) -> Actual
+        def coerce_actual: (untyped actual) -> Actual
+
+        # Coerce actual values using type-provided coercion procs
+        #
+        # This method processes the actual value through any type-level coercion procs
+        # that were provided via options. This runs after the constraint's own coercion
+        # but before validation.
+        #
+        # @param actual [Object] The actual value to coerce
+        #
+        # @return [Object] The coerced value
+        def coerce_actual_for_type: (untyped actual) -> untyped
 
         # Coerce the expected value into the expected type.
         #

--- a/domainic-type/sig/domainic/type/constraint/set.rbs
+++ b/domainic-type/sig/domainic/type/constraint/set.rbs
@@ -53,6 +53,8 @@ module Domainic
         # @option options [String, Symbol, nil] description The quantifier description of the constraint when given
         #   a string that ends with "not_described" it will not be included in the constraint set description.
         # @option options [Boolean] :abort_on_failure Whether to stop on failure
+        # @option options [Array<Proc>, Proc] :coerce_with Coercers to run on the value before validating the
+        #   constraint.
         #
         # @return [void]
         def add: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> void
@@ -125,6 +127,8 @@ module Domainic
         # @option options [String, Symbol, nil] description The quantifier description of the constraint when given
         #   a string that ends with "not_described" it will not be included in the constraint set description.
         # @option options [Boolean] :abort_on_failure Whether to stop on failure
+        # @option options [Array<Proc>, Proc] :coerce_with Coercers to run on the value before validating the
+        #   constraint.
         #
         # @return [Behavior] The new constraint instance
         def prepare: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> Behavior


### PR DESCRIPTION
Added support for type-provided coercion procs in constraints while maintaining the existing constraint-level coercion system. This allows types to provide custom coercion logic that runs after the constraint's own coercion but before validation.

Key changes:
- Added coerce_actual_for_type method to handle type coercion
- Integrated type coercion into the constraint validation pipeline
- Added full test coverage for type coercion scenarios
- Updated documentation with new coercion details

Type coercion runs after constraint coercion but before validation, enabling a clean separation of concerns while maintaining composability. Failures in type coercion cause validation to fail gracefully.

Changelog:
- changed `Constraint::Behavior#satisfied?` to use type coercion

resolves #83