### PR TITLE
Fixes `Domainic::Dev::CLI::Command::LintMarkdownCommand`

### DIFF
--- a/domainic-dev/lib/domainic/dev/cli/command/base_command.rb
+++ b/domainic-dev/lib/domainic/dev/cli/command/base_command.rb
@@ -81,6 +81,16 @@ module Domainic
             "\e[1m#{text}\e[0m"
           end
 
+          # Creates a hyperlink with the given reference and text.
+          #
+          # @param reference [String] the URL reference
+          # @param text [String] the text to display
+          # @return [String] the hyperlink
+          # @rbs (String reference, String text) -> String
+          def hyper_link(reference, text)
+            "\e]8;;#{reference}\e\\#{text}\e]8;;\e\\"
+          end
+
           # Retrieves the icon for the given name.
           #
           # @param name [String, Symbol] the name of the icon

--- a/domainic-dev/sig/domainic/dev/cli/command/base_command.rbs
+++ b/domainic-dev/sig/domainic/dev/cli/command/base_command.rbs
@@ -51,6 +51,13 @@ module Domainic
           # @return [String] the bolded text
           def embolden: (String text) -> String
 
+          # Creates a hyperlink with the given reference and text.
+          #
+          # @param reference [String] the URL reference
+          # @param text [String] the text to display
+          # @return [String] the hyperlink
+          def hyper_link: (String reference, String text) -> String
+
           # Retrieves the icon for the given name.
           #
           # @param name [String, Symbol] the name of the icon

--- a/domainic-dev/sig/domainic/dev/cli/command/lint_markdown_command.rbs
+++ b/domainic-dev/sig/domainic/dev/cli/command/lint_markdown_command.rbs
@@ -13,11 +13,21 @@ module Domainic
         class LintMarkdownCommand < BaseCommand
           type result = { success: bool, message: String, file: Pathname, output: String }
 
+          # Pattern to match a GitHub link in an mdl documentation message.
+          #
+          # @return [Regexp] the pattern
+          MDL_DOCSTRING_TO_GITHUB_LINK_PATTERN: Regexp
+
+          # Pattern to match an mdl violation line and extract the file, line number, rule ID, and message.
+          #
+          # @return [Regexp] the pattern
+          MDL_VIOLATION_TO_LINE_AND_RULE_PATTERN: Regexp
+
           @results: Array[result]
 
-          @markdown_files: Array[Pathname]
-
           @documentation_messages: Set[String]
+
+          @markdown_files: Array[Pathname]
 
           # Execute the Markdown linting command.
           #
@@ -41,16 +51,43 @@ module Domainic
           # @return [Set<String>] the documentation messages
           def documentation_messages: () -> Set[String]
 
-          # Extract error lines from a result, capturing any documentation messages.
+          # Generate a linked line number for a Markdown file.
           #
-          # @param result [Hash{Symbol => Boolean, Pathname, String}] the lint result
-          # @return [Array<String>] the error lines
-          def extract_error_lines: (result result) -> Array[String]
+          # @param file [String] the file path
+          # @param line_number [String] the line number
+          # @return [String] the linked line number
+          def linked_line_number: (String file, String line_number) -> String
+
+          # Generate a linked mdl rule id.
+          #
+          # @param mdl_rule_id [String] the mdl rule id
+          # @return [String] the linked mdl rule id
+          def linked_mdl_rule: (String mdl_rule_id) -> String
 
           # Get all Markdown files in the project.
           #
           # @return [Array<Pathname>] array of Markdown file paths
           def markdown_files: () -> Array[Pathname]
+
+          # Extract mdl violation lines from a result, capturing any mdl documentation messages.
+          #
+          # @param result [Hash{Symbol => Boolean, Pathname, String}] the lint result
+          # @return [Array<String>] the error lines
+          def parse_result: (result result) -> Array[String]
+
+          # Parse a single violation line from mdl output.
+          #
+          # @param line [String] the violation line
+          # @return [String] the parsed violation line
+          def parse_violation_line: (String line) -> String
+
+          # Parse all violation lines from mdl output.
+          #
+          # Sorts violations by line number and parses each line.
+          #
+          # @param violation_lines [Array<String>] the violation lines
+          # @return [Array<String>] the parsed violation lines
+          def parse_violation_lines: (Array[String] violation_lines) -> Array[String]
 
           # Run mdl on all Markdown files and collect results.
           #


### PR DESCRIPTION
## Description

This fixes the ordering of mdl violations in the `bin/dev lint md` output. Additionally, this enhances the output of the violations to link to the appropriate file and line number; as well as link to the mdl rule being violated.  Simply click the line number or mdl rule id, and you will be brought to the appropriate place.

## Related Issues

- fixes #97

## Changes Made

- mdl violations are now output in line order
- the line numbers of each mdl violation will go directly to the offending file and line number when clicked
- the mdl rule ids of each mdl violation will go directly to the documentation for that rule when clicked.

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed