### PR TITLE
Add git commit template and pre-commit hook setup

### DIFF
--- a/.github/COMMIT_MESSAGE_TEMPLATE.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE.md
@@ -1,0 +1,23 @@
+Brief summary of changes (50 chars or less)
+
+Detailed explanation of the changes, if necessary. Wrap lines at 72
+characters. The body can include multiple paragraphs for complex changes.
+
+Use bullet points for specific additions/changes when helpful:
+- First change or addition
+- Second change or addition
+- etc.
+
+For significant changes, include a Changelog section listing specific
+classes, methods, or modules that were added, modified, or removed:
+
+Changelog:
+- added `Some::New::Class`
+- changed `Existing::Changed::Class`
+- fixed `Existing::Class#method`
+- removed `Old::Deprecated::Class`
+
+End with issue references using keywords like 'fixes', 'resolves', or
+'see':
+fixes #123
+see #456

--- a/bin/setup
+++ b/bin/setup
@@ -3,5 +3,32 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+# Install deoendencies
 bundle install
 bundle exec rbs collection install
+
+# Configure git commit template
+git config --local commit.template .github/COMMIT_MESSAGE_TEMPLATE.md
+
+# Configure pre-commit hook
+cat > .git/hooks/pre-commit << 'EOL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stash any unstaged changes
+git stash -q --keep-index
+
+# Run CI checks
+bin/dev ci
+
+# Store the last exit code
+RESULT=$?
+
+# Restore unstaged changes
+git stash pop -q || true
+
+# Return the exit code
+exit $RESULT
+EOL
+
+chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
This change automates two development workflow improvements:
1. Sets up a standardized git commit message template
2. Adds a pre-commit hook that runs CI checks before commits

Changes made:
- Added git commit template configuration to bin/setup
- Added pre-commit hook creation to bin/setup that runs bin/dev ci
- Created .github/gitmessage template file

The commit template helps maintain consistent commit messages while the pre-commit hook ensures code quality by running CI checks locally before commits are made.

resolves #100