### PR TITLE
Bump dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     github-markup (5.0.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.9.0)
+    json (2.9.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -55,7 +55,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.3)
+    logger (1.6.4)
     mdl (0.13.0)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.1)
@@ -159,7 +159,7 @@ GEM
     webrick (1.9.1)
     yard (0.9.37)
     yard-sitemap (1.0.1)
-    zlib (3.2.0)
+    zlib (3.2.1)
 
 PLATFORMS
   arm64-darwin-23

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 56038c8a383c25bae14a891e3c0cc5c2e5a9c976
+    revision: 71fb7ae83789ae150bdee1cd8a7cd3035b5d79e2
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock


### PR DESCRIPTION
This bumps a few dependencies and updates the rbs collection

* bumps json from 2.9.0 -> 2.9.1
* bumps logger from 1.6.3 -> 1.6.4
* bumps thor signatures to new revision