### PR TITLE
Add Codacy code coverage reporting and documentation linting

### DIFF
--- a/.github/actions/test/ruby/action.yml
+++ b/.github/actions/test/ruby/action.yml
@@ -6,4 +6,4 @@ runs:
   steps:
     - name: Run rspec
       shell: bash
-      run: bin/dev test
+      run: bin/dev test && bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Setup ruby
         uses: ./.github/actions/setup/ruby
       - name: Test ruby code
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         uses: ./.github/actions/test/ruby
       - name: Test ruby types
         uses: ./.github/actions/test/types

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,15 @@
+default: true
+
+MD007:
+  indent: 2
+MD013:
+  line_length: 120
+  tables: false
+MD024:
+  allow_different_nesting: true
+MD029:
+  style: ordered
+MD033:
+  allowed_elements:
+    - details
+    - summary

--- a/.mdl.rb
+++ b/.mdl.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
+require 'yaml'
+config = YAML.load_file(File.expand_path('.markdownlint.yml', __dir__), symbolize_names: true)
+
 all
 
-rule 'MD007', indent: 2
+config.except(:default).each_pair do |rule_id, options|
+  options = options.transform_values do |value|
+    value.is_a?(Array) ? value.join(',') : value
+  end
 
-rule 'MD013', line_length: 120, tables: false
-
-# Allow CHANGELOG.md like nesting
-rule 'MD024', allow_different_nesting: true
-
-# Allow ordered lists
-rule 'MD029', style: 'ordered'
-
-# Allow collapsible details
-rule 'MD033', allowed_elements: 'details, summary'
+  rule(rule_id.to_s, **options)
+end

--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,5 @@ end
 group :test do
   gem 'rspec', require: false
   gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     steep (1.9.2)
       activesupport (>= 5.1)
@@ -183,6 +184,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-yard
   simplecov
+  simplecov-lcov
   steep
   webrick
   yard

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Domainic
 
 [![Domainic Build](https://img.shields.io/github/actions/workflow/status/domainic/domainic/build.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&logoSize=auto)](https://github.com/domainic/domainic/actions/workflows/build.yml)
+[![Domainic Code Coverage](https://img.shields.io/codacy/coverage/17177dca4a76428c9422ceb8fb970271/main?style=for-the-badge&logo=codacy&logoSize=auto)](https://app.codacy.com/gh/domainic/domainic/coverage)
+[![Domainic Code Quality](https://img.shields.io/codacy/grade/17177dca4a76428c9422ceb8fb970271/main?style=for-the-badge&logo=codacy&logoSize=auto)](https://app.codacy.com/gh/domainic/domainic/dashboard)
 [![Domainic Version](https://img.shields.io/badge/not%20released-orange?label=gem%20version&logo=rubygems&logoSize=auto&style=for-the-badge)](https://rubygems.org/gems/domainic)
 [![Domainic License](https://img.shields.io/github/license/domainic/domainic?logo=opensourceinitiative&logoColor=white&logoSize=auto&style=for-the-badge)](./LICENSE)
 [![Domainic Open Issues](https://img.shields.io/github/issues-search/domainic/domainic?label=open%20issues&logo=github&logoSize=auto&query=is%3Aopen&color=red&style=for-the-badge)](https://github.com/domainic/domainic/issues?q=state%3Aopen)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,19 @@
 
 # Setup coverage reporting
 require 'simplecov'
+require 'simplecov-lcov'
 
 SimpleCov.start do
   enable_coverage :branch
   coverage_dir File.expand_path('../coverage', __dir__)
+  formatter SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::LcovFormatter,
+      SimpleCov::Formatter::HTMLFormatter
+    ]
+  )
   add_filter '/spec/'
+  add_filter '/domainic-dev/'
   track_files File.expand_path('../**/*.rb', __dir__)
 end
 


### PR DESCRIPTION
## Description

Integrates Codacy for code coverage tracking and improves documentation linting configuration. Consolidates markdown linting rules into a single configuration file and sets up coverage reporting through simplecov-lcov.

## Changes Made

* Added .markdownlint.yml for centralized markdown linting rules
* Modified .mdl.rb to read from .markdownlint.yml
* Added simplecov-lcov gem for LCOV coverage reporting
* Configured SimpleCov to use LCOV formatter
* Added Codacy badges to main README.md
* Excluded domainic-dev from coverage metrics
* Updated test workflow to report coverage to Codacy