### PR TITLE
Enhance Enumerable module with fluent range constraints

### DIFF
--- a/domainic-type/lib/domainic/type/behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior.rb
@@ -112,10 +112,7 @@ module Domainic
         #   Type::accessor accessor,
         #   String | Symbol constraint_type,
         #   ?untyped expectation,
-        #   ?abort_on_failure: bool,
-        #   ?coerce_with: Array[Proc] | Proc,
-        #   ?concerning: String | Symbol,
-        #   ?description: String | Symbol
+        #   **untyped options
         #   ) -> void
         def intrinsic(...)
           intrinsic_constraints.add(...)
@@ -233,10 +230,7 @@ module Domainic
       #   Type::accessor accessor,
       #   String | Symbol constraint_type,
       #   ?untyped expectation,
-      #   ?abort_on_failure: bool,
-      #   ?coerce_with: Array[Proc] | Proc,
-      #   ?concerning: String | Symbol,
-      #   ?description: String | Symbol
+      #   **untyped options
       #   ) -> self
       def constrain(...)
         @constraints.add(...)

--- a/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 require 'domainic/type/behavior'
+require 'domainic/type/behavior/range_builder'
 
 module Domainic
   module Type
     module Behavior
       # A module providing enumerable-specific validation behaviors for types.
       #
-      # This module extends the base Type::Behavior with methods specifically designed
-      # for validating enumerable collections. It provides a fluent interface for
-      # common enumerable validations such as uniqueness, emptiness, ordering,
-      # and size constraints.
+      # This module extends the base Type::Behavior with methods specifically designed for validating enumerable
+      # collections. It provides a fluent interface for common enumerable validations such as uniqueness, emptiness,
+      # ordering, and size constraints.
       #
       # @example Basic usage
       #   class ArrayType
@@ -42,22 +42,33 @@ module Domainic
       module EnumerableBehavior
         include Behavior
 
+        def being_distinct
+          constrain :entries, :uniqueness, description: 'being'
+        end
+        alias being_unique being_distinct
+        alias distinct being_distinct
+        alias unique being_distinct
+
         # Validate that the enumerable contains duplicate elements.
         #
-        # Creates an inverse uniqueness constraint that ensures the collection
-        # has at least one duplicate element.
+        # Creates an inverse uniqueness constraint that ensures the collection has at least one duplicate element.
         #
         # @example
         #   type.being_duplicative
         #   type.validate([1, 1, 2])   # => true
         #   type.validate([1, 2, 3])   # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         # @rbs () -> EnumerableBehavior
         def being_duplicative
           unique = @constraints.prepare :self, :uniqueness
-          constrain :self, :not, unique, concerning: :uniqueness, description: 'being'
+          constrain :entries, :not, unique, concerning: :uniqueness, description: 'being'
         end
+        alias being_redundant being_duplicative
+        alias being_repetitive being_duplicative
+        alias duplicative being_duplicative
+        alias redundant being_duplicative
+        alias repetitive being_duplicative
 
         # Validate that the enumerable is empty.
         #
@@ -68,66 +79,83 @@ module Domainic
         #   type.validate([])     # => true
         #   type.validate([1])    # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         # @rbs () -> EnumerableBehavior
         def being_empty
-          constrain :self, :emptiness, description: 'being'
+          constrain :entries, :emptiness, description: 'being'
         end
-
-        # Validate that the enumerable elements are in sorted order.
-        #
-        # Creates a constraint that ensures the collection's elements are
-        # in ascending order based on their natural comparison methods.
-        #
-        # @example
-        #   type.being_ordered
-        #   type.validate([1, 2, 3])   # => true
-        #   type.validate([3, 1, 2])   # => false
-        #
-        # @return [EnumerableBehavior] self for method chaining
-        # @rbs () -> EnumerableBehavior
-        def being_ordered
-          constrain :self, :ordering, description: 'being'
-        end
+        alias being_vacant being_empty
+        alias empty being_empty
+        alias vacant being_empty
 
         # Validate that the enumerable contains elements.
         #
-        # Creates an inverse emptiness constraint that ensures the collection
-        # has at least one element.
+        # Creates an inverse emptiness constraint that ensures the collection has at least one element.
         #
         # @example
         #   type.being_populated
         #   type.validate([1])    # => true
         #   type.validate([])     # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         # @rbs () -> EnumerableBehavior
         def being_populated
           empty = @constraints.prepare :self, :emptiness
-          constrain :self, :not, empty, concerning: :emptiness, description: 'being'
+          constrain :entries, :not, empty, concerning: :emptiness, description: 'being'
         end
+        alias being_inhabited being_populated
+        alias being_occupied being_populated
+        alias populated being_populated
+        alias inhabited being_populated
+        alias occupied being_populated
+
+        # Validate that the enumerable elements are in sorted order.
+        #
+        # Creates a constraint that ensures the collection's elements are in ascending order based on their natural
+        # comparison methods.
+        #
+        # @example
+        #   type.being_ordered
+        #   type.validate([1, 2, 3])   # => true
+        #   type.validate([3, 1, 2])   # => false
+        #
+        # @return [self] self for method chaining
+        # @rbs () -> EnumerableBehavior
+        def being_sorted
+          constrain :entries, :ordering, description: 'being'
+        end
+        alias being_aranged being_sorted
+        alias being_ordered being_sorted
+        alias being_sequential being_sorted
+        alias aranged being_sorted
+        alias ordered being_sorted
+        alias sorted being_sorted
+        alias sequential being_sorted
 
         # Validate that the enumerable elements are not in sorted order.
         #
-        # Creates an inverse ordering constraint that ensures the collection's
-        # elements are not in ascending order.
+        # Creates an inverse ordering constraint that ensures the collection's elements are not in ascending order.
         #
         # @example
         #   type.being_unordered
         #   type.validate([3, 1, 2])   # => true
         #   type.validate([1, 2, 3])   # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         # @rbs () -> EnumerableBehavior
-        def being_unordered
+        def being_unsorted
           ordered = @constraints.prepare :self, :ordering
-          constrain :self, :not, ordered, concerning: :ordering, description: 'being'
+          constrain :entries, :not, ordered, concerning: :ordering, description: 'being'
         end
+        alias being_disordered being_unsorted
+        alias being_unordered being_unsorted
+        alias disordered being_unsorted
+        alias unsorted being_unsorted
+        alias unordered being_unsorted
 
         # Validate that the enumerable contains specific entries.
         #
-        # Creates a series of inclusion constraints ensuring the collection
-        # contains all specified elements.
+        # Creates a series of inclusion constraints ensuring the collection contains all specified elements.
         #
         # @example
         #   type.containing(1, 2)
@@ -135,49 +163,121 @@ module Domainic
         #   type.validate([1, 3])      # => false
         #
         # @param entries [Array<Object>] the elements that must be present
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         # @rbs (*untyped entries) -> EnumerableBehavior
         def containing(*entries)
-          constrain :self, :inclusion, entries
+          constrain :entries, :inclusion, entries
         end
+        alias including containing
 
-        # Validate that the enumerable's size is at most a given value.
+        # Validate that the enumerable contains a specific last entry.
         #
-        # Creates a range constraint on the collection's size ensuring it
-        # does not exceed the specified maximum.
+        # Creates an equality constraint on the collection's last entry ensuring it is equal to the specified value.
         #
         # @example
-        #   type.having_maximum_count(3)
+        #   type.having_last_entry(3)
         #   type.validate([1, 2, 3])   # => true
-        #   type.validate([1, 2, 3, 4]) # => false
+        #   type.validate([1, 3, 2])   # => false
         #
-        # @param maximum [Integer] the maximum allowed size
-        # @return [EnumerableBehavior] self for method chaining
-        # @rbs (Integer maximum) -> EnumerableBehavior
-        def having_maximum_count(maximum)
-          accessor = __method__.to_s.split('_').last.to_sym
-          # @type var accessor: Type::accessor
-          constrain accessor, :range, { maximum: maximum }, concerning: :size, description: 'having'
+        # @param literal [Object] the value that must be the last entry
+        # @return [self] self for method chaining
+        # @rbs (untyped literal) -> EnumerableBehavior
+        def ending_with(literal)
+          constrain :last, :equality, literal, concerning: :last_entry_value, description: 'with last entry'
         end
+        alias closing_with ending_with
+        alias finishing_with ending_with
 
-        # Validate that the enumerable's size is at least a given value.
+        # Validate that the enumerable does not contain specific entries.
         #
-        # Creates a range constraint on the collection's size ensuring it
-        # has at least the specified minimum number of elements.
+        # Creates a series of exclusion constraints ensuring the collection does not contain any of the specified
+        # elements.
         #
         # @example
-        #   type.having_minimum_count(2)
-        #   type.validate([1, 2, 3])   # => true
-        #   type.validate([1])         # => false
+        #   type.excluding(1, 2)
+        #   type.validate([3, 4, 5])   # => true
+        #   type.validate([1, 2, 3])   # => false
         #
-        # @param minimum [Integer] the minimum required size
-        # @return [EnumerableBehavior] self for method chaining
-        # @rbs (Integer minimum) -> EnumerableBehavior
-        def having_minimum_count(minimum)
-          accessor = __method__.to_s.split('_').last.to_sym
-          # @type var accessor: Type::accessor
-          constrain accessor, :range, { minimum: minimum }, concerning: :size, description: 'having'
+        # @param entries [Array<Object>] the elements that must not be present
+        # @return [self] self for method chaining
+        # @rbs (*untyped entries) -> EnumerableBehavior
+        def excluding(*entries)
+          including = @constraints.prepare :self, :inclusion, entries
+          constrain :entries, :not, including, concerning: :exclusion
         end
+        alias omitting excluding
+
+        # Validates that the enumerable has count equal to the desired specifications
+        #
+        # @example with explicit options
+        #   type.having_count(at_least: 1, at_most: 5)
+        #   type.having_count(between: { minimum: 1, maximum: 3 })
+        #   type.having_count(exactly: 3)
+        #
+        # @example with builder pattern
+        #   type.having_count.at_least(1).at_most(5)
+        #   type.having_count.between(min: 1, max: 3)
+        #   type.having_count.exactly(3)
+        #
+        # @param options [Hash{Symbol => Integer, Hash{Symbol => Integer}}] size constraint options
+        # @option options [Integer] :at_least minimum size
+        # @option options [Integer] :at_most maximum size
+        # @option options [Hash{Symbol => Integer}] :between min/max size range
+        # @option options [Integer] :exactly exact size
+        #
+        # @return [RangeBuilder] for chaining additional constraints
+        # @rbs (**Integer | Hash[String | Symbol, Integer] options) -> RangeBuilder
+        def having_count(**options)
+          builder_options = { concerning: :size, description: "having #{__method__.to_s.split('_').last}" }
+          builder = RangeBuilder.new(self, :size, **builder_options) # steep:ignore ArgumentTypeMismatch
+          return builder if options.empty?
+
+          options.each_pair do |method, value|
+            value.is_a?(Hash) ? builder.send(method, **value.transform_keys(&:to_sym)) : builder.send(method, value)
+          end
+
+          builder
+        end
+        alias count having_count
+        alias having_length having_count
+        alias having_size having_count
+        alias length having_count
+        alias size having_count
+
+        # Validate that the enumerable contains elements of a specific type.
+        #
+        # Creates a type constraint on the collection's elements ensuring they are all of the specified type.
+        #
+        # @example
+        #   type.of(String)
+        #   type.validate(['a', 'b', 'c'])   # => true
+        #   type.validate(['a', 1, 'c'])     # => false
+        #
+        # @param type [Class, Module, Behavior] the type that all elements must be
+        # @return [self] self for method chaining
+        # @rbs (Class | Module | Behavior type) -> EnumerableBehavior
+        def of(type)
+          type = @constraints.prepare :entries, :type, type
+          constrain :entries, :all, type, concerning: :entry_type
+        end
+
+        # Validate that the enumerable contains a specific first entry.
+        #
+        # Creates an equality constraint on the collection's first entry ensuring it is equal to the specified value.
+        #
+        # @example
+        #   type.having_first_entry(1)
+        #   type.validate([1, 2, 3])   # => true
+        #   type.validate([2, 3, 1])   # => false
+        #
+        # @param literal [Object] the value that must be the first entry
+        # @return [self] self for method chaining
+        # @rbs (untyped literal) -> EnumerableBehavior
+        def starting_with(literal)
+          constrain :first, :equality, literal, concerning: :first_entry_value, description: 'with first entry'
+        end
+        alias begining_with starting_with
+        alias leading_with starting_with
       end
     end
   end

--- a/domainic-type/lib/domainic/type/behavior/range_builder.rb
+++ b/domainic-type/lib/domainic/type/behavior/range_builder.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    module Behavior
+      # A builder for constructing range-based constraints with a fluent interface.
+      #
+      # {RangeBuilder} provides methods for specifying range constraints in a readable manner.
+      # It supports setting minimum and maximum bounds, either separately or together, as well
+      # as specifying exact values.
+      #
+      # The builder maintains method chaining capability with the parent type system by
+      # delegating unknown methods back to the originating type.
+      #
+      # @example Building count constraints
+      #   type.having_count.at_least(5)            # minimum of 5 elements
+      #   type.having_count.at_most(10)            # maximum of 10 elements
+      #   type.having_count.between(min: 5, max: 10) # between 5 and 10 elements
+      #   type.having_count.exactly(7)             # exactly 7 elements
+      #
+      # @api private
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class RangeBuilder
+        # @rbs @constraining: Type::Accessor
+        # @rbs @options: Hash[Symbol, untyped]
+        # @rbs @type: Behavior
+
+        # Initialize a new RangeBuilder.
+        #
+        # @param type [Behavior] the type instance to build constraints for
+        # @param constraining [Symbol] the accessor to constrain (:size, :length, etc)
+        # @param options [Hash] additional options for the constraints
+        #
+        # @return [void]
+        # @rbs (Behavior type, Type::accessor, **untyped options) -> void
+        def initialize(type, constraining, **options)
+          @constraining = constraining
+          @options = options.transform_keys(&:to_sym)
+          @type = type
+        end
+
+        # Set a minimum bound for the range.
+        #
+        # @example
+        #   type.having_count.at_least(5) # => minimum of 5 elements
+        #
+        # @param value [Integer] the minimum value
+        # @return [self] for method chaining
+        # @rbs (Integer value) -> self
+        def at_least(value)
+          @type.send(:constrain, @constraining, :range, { minimum: value }, **@options)
+          self
+        end
+
+        # Set a maximum bound for the range.
+        #
+        # @example
+        #   type.having_count.at_most(10) # => maximum of 10 elements
+        #
+        # @param value [Integer] the maximum value
+        # @return [self] for method chaining
+        # @rbs (Integer value) -> self
+        def at_most(value)
+          @type.send(:constrain, @constraining, :range, { maximum: value }, **@options)
+          self
+        end
+
+        # Set both minimum and maximum bounds for the range.
+        #
+        # @example
+        #   type.having_count.between(min: 5, max: 10)
+        #   type.having_count.between(minimum: 5, maximum: 10)
+        #
+        # @param min [Integer, nil] the minimum value
+        # @param maximum [Integer, nil] the maximum value (alias for max)
+        # @param minimum [Integer, nil] the minimum value (alias for min)
+        # @param max [Integer, nil] the maximum value
+        # @return [self] for method chaining
+        # @rbs (?max: Integer?, ?maximum: Integer?, ?min: Integer?, ?minimum: Integer?) -> self
+        def between(max: nil, maximum: nil, min: nil, minimum: nil)
+          min ||= minimum
+          max ||= maximum
+          raise ArgumentError, 'minimum and maximum values must be provided' unless min && max
+
+          constraint_options = @options.merge(inclusive: false)
+          @type.send(:constrain, @constraining, :range, { minimum: min, maximum: max }, **constraint_options)
+          self
+        end
+
+        # Set an exact value for the range (min == max).
+        #
+        # @example
+        #   type.having_count.exactly(7) # => exactly 7 elements
+        #
+        # @param value [Integer] the exact value
+        # @return [self] for method chaining
+        # @rbs (Integer value) -> self
+        def exactly(value)
+          @type.send(:constrain, @constraining, :range, { minimum: value, maximum: value }, **@options)
+          self
+        end
+
+        private
+
+        # Delegate unknown methods to the parent type.
+        #
+        # This enables method chaining with the parent type system.
+        #
+        # @return [Behavior] for continued type constraints
+        # @rbs(Symbol method_name, *untyped arguments, **untyped keyword_arguments) -> Behavior
+        def method_missing(method_name, ...)
+          return super unless @type.respond_to?(method_name)
+
+          @type.send(method_name, ...)
+        end
+
+        # Check if the builder can respond to a method.
+        #
+        # @return [Boolean] true if the method can be handled
+        # @rbs (Symbol method_name, ?bool _include_private) -> bool
+        def respond_to_missing?(method_name, _include_private = false)
+          @type.respond_to?(method_name) || super
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/constraint/constraints/structural/range_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/structural/range_constraint.rb
@@ -32,8 +32,10 @@ module Domainic
       class RangeConstraint
         # @rbs!
         #   type expected = { ?minimum: Numeric, ?maximum: Numeric }
+        #
+        #   type options = { ?inclusive: bool }
 
-        include Behavior #[expected, Numeric, {}]
+        include Behavior #[expected, Numeric, options]
 
         # Get a human-readable description of the range constraint.
         #
@@ -90,7 +92,10 @@ module Domainic
         # @rbs override
         def satisfies_constraint?
           min, max = @expected.values_at(:minimum, :maximum)
-          @actual >= (min || -Float::INFINITY) && @actual <= (max || Float::INFINITY)
+          min_comparison, max_comparison = @options.fetch(:inclusive, true) ? %i[>= <=] : %i[> <]
+
+          @actual.send(min_comparison, (min || -Float::INFINITY)) &&
+            @actual.send(max_comparison, (max || Float::INFINITY))
         end
 
         # Validate that the expected value is a properly formatted range specification.

--- a/domainic-type/sig/domainic/type/behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior.rbs
@@ -90,7 +90,7 @@ module Domainic
         # @see Constraint::Set#add
         #
         # @return [void]
-        def intrinsic: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, ?abort_on_failure: bool, ?coerce_with: Array[Proc] | Proc, ?concerning: String | Symbol, ?description: String | Symbol) -> void
+        def intrinsic: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> void
 
         # Get the set of intrinsic constraints for this type.
         #
@@ -149,7 +149,7 @@ module Domainic
       # @see Constraint::Set#add
       #
       # @return [self]
-      def constrain: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, ?abort_on_failure: bool, ?coerce_with: Array[Proc] | Proc, ?concerning: String | Symbol, ?description: String | Symbol) -> self
+      def constrain: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> self
     end
   end
 end

--- a/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
@@ -3,10 +3,9 @@ module Domainic
     module Behavior
       # A module providing enumerable-specific validation behaviors for types.
       #
-      # This module extends the base Type::Behavior with methods specifically designed
-      # for validating enumerable collections. It provides a fluent interface for
-      # common enumerable validations such as uniqueness, emptiness, ordering,
-      # and size constraints.
+      # This module extends the base Type::Behavior with methods specifically designed for validating enumerable
+      # collections. It provides a fluent interface for common enumerable validations such as uniqueness, emptiness,
+      # ordering, and size constraints.
       #
       # @example Basic usage
       #   class ArrayType
@@ -38,18 +37,35 @@ module Domainic
       module EnumerableBehavior
         include Behavior
 
+        def being_distinct: () -> untyped
+
+        alias being_unique being_distinct
+
+        alias distinct being_distinct
+
+        alias unique being_distinct
+
         # Validate that the enumerable contains duplicate elements.
         #
-        # Creates an inverse uniqueness constraint that ensures the collection
-        # has at least one duplicate element.
+        # Creates an inverse uniqueness constraint that ensures the collection has at least one duplicate element.
         #
         # @example
         #   type.being_duplicative
         #   type.validate([1, 1, 2])   # => true
         #   type.validate([1, 2, 3])   # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         def being_duplicative: () -> EnumerableBehavior
+
+        alias being_redundant being_duplicative
+
+        alias being_repetitive being_duplicative
+
+        alias duplicative being_duplicative
+
+        alias redundant being_duplicative
+
+        alias repetitive being_duplicative
 
         # Validate that the enumerable is empty.
         #
@@ -60,52 +76,89 @@ module Domainic
         #   type.validate([])     # => true
         #   type.validate([1])    # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         def being_empty: () -> EnumerableBehavior
 
-        # Validate that the enumerable elements are in sorted order.
-        #
-        # Creates a constraint that ensures the collection's elements are
-        # in ascending order based on their natural comparison methods.
-        #
-        # @example
-        #   type.being_ordered
-        #   type.validate([1, 2, 3])   # => true
-        #   type.validate([3, 1, 2])   # => false
-        #
-        # @return [EnumerableBehavior] self for method chaining
-        def being_ordered: () -> EnumerableBehavior
+        alias being_vacant being_empty
+
+        alias empty being_empty
+
+        alias vacant being_empty
 
         # Validate that the enumerable contains elements.
         #
-        # Creates an inverse emptiness constraint that ensures the collection
-        # has at least one element.
+        # Creates an inverse emptiness constraint that ensures the collection has at least one element.
         #
         # @example
         #   type.being_populated
         #   type.validate([1])    # => true
         #   type.validate([])     # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         def being_populated: () -> EnumerableBehavior
+
+        alias being_inhabited being_populated
+
+        alias being_occupied being_populated
+
+        alias populated being_populated
+
+        alias inhabited being_populated
+
+        alias occupied being_populated
+
+        # Validate that the enumerable elements are in sorted order.
+        #
+        # Creates a constraint that ensures the collection's elements are in ascending order based on their natural
+        # comparison methods.
+        #
+        # @example
+        #   type.being_ordered
+        #   type.validate([1, 2, 3])   # => true
+        #   type.validate([3, 1, 2])   # => false
+        #
+        # @return [self] self for method chaining
+        def being_sorted: () -> EnumerableBehavior
+
+        alias being_aranged being_sorted
+
+        alias being_ordered being_sorted
+
+        alias being_sequential being_sorted
+
+        alias aranged being_sorted
+
+        alias ordered being_sorted
+
+        alias sorted being_sorted
+
+        alias sequential being_sorted
 
         # Validate that the enumerable elements are not in sorted order.
         #
-        # Creates an inverse ordering constraint that ensures the collection's
-        # elements are not in ascending order.
+        # Creates an inverse ordering constraint that ensures the collection's elements are not in ascending order.
         #
         # @example
         #   type.being_unordered
         #   type.validate([3, 1, 2])   # => true
         #   type.validate([1, 2, 3])   # => false
         #
-        # @return [EnumerableBehavior] self for method chaining
-        def being_unordered: () -> EnumerableBehavior
+        # @return [self] self for method chaining
+        def being_unsorted: () -> EnumerableBehavior
+
+        alias being_disordered being_unsorted
+
+        alias being_unordered being_unsorted
+
+        alias disordered being_unsorted
+
+        alias unsorted being_unsorted
+
+        alias unordered being_unsorted
 
         # Validate that the enumerable contains specific entries.
         #
-        # Creates a series of inclusion constraints ensuring the collection
-        # contains all specified elements.
+        # Creates a series of inclusion constraints ensuring the collection contains all specified elements.
         #
         # @example
         #   type.containing(1, 2)
@@ -113,36 +166,104 @@ module Domainic
         #   type.validate([1, 3])      # => false
         #
         # @param entries [Array<Object>] the elements that must be present
-        # @return [EnumerableBehavior] self for method chaining
+        # @return [self] self for method chaining
         def containing: (*untyped entries) -> EnumerableBehavior
 
-        # Validate that the enumerable's size is at most a given value.
-        #
-        # Creates a range constraint on the collection's size ensuring it
-        # does not exceed the specified maximum.
-        #
-        # @example
-        #   type.having_maximum_count(3)
-        #   type.validate([1, 2, 3])   # => true
-        #   type.validate([1, 2, 3, 4]) # => false
-        #
-        # @param maximum [Integer] the maximum allowed size
-        # @return [EnumerableBehavior] self for method chaining
-        def having_maximum_count: (Integer maximum) -> EnumerableBehavior
+        alias including containing
 
-        # Validate that the enumerable's size is at least a given value.
+        # Validate that the enumerable contains a specific last entry.
         #
-        # Creates a range constraint on the collection's size ensuring it
-        # has at least the specified minimum number of elements.
+        # Creates an equality constraint on the collection's last entry ensuring it is equal to the specified value.
         #
         # @example
-        #   type.having_minimum_count(2)
+        #   type.having_last_entry(3)
         #   type.validate([1, 2, 3])   # => true
-        #   type.validate([1])         # => false
+        #   type.validate([1, 3, 2])   # => false
         #
-        # @param minimum [Integer] the minimum required size
-        # @return [EnumerableBehavior] self for method chaining
-        def having_minimum_count: (Integer minimum) -> EnumerableBehavior
+        # @param literal [Object] the value that must be the last entry
+        # @return [self] self for method chaining
+        def ending_with: (untyped literal) -> EnumerableBehavior
+
+        alias closing_with ending_with
+
+        alias finishing_with ending_with
+
+        # Validate that the enumerable does not contain specific entries.
+        #
+        # Creates a series of exclusion constraints ensuring the collection does not contain any of the specified
+        # elements.
+        #
+        # @example
+        #   type.excluding(1, 2)
+        #   type.validate([3, 4, 5])   # => true
+        #   type.validate([1, 2, 3])   # => false
+        #
+        # @param entries [Array<Object>] the elements that must not be present
+        # @return [self] self for method chaining
+        def excluding: (*untyped entries) -> EnumerableBehavior
+
+        alias omitting excluding
+
+        # Validates that the enumerable has count equal to the desired specifications
+        #
+        # @example with explicit options
+        #   type.having_count(at_least: 1, at_most: 5)
+        #   type.having_count(between: { minimum: 1, maximum: 3 })
+        #   type.having_count(exactly: 3)
+        #
+        # @example with builder pattern
+        #   type.having_count.at_least(1).at_most(5)
+        #   type.having_count.between(min: 1, max: 3)
+        #   type.having_count.exactly(3)
+        #
+        # @param options [Hash{Symbol => Integer, Hash{Symbol => Integer}}] size constraint options
+        # @option options [Integer] :at_least minimum size
+        # @option options [Integer] :at_most maximum size
+        # @option options [Hash{Symbol => Integer}] :between min/max size range
+        # @option options [Integer] :exactly exact size
+        #
+        # @return [RangeBuilder] for chaining additional constraints
+        def having_count: (**Integer | Hash[String | Symbol, Integer] options) -> RangeBuilder
+
+        alias count having_count
+
+        alias having_length having_count
+
+        alias having_size having_count
+
+        alias length having_count
+
+        alias size having_count
+
+        # Validate that the enumerable contains elements of a specific type.
+        #
+        # Creates a type constraint on the collection's elements ensuring they are all of the specified type.
+        #
+        # @example
+        #   type.of(String)
+        #   type.validate(['a', 'b', 'c'])   # => true
+        #   type.validate(['a', 1, 'c'])     # => false
+        #
+        # @param type [Class, Module, Behavior] the type that all elements must be
+        # @return [self] self for method chaining
+        def of: (Class | Module | Behavior type) -> EnumerableBehavior
+
+        # Validate that the enumerable contains a specific first entry.
+        #
+        # Creates an equality constraint on the collection's first entry ensuring it is equal to the specified value.
+        #
+        # @example
+        #   type.having_first_entry(1)
+        #   type.validate([1, 2, 3])   # => true
+        #   type.validate([2, 3, 1])   # => false
+        #
+        # @param literal [Object] the value that must be the first entry
+        # @return [self] self for method chaining
+        def starting_with: (untyped literal) -> EnumerableBehavior
+
+        alias begining_with starting_with
+
+        alias leading_with starting_with
       end
     end
   end

--- a/domainic-type/sig/domainic/type/behavior/range_builder.rbs
+++ b/domainic-type/sig/domainic/type/behavior/range_builder.rbs
@@ -1,0 +1,94 @@
+module Domainic
+  module Type
+    module Behavior
+      # A builder for constructing range-based constraints with a fluent interface.
+      #
+      # {RangeBuilder} provides methods for specifying range constraints in a readable manner.
+      # It supports setting minimum and maximum bounds, either separately or together, as well
+      # as specifying exact values.
+      #
+      # The builder maintains method chaining capability with the parent type system by
+      # delegating unknown methods back to the originating type.
+      #
+      # @example Building count constraints
+      #   type.having_count.at_least(5)            # minimum of 5 elements
+      #   type.having_count.at_most(10)            # maximum of 10 elements
+      #   type.having_count.between(min: 5, max: 10) # between 5 and 10 elements
+      #   type.having_count.exactly(7)             # exactly 7 elements
+      #
+      # @api private
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class RangeBuilder
+        @constraining: Type::Accessor
+
+        @type: Behavior
+
+        @options: Hash[Symbol, untyped]
+
+        # Initialize a new RangeBuilder.
+        #
+        # @param type [Behavior] the type instance to build constraints for
+        # @param constraining [Symbol] the accessor to constrain (:size, :length, etc)
+        # @param options [Hash] additional options for the constraints
+        #
+        # @return [void]
+        def initialize: (Behavior type, Type::accessor, **untyped options) -> void
+
+        # Set a minimum bound for the range.
+        #
+        # @example
+        #   type.having_count.at_least(5) # => minimum of 5 elements
+        #
+        # @param value [Integer] the minimum value
+        # @return [self] for method chaining
+        def at_least: (Integer value) -> self
+
+        # Set a maximum bound for the range.
+        #
+        # @example
+        #   type.having_count.at_most(10) # => maximum of 10 elements
+        #
+        # @param value [Integer] the maximum value
+        # @return [self] for method chaining
+        def at_most: (Integer value) -> self
+
+        # Set both minimum and maximum bounds for the range.
+        #
+        # @example
+        #   type.having_count.between(min: 5, max: 10)
+        #   type.having_count.between(minimum: 5, maximum: 10)
+        #
+        # @param min [Integer, nil] the minimum value
+        # @param maximum [Integer, nil] the maximum value (alias for max)
+        # @param minimum [Integer, nil] the minimum value (alias for min)
+        # @param max [Integer, nil] the maximum value
+        # @return [self] for method chaining
+        def between: (?max: Integer?, ?maximum: Integer?, ?min: Integer?, ?minimum: Integer?) -> self
+
+        # Set an exact value for the range (min == max).
+        #
+        # @example
+        #   type.having_count.exactly(7) # => exactly 7 elements
+        #
+        # @param value [Integer] the exact value
+        # @return [self] for method chaining
+        def exactly: (Integer value) -> self
+
+        private
+
+        # Delegate unknown methods to the parent type.
+        #
+        # This enables method chaining with the parent type system.
+        #
+        # @return [Behavior] for continued type constraints
+        def method_missing: (Symbol method_name, *untyped arguments, **untyped keyword_arguments) -> Behavior
+
+        # Check if the builder can respond to a method.
+        #
+        # @return [Boolean] true if the method can be handled
+        def respond_to_missing?: (Symbol method_name, ?bool _include_private) -> bool
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/constraint/constraints/structural/range_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/structural/range_constraint.rbs
@@ -28,7 +28,9 @@ module Domainic
       class RangeConstraint
         type expected = { ?minimum: Numeric, ?maximum: Numeric }
 
-        include Behavior[expected, Numeric, { }]
+        type options = { ?inclusive: bool }
+
+        include Behavior[expected, Numeric, options]
 
         # Get a human-readable description of the range constraint.
         #

--- a/domainic-type/spec/domainic/type/behavior/range_builder_spec.rb
+++ b/domainic-type/spec/domainic/type/behavior/range_builder_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/behavior'
+require 'domainic/type/behavior/range_builder'
+
+RSpec.describe Domainic::Type::Behavior::RangeBuilder do
+  subject(:builder) { described_class.new(type, constraining, **options) }
+
+  let(:type) do
+    Class.new do
+      include Domainic::Type::Behavior
+    end.new
+  end
+  let(:constraining) { :size }
+  let(:options) { { description: 'having count' } }
+
+  before do
+    allow(type).to receive(:send).with(:constrain, anything, anything, anything, anything).and_return(type)
+  end
+
+  it { is_expected.to respond_to(:at_least) }
+  it { is_expected.to respond_to(:at_most) }
+  it { is_expected.to respond_to(:between) }
+  it { is_expected.to respond_to(:exactly) }
+
+  describe '#at_least' do
+    it 'is expected to create a minimum range constraint' do
+      allow(type).to receive(:send)
+      builder.at_least(5)
+
+      expect(type).to have_received(:send).with(
+        :constrain,
+        constraining,
+        :range,
+        { minimum: 5 },
+        description: 'having count'
+      )
+    end
+
+    it 'is expected to return self for chaining' do
+      expect(builder.at_least(5)).to eq(builder)
+    end
+  end
+
+  describe '#at_most' do
+    it 'is expected to create a maximum range constraint' do
+      allow(type).to receive(:send)
+      builder.at_most(10)
+
+      expect(type).to have_received(:send).with(
+        :constrain,
+        constraining,
+        :range,
+        { maximum: 10 },
+        description: 'having count'
+      )
+    end
+
+    it 'is expected to return self for chaining' do
+      expect(builder.at_most(10)).to eq(builder)
+    end
+  end
+
+  describe '#between' do
+    context 'with min/max parameters' do
+      it 'is expected to create a range constraint' do
+        allow(type).to receive(:send)
+        builder.between(min: 5, max: 10)
+
+        expect(type).to have_received(:send).with(
+          :constrain,
+          constraining,
+          :range,
+          { minimum: 5, maximum: 10 },
+          description: 'having count',
+          inclusive: false
+        )
+      end
+    end
+
+    context 'with minimum/maximum parameters' do
+      it 'is expected to create a range constraint' do
+        allow(type).to receive(:send)
+        builder.between(minimum: 5, maximum: 10)
+
+        expect(type).to have_received(:send).with(
+          :constrain,
+          constraining,
+          :range,
+          { minimum: 5, maximum: 10 },
+          description: 'having count',
+          inclusive: false
+        )
+      end
+    end
+
+    it 'is expected to return self for chaining' do
+      expect(builder.between(min: 5, max: 10)).to eq(builder)
+    end
+  end
+
+  describe '#exactly' do
+    it 'is expected to create an exact range constraint' do
+      allow(type).to receive(:send)
+      builder.exactly(7)
+
+      expect(type).to have_received(:send).with(
+        :constrain,
+        constraining,
+        :range,
+        { minimum: 7, maximum: 7 },
+        description: 'having count'
+      )
+    end
+
+    it 'is expected to return self for chaining' do
+      expect(builder.exactly(7)).to eq(builder)
+    end
+  end
+end


### PR DESCRIPTION
## Description

This update introduces more expressive and flexible size constraints in the `EnumerableBehavior` module. Key changes include:

### New Features

1. **RangeBuilder Class**  
   - Provides a fluent interface for size constraints.
   - Supports methods like `at_least`, `at_most`, `between`, and `exactly`.
   - Enables method chaining, integrating with the parent type system.
   - Includes full documentation and specs.
   - Reusable for numerics and strings.

2. **Enhanced `having_count` Method**  
   - Supports both builder pattern and direct options:
     - Fluent API: `having_count.at_least(5).at_most(10)`
     - Direct options: `having_count(between: { min: 5, max: 10 })`

3. **Inclusive Option for `RangeConstraint`**  
   - Adds support for exclusive ranges via `having_count.between`.
   - Defaults to inclusive behavior for backward compatibility.

### Other Improvements

- Method and alias updates in `EnumerableBehavior`.
- Maintains backward compatibility while improving readability and expressiveness.

These changes lay the groundwork for extending the `RangeBuilder` pattern to other constraint types in the future.

## Related Issues

* See #36.

## Changes Made

1. Added `Domainic::Type::Behavior::RangeBuilder`.
2. Enhanced `Domainic::Type::Behavior::EnumerableBehavior` with new features.
3. Updated `Domainic::Type::Constraint::RangeConstraint` to include an `inclusive` option.

## Checklist

Before submitting this PR, ensure the following:
- [x] All checks pass after running `bin/dev ci`.
- [x] Tests have been added/updated to confirm functionality.
- [x] Documentation has been added/updated where needed.

## Additional Notes

The `having_count` design, while complex, ensures compatibility with the existing initializer logic in Domainic::Type::Behavior. It supports multiple use cases:

### DSL Example

```ruby
ArrayType.having_count.at_least(1).at_most(3)
```

### Options API Example

```ruby
ArrayType.having_count(exactly: 5)
```

### Compatible with the Behavior initializer

```ruby
ArrayType.new(having_count: { between: { minimum: 1, maximum: 5 } })
```

## Next Steps

Although this brings the `EnumerableBehavior` module closer to completion, further work is needed on cleanup, documentation, and specs. Additionally, we should finalize the design of our expressive API.  

One proposal is to categorize methods by their purpose:
* **State-based** (e.g., `being_distinct`): prefixed with `being`.
* **Content-based**: no prefix.
* **Size-based**: prefixed with `having`.

A formal pattern decision is **critical** for the library's long-term success, but I remain open to feedback on this approach.