### PR TITLE
Fix missing require statements in Attributer

### DIFF
--- a/domainic-attributer/CHANGELOG.md
+++ b/domainic-attributer/CHANGELOG.md
@@ -19,8 +19,12 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ### Fixed
 
-* [#18](https://github.com/domainic/domainic/pull/18) Added missing requires for `Domainic::Attributer::Undefined` in
+* [#18](https://github.com/domainic/domainic/pull/18) Fixed missing requires for `Domainic::Attributer::Undefined` in
   the `Domainic::Attributer::Attribute` and `Domainic::Attributer::Attribute::Validator` classes.
+* [#94](https://github.com/domainic/domainic/pull/94) Fixed missing requires for `Domainic::Attributer::Undefined` in
+  `Domainic::Attributer::DSL::OptionParser`, and `Domainic::Attributer::DSL::Initializer`
+* [#94](https://github.com/domainic/domainic/pull/94) Fixed missing require for `Domainic::Attributer::Attribute` in
+  `Domainic::Attributer::Attribute::BelongsToAttribute`
 * Various documentation improvements and corrections.
 
 ## [v0.1.0] - 2024-12-12

--- a/domainic-attributer/lib/domainic/attributer/attribute/mixin/belongs_to_attribute.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute/mixin/belongs_to_attribute.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'domainic/attributer/attribute'
+
 module Domainic
   module Attributer
     class Attribute

--- a/domainic-attributer/lib/domainic/attributer/dsl/attribute_builder/option_parser.rb
+++ b/domainic-attributer/lib/domainic/attributer/dsl/attribute_builder/option_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'domainic/attributer/undefined'
+
 module Domainic
   module Attributer
     module DSL

--- a/domainic-attributer/lib/domainic/attributer/dsl/initializer.rb
+++ b/domainic-attributer/lib/domainic/attributer/dsl/initializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'domainic/attributer/undefined'
+
 module Domainic
   module Attributer
     module DSL


### PR DESCRIPTION
## Description

Fix missing require statements needed for proper class loading:
  - require 'undefined' in option_parser.rb and initializer.rb
  - require 'attribute' in belongs_to_attribute.rb

These dependencies were previously working through Ruby's autoload but should be explicitly required for clearer code organization and to prevent potential loading issues.

## Changes Made

  - fixed `Domainic::Attributer::DSL::OptionParser` missing require for `Domainic::Attributer::Undefined`
  - fixed `Domainic::Attributer::DSL::Initializer` missing require for `Domainic::Attributer::Undefined`
  - fixed `Domainic::Attributer::Attribute::BelongsToAttribute` missing require for `Domainic::Attributer::Attribute`