### PR TITLE
Add `rubocop-ordered_methods` and fix method ordering

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-on-rbs
+  - rubocop-ordered_methods
   - rubocop-performance
   - rubocop-rspec
   - rubocop-yard

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :lint do
   gem 'mdl', require: false
   gem 'rubocop', require: false
   gem 'rubocop-on-rbs', require: false
+  gem 'rubocop-ordered_methods', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-yard', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       rbs (~> 3.5)
       rubocop (~> 1.61)
       zlib
+    rubocop-ordered_methods (0.13)
+      rubocop (>= 1.0)
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -176,6 +178,7 @@ DEPENDENCIES
   rspec
   rubocop
   rubocop-on-rbs
+  rubocop-ordered_methods
   rubocop-performance
   rubocop-rspec
   rubocop-yard

--- a/domainic-attributer/lib/domainic/attributer/class_methods.rb
+++ b/domainic-attributer/lib/domainic/attributer/class_methods.rb
@@ -164,6 +164,14 @@ module Domainic
 
       private
 
+      # Get the attribute set for this class
+      #
+      # @return [AttributeSet] the set of attributes defined for this class
+      # @rbs () -> AttributeSet
+      def __attributes__
+        @__attributes__ ||= AttributeSet.new(self)
+      end
+
       # Handle class inheritance for attributes
       #
       # Ensures that subclasses inherit a copy of their parent's attributes while
@@ -175,14 +183,6 @@ module Domainic
       def inherited(subclass)
         super
         subclass.instance_variable_set(:@__attributes__, __attributes__.dup_with_base(subclass))
-      end
-
-      # Get the attribute set for this class
-      #
-      # @return [AttributeSet] the set of attributes defined for this class
-      # @rbs () -> AttributeSet
-      def __attributes__
-        @__attributes__ ||= AttributeSet.new(self)
       end
     end
   end

--- a/domainic-attributer/sig/domainic/attributer/class_methods.rbs
+++ b/domainic-attributer/sig/domainic/attributer/class_methods.rbs
@@ -75,6 +75,11 @@ module Domainic
 
       private
 
+      # Get the attribute set for this class
+      #
+      # @return [AttributeSet] the set of attributes defined for this class
+      def __attributes__: () -> AttributeSet
+
       # Handle class inheritance for attributes
       #
       # Ensures that subclasses inherit a copy of their parent's attributes while
@@ -83,11 +88,6 @@ module Domainic
       # @param subclass [Class] the inheriting class
       # @return [void]
       def inherited: (Class | Module subclass) -> void
-
-      # Get the attribute set for this class
-      #
-      # @return [AttributeSet] the set of attributes defined for this class
-      def __attributes__: () -> AttributeSet
     end
   end
 end

--- a/domainic-attributer/spec/domainic/attributer/attribute_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/attribute_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Domainic::Attributer::Attribute do
         @test = nil
       end
 
-      def generate_value
-        'generated'
-      end
-
       def coerce_value(value)
         @coerced << value
         "coerced: #{value}"
+      end
+
+      def generate_value
+        'generated'
       end
 
       def record_change(old_value, new_value)

--- a/domainic-attributer/spec/domainic/attributer/dsl/initializer_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/dsl/initializer_spec.rb
@@ -108,12 +108,12 @@ RSpec.describe Domainic::Attributer::DSL::Initializer do
         @arg_attribute ||= build_attribute(:required_arg, arg_signature)
       end
 
-      def opt_attribute
-        @opt_attribute ||= build_attribute(:optional, opt_signature)
-      end
-
       def arg_selection
         @arg_selection ||= instance_double(Domainic::Attributer::AttributeSet, attributes: [arg_attribute])
+      end
+
+      def opt_attribute
+        @opt_attribute ||= build_attribute(:optional, opt_signature)
       end
 
       def opt_selection
@@ -134,20 +134,20 @@ RSpec.describe Domainic::Attributer::DSL::Initializer do
 
   private
 
-  def build_signature(argument: false, option: false)
-    instance_double(
-      Domainic::Attributer::Attribute::Signature,
-      argument?: argument,
-      option?: option
-    )
-  end
-
   def build_attribute(name, signature)
     instance_double(
       Domainic::Attributer::Attribute,
       default?: !signature.argument?,
       name: name,
       signature: signature
+    )
+  end
+
+  def build_signature(argument: false, option: false)
+    instance_double(
+      Domainic::Attributer::Attribute::Signature,
+      argument?: argument,
+      option?: option
     )
   end
 end

--- a/domainic-dev/lib/domainic/dev/cli/command/lint_markdown_command.rb
+++ b/domainic-dev/lib/domainic/dev/cli/command/lint_markdown_command.rb
@@ -43,6 +43,16 @@ module Domainic
             end
           end
 
+          # Set the exit status based on linting results.
+          #
+          # @return [void]
+          # @rbs () -> void
+          def exit_status
+            return if results.all? { |result| result[:success] }
+
+            exit 1
+          end
+
           # Print additional documentation messages for linting failures.
           #
           # @return [void]
@@ -52,16 +62,6 @@ module Domainic
 
             puts "\nFurther documentation is available for these failures:"
             documentation_messages.each { |message| puts " #{message}" }
-          end
-
-          # Set the exit status based on linting results.
-          #
-          # @return [void]
-          # @rbs () -> void
-          def exit_status
-            return if results.all? { |result| result[:success] }
-
-            exit 1
           end
 
           private

--- a/domainic-dev/lib/domainic/dev/gem.rb
+++ b/domainic-dev/lib/domainic/dev/gem.rb
@@ -82,16 +82,6 @@ module Domainic
 
       private
 
-      # Initialize gem information from gemspec.
-      #
-      # @return [void]
-      # @rbs () -> void
-      def initialize_with_gemspec
-        spec = ::Gem::Specification.load(paths.gemspec.to_s) # steep:ignore
-        @dependencies = spec.dependencies
-        @name = spec.name
-      end
-
       # Initialize version information.
       #
       # @return [void]
@@ -102,6 +92,16 @@ module Domainic
         raise "#{name} gemspec is missing a valid SEMVER" unless semver
 
         @version = Version.new(semver)
+      end
+
+      # Initialize gem information from gemspec.
+      #
+      # @return [void]
+      # @rbs () -> void
+      def initialize_with_gemspec
+        spec = ::Gem::Specification.load(paths.gemspec.to_s) # steep:ignore
+        @dependencies = spec.dependencies
+        @name = spec.name
       end
     end
   end

--- a/domainic-dev/lib/domainic/dev/generator/gem_generator.rb
+++ b/domainic-dev/lib/domainic/dev/generator/gem_generator.rb
@@ -37,14 +37,6 @@ module Domainic
           assign_names!(name)
         end
 
-        # Create the gem's gemspec file.
-        #
-        # @return [void]
-        # @rbs () -> void
-        def create_gemspec
-          template('gemspec.erb', "#{name}/#{name}.gemspec") # steep:ignore NoMethod
-        end
-
         # Create the gem's CHANGELOG file.
         #
         # @return [void]
@@ -53,12 +45,29 @@ module Domainic
           template('CHANGELOG.md.erb', "#{name}/CHANGELOG.md") # steep:ignore NoMethod
         end
 
+        # Create the gem's gemspec file.
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_gemspec
+          template('gemspec.erb', "#{name}/#{name}.gemspec") # steep:ignore NoMethod
+        end
+
         # Create the gem's LICENSE file.
         #
         # @return [void]
         # @rbs () -> void
         def create_license
           template('LICENSE', "#{name}/LICENSE") # steep:ignore NoMethod
+        end
+
+        # Create the module's main library file.
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_module_lib_file
+          dest = [name, 'lib', directory_name, "#{file_name}.rb"].join('/')
+          template('lib/module.rb.erb', dest) # steep:ignore NoMethod
         end
 
         # Create the gem's README file.
@@ -79,23 +88,6 @@ module Domainic
           template('lib/root.rb.erb', "#{name}/lib/#{name}.rb") # steep:ignore NoMethod
         end
 
-        # Create the module's main library file.
-        #
-        # @return [void]
-        # @rbs () -> void
-        def create_module_lib_file
-          dest = [name, 'lib', directory_name, "#{file_name}.rb"].join('/')
-          template('lib/module.rb.erb', dest) # steep:ignore NoMethod
-        end
-
-        # Create the gem's spec_helper file.
-        #
-        # @return [void]
-        # @rbs () -> void
-        def create_spec_helper
-          template('spec/spec_helper.rb.erb', "#{name}/spec/spec_helper.rb") # steep:ignore NoMethod
-        end
-
         # Create the root spec file.
         #
         # @return [void]
@@ -112,6 +104,14 @@ module Domainic
         def create_signature_manifest
           dest = [name, 'sig', 'manifest.yaml'].join('/')
           template('sig/manifest.yaml.erb', dest) # steep:ignore NoMethod
+        end
+
+        # Create the gem's spec_helper file.
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_spec_helper
+          template('spec/spec_helper.rb.erb', "#{name}/spec/spec_helper.rb") # steep:ignore NoMethod
         end
 
         # Generate RBS signatures for the new gem.

--- a/domainic-dev/sig/domainic/dev/cli/command/lint_markdown_command.rbs
+++ b/domainic-dev/sig/domainic/dev/cli/command/lint_markdown_command.rbs
@@ -24,15 +24,15 @@ module Domainic
           # @return [void]
           def execute: () -> void
 
-          # Print additional documentation messages for linting failures.
-          #
-          # @return [void]
-          def print_documentation_messages: () -> void
-
           # Set the exit status based on linting results.
           #
           # @return [void]
           def exit_status: () -> void
+
+          # Print additional documentation messages for linting failures.
+          #
+          # @return [void]
+          def print_documentation_messages: () -> void
 
           private
 

--- a/domainic-dev/sig/domainic/dev/gem.rbs
+++ b/domainic-dev/sig/domainic/dev/gem.rbs
@@ -58,16 +58,16 @@ module Domainic
 
       private
 
-      # Initialize gem information from gemspec.
-      #
-      # @return [void]
-      def initialize_with_gemspec: () -> void
-
       # Initialize version information.
       #
       # @return [void]
       # @raise [RuntimeError] if the gemspec is missing a valid SEMVER
       def initialize_version: () -> void
+
+      # Initialize gem information from gemspec.
+      #
+      # @return [void]
+      def initialize_with_gemspec: () -> void
     end
   end
 end

--- a/domainic-dev/sig/domainic/dev/generator/gem_generator.rbs
+++ b/domainic-dev/sig/domainic/dev/generator/gem_generator.rbs
@@ -26,20 +26,25 @@ module Domainic
         # @return [void]
         def initialize: (Array[untyped], *untyped) -> void
 
-        # Create the gem's gemspec file.
-        #
-        # @return [void]
-        def create_gemspec: () -> void
-
         # Create the gem's CHANGELOG file.
         #
         # @return [void]
         def create_changelog: () -> void
 
+        # Create the gem's gemspec file.
+        #
+        # @return [void]
+        def create_gemspec: () -> void
+
         # Create the gem's LICENSE file.
         #
         # @return [void]
         def create_license: () -> void
+
+        # Create the module's main library file.
+        #
+        # @return [void]
+        def create_module_lib_file: () -> void
 
         # Create the gem's README file.
         #
@@ -51,16 +56,6 @@ module Domainic
         # @return [void]
         def create_root_lib_file: () -> void
 
-        # Create the module's main library file.
-        #
-        # @return [void]
-        def create_module_lib_file: () -> void
-
-        # Create the gem's spec_helper file.
-        #
-        # @return [void]
-        def create_spec_helper: () -> void
-
         # Create the root spec file.
         #
         # @return [void]
@@ -70,6 +65,11 @@ module Domainic
         #
         # @return [void]
         def create_signature_manifest: () -> void
+
+        # Create the gem's spec_helper file.
+        #
+        # @return [void]
+        def create_spec_helper: () -> void
 
         # Generate RBS signatures for the new gem.
         #

--- a/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
@@ -74,6 +74,22 @@ module Domainic
           constrain :self, :emptiness, description: 'being'
         end
 
+        # Validate that the enumerable elements are in sorted order.
+        #
+        # Creates a constraint that ensures the collection's elements are
+        # in ascending order based on their natural comparison methods.
+        #
+        # @example
+        #   type.being_ordered
+        #   type.validate([1, 2, 3])   # => true
+        #   type.validate([3, 1, 2])   # => false
+        #
+        # @return [EnumerableBehavior] self for method chaining
+        # @rbs () -> EnumerableBehavior
+        def being_ordered
+          constrain :self, :ordering, description: 'being'
+        end
+
         # Validate that the enumerable contains elements.
         #
         # Creates an inverse emptiness constraint that ensures the collection
@@ -89,22 +105,6 @@ module Domainic
         def being_populated
           empty = @constraints.prepare :self, :emptiness
           constrain :self, :not, empty, concerning: :emptiness, description: 'being'
-        end
-
-        # Validate that the enumerable elements are in sorted order.
-        #
-        # Creates a constraint that ensures the collection's elements are
-        # in ascending order based on their natural comparison methods.
-        #
-        # @example
-        #   type.being_ordered
-        #   type.validate([1, 2, 3])   # => true
-        #   type.validate([3, 1, 2])   # => false
-        #
-        # @return [EnumerableBehavior] self for method chaining
-        # @rbs () -> EnumerableBehavior
-        def being_ordered
-          constrain :self, :ordering, description: 'being'
         end
 
         # Validate that the enumerable elements are not in sorted order.

--- a/domainic-type/lib/domainic/type/constraint/resolver.rb
+++ b/domainic-type/lib/domainic/type/constraint/resolver.rb
@@ -45,20 +45,6 @@ module Domainic
         # @rbs @file_name: String
 
         class << self
-          # Resolve a constraint type to its corresponding class.
-          #
-          # This is a convenience method that creates a new Resolver instance and
-          # immediately resolves the constraint class.
-          #
-          # @param constraint_type [Symbol] The type of constraint to resolve
-          #
-          # @raise [ArgumentError] if the constraint type is unknown
-          # @return [Class] The resolved constraint class
-          # @rbs (Symbol constraint_type) -> _ConstraintClass
-          def resolve!(constraint_type)
-            new(constraint_type).resolve!
-          end
-
           # Register a new constraint with the resolver.
           #
           # @param lookup_key [String, Symbol] The lookup key for the constraint. This is how types should reference
@@ -73,6 +59,20 @@ module Domainic
             raise ArgumentError, "Constraint already registered: #{lookup_key}" if registry.key?(lookup_key.to_sym)
 
             registry[lookup_key.to_sym] = { constant: constant_name, require_path: require_path }
+          end
+
+          # Resolve a constraint type to its corresponding class.
+          #
+          # This is a convenience method that creates a new Resolver instance and
+          # immediately resolves the constraint class.
+          #
+          # @param constraint_type [Symbol] The type of constraint to resolve
+          #
+          # @raise [ArgumentError] if the constraint type is unknown
+          # @return [Class] The resolved constraint class
+          # @rbs (Symbol constraint_type) -> _ConstraintClass
+          def resolve!(constraint_type)
+            new(constraint_type).resolve!
           end
 
           private

--- a/domainic-type/lib/domainic/type/types/specification/duck_type.rb
+++ b/domainic-type/lib/domainic/type/types/specification/duck_type.rb
@@ -21,20 +21,6 @@ module Domainic
     class DuckType
       include Behavior
 
-      # Add method presence constraints to the type
-      #
-      # @example
-      #   type = DuckType.new.responding_to(:foo, :bar)
-      #
-      # @param methods [Array<String, Symbol>] the methods that must be present
-      #
-      # @return [self] the type for method chaining
-      # @rbs (*String | Symbol methods) -> self
-      def responding_to(*methods)
-        methods = methods.map { |method| @constraints.prepare :self, :method_presence, method }
-        constrain :self, :and, methods, concerning: :method_presence
-      end
-
       # Add method exclusion constraints to the type
       #
       # @example
@@ -49,6 +35,20 @@ module Domainic
           @constraints.prepare(:self, :not, @constraints.prepare(:self, :method_presence, method))
         end
         constrain :self, :and, not_methods, concerning: :method_exclusion
+      end
+
+      # Add method presence constraints to the type
+      #
+      # @example
+      #   type = DuckType.new.responding_to(:foo, :bar)
+      #
+      # @param methods [Array<String, Symbol>] the methods that must be present
+      #
+      # @return [self] the type for method chaining
+      # @rbs (*String | Symbol methods) -> self
+      def responding_to(*methods)
+        methods = methods.map { |method| @constraints.prepare :self, :method_presence, method }
+        constrain :self, :and, methods, concerning: :method_presence
       end
     end
   end

--- a/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
@@ -63,19 +63,6 @@ module Domainic
         # @return [EnumerableBehavior] self for method chaining
         def being_empty: () -> EnumerableBehavior
 
-        # Validate that the enumerable contains elements.
-        #
-        # Creates an inverse emptiness constraint that ensures the collection
-        # has at least one element.
-        #
-        # @example
-        #   type.being_populated
-        #   type.validate([1])    # => true
-        #   type.validate([])     # => false
-        #
-        # @return [EnumerableBehavior] self for method chaining
-        def being_populated: () -> EnumerableBehavior
-
         # Validate that the enumerable elements are in sorted order.
         #
         # Creates a constraint that ensures the collection's elements are
@@ -88,6 +75,19 @@ module Domainic
         #
         # @return [EnumerableBehavior] self for method chaining
         def being_ordered: () -> EnumerableBehavior
+
+        # Validate that the enumerable contains elements.
+        #
+        # Creates an inverse emptiness constraint that ensures the collection
+        # has at least one element.
+        #
+        # @example
+        #   type.being_populated
+        #   type.validate([1])    # => true
+        #   type.validate([])     # => false
+        #
+        # @return [EnumerableBehavior] self for method chaining
+        def being_populated: () -> EnumerableBehavior
 
         # Validate that the enumerable elements are not in sorted order.
         #

--- a/domainic-type/sig/domainic/type/constraint/resolver.rbs
+++ b/domainic-type/sig/domainic/type/constraint/resolver.rbs
@@ -41,17 +41,6 @@ module Domainic
 
         self.@registry: Hash[Symbol, Hash[Symbol, registry_constraint]]
 
-        # Resolve a constraint type to its corresponding class.
-        #
-        # This is a convenience method that creates a new Resolver instance and
-        # immediately resolves the constraint class.
-        #
-        # @param constraint_type [Symbol] The type of constraint to resolve
-        #
-        # @raise [ArgumentError] if the constraint type is unknown
-        # @return [Class] The resolved constraint class
-        def self.resolve!: (Symbol constraint_type) -> _ConstraintClass
-
         # Register a new constraint with the resolver.
         #
         # @param lookup_key [String, Symbol] The lookup key for the constraint. This is how types should reference
@@ -62,6 +51,17 @@ module Domainic
         # @raise [ArgumentError] if the constraint is already registered
         # @return [void]
         def self.register_constraint: (String | Symbol lookup_key, String constant_name, String require_path) -> void
+
+        # Resolve a constraint type to its corresponding class.
+        #
+        # This is a convenience method that creates a new Resolver instance and
+        # immediately resolves the constraint class.
+        #
+        # @param constraint_type [Symbol] The type of constraint to resolve
+        #
+        # @raise [ArgumentError] if the constraint type is unknown
+        # @return [Class] The resolved constraint class
+        def self.resolve!: (Symbol constraint_type) -> _ConstraintClass
 
         # The registry of known constraints
         #

--- a/domainic-type/sig/domainic/type/types/specification/duck_type.rbs
+++ b/domainic-type/sig/domainic/type/types/specification/duck_type.rbs
@@ -17,16 +17,6 @@ module Domainic
     class DuckType
       include Behavior
 
-      # Add method presence constraints to the type
-      #
-      # @example
-      #   type = DuckType.new.responding_to(:foo, :bar)
-      #
-      # @param methods [Array<String, Symbol>] the methods that must be present
-      #
-      # @return [self] the type for method chaining
-      def responding_to: (*String | Symbol methods) -> self
-
       # Add method exclusion constraints to the type
       #
       # @example
@@ -36,6 +26,16 @@ module Domainic
       #
       # @return [self] the type for method chaining
       def not_responding_to: (*String | Symbol methods) -> self
+
+      # Add method presence constraints to the type
+      #
+      # @example
+      #   type = DuckType.new.responding_to(:foo, :bar)
+      #
+      # @param methods [Array<String, Symbol>] the methods that must be present
+      #
+      # @return [self] the type for method chaining
+      def responding_to: (*String | Symbol methods) -> self
     end
   end
 end

--- a/domainic-type/spec/domainic/type/constraint/all_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/all_constraint_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Domainic::Type::Constraint::AllConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(_value) = true
+
       def short_description = 'be a string'
 
       def short_violation_description = 'was not a string'
-
-      def satisfied?(_value) = true
     end.new(:self)
   end
 
@@ -106,9 +106,9 @@ RSpec.describe Domainic::Type::Constraint::AllConstraint do
         Class.new do
           include Domainic::Type::Constraint::Behavior
 
-          def short_violation_description = 'was not a string'
-
           def satisfied?(_value) = false
+
+          def short_violation_description = 'was not a string'
         end.new(:self)
       end
 

--- a/domainic-type/spec/domainic/type/constraint/and_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/and_constraint_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Domainic::Type::Constraint::AndConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(value) = value.is_a?(String)
       def short_description = 'be a string'
       def short_violation_description = 'was not a string'
-      def satisfied?(value) = value.is_a?(String)
     end.new(:self)
   end
 
@@ -19,9 +19,9 @@ RSpec.describe Domainic::Type::Constraint::AndConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(value) = !value.empty?
       def short_description = 'be non-empty'
       def short_violation_description = 'was empty'
-      def satisfied?(value) = !value.empty?
     end.new(:self)
   end
 

--- a/domainic-type/spec/domainic/type/constraint/any_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/any_constraint_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Domainic::Type::Constraint::AnyConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(_value) = true
+
       def short_description = 'be a string'
 
       def short_violation_description = 'was not a string'
-
-      def satisfied?(_value) = true
     end.new(:self)
   end
 
@@ -110,11 +110,11 @@ RSpec.describe Domainic::Type::Constraint::AnyConstraint do
         Class.new do
           include Domainic::Type::Constraint::Behavior
 
-          def short_violation_description = 'was not a string'
-
           def satisfied?(value)
             value.is_a?(String)
           end
+
+          def short_violation_description = 'was not a string'
         end.new(:self)
       end
 

--- a/domainic-type/spec/domainic/type/constraint/behavior_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/behavior_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe Domainic::Type::Constraint::Behavior do
 
           protected
 
-          def satisfies_constraint?
-            true
-          end
-
           def coerce_expectation(expectation)
             expectation.to_s
+          end
+
+          def satisfies_constraint?
+            true
           end
         end
       end
@@ -194,12 +194,12 @@ RSpec.describe Domainic::Type::Constraint::Behavior do
 
           protected
 
-          def satisfies_constraint?
-            @actual == @expected
-          end
-
           def coerce_actual(actual)
             actual.to_s
+          end
+
+          def satisfies_constraint?
+            @actual == @expected
           end
         end
       end
@@ -217,12 +217,12 @@ RSpec.describe Domainic::Type::Constraint::Behavior do
 
           protected
 
-          def satisfies_constraint?
-            @actual == @expected
-          end
-
           def coerce_actual(actual)
             actual.upcase
+          end
+
+          def satisfies_constraint?
+            @actual == @expected
           end
         end
       end

--- a/domainic-type/spec/domainic/type/constraint/not_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/not_constraint_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Domainic::Type::Constraint::NotConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(_value) = true
+
       def short_description = 'be a string'
 
       def short_violation_description = 'was a string'
-
-      def satisfied?(_value) = true
     end.new(:self)
   end
 

--- a/domainic-type/spec/domainic/type/constraint/or_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/or_constraint_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Domainic::Type::Constraint::OrConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(value) = value.is_a?(String)
       def short_description = 'be a string'
       def short_violation_description = 'was not a string'
-      def satisfied?(value) = value.is_a?(String)
     end.new(:self)
   end
 
@@ -19,9 +19,9 @@ RSpec.describe Domainic::Type::Constraint::OrConstraint do
     Class.new do
       include Domainic::Type::Constraint::Behavior
 
+      def satisfied?(value) = value.is_a?(Symbol)
       def short_description = 'be a symbol'
       def short_violation_description = 'was not a symbol'
-      def satisfied?(value) = value.is_a?(Symbol)
     end.new(:self)
   end
 


### PR DESCRIPTION
Adds the rubocop-ordered_methods extension to enforce alphabetical ordering of methods within visibility groups (public, protected, private). Ran auto-correction across the codebase to align with this standard.

* Added rubocop-ordered_methods to development dependencies
* Added extension to .rubocop.yml configuration
* Auto-corrected method ordering in 18 files

This change standardizes method organization throughout the project, improving code readability and maintainability.