### PR TITLE
Add documentation structure for projects and milestones

### DIFF
--- a/.github/COMMIT_MESSAGE_TEMPLATE.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE.md
@@ -4,18 +4,18 @@ Detailed explanation of the changes, if necessary. Wrap lines at 72
 characters. The body can include multiple paragraphs for complex changes.
 
 Use bullet points for specific additions/changes when helpful:
-- First change or addition
-- Second change or addition
-- etc.
+* First change or addition
+* Second change or addition
+* etc.
 
 For significant changes, include a Changelog section listing specific
 classes, methods, or modules that were added, modified, or removed:
 
 Changelog:
-- added `Some::New::Class`
-- changed `Existing::Changed::Class`
-- fixed `Existing::Class#method`
-- removed `Old::Deprecated::Class`
+* added `Some::New::Class`
+* changed `Existing::Changed::Class`
+* fixed `Existing::Class#method`
+* removed `Old::Deprecated::Class`
 
 End with issue references using keywords like 'fixes', 'resolves', or
 'see':

--- a/docs/milestones/domainic-attributer-v0.1.0.md
+++ b/docs/milestones/domainic-attributer-v0.1.0.md
@@ -1,0 +1,111 @@
+# domainic-attributer v0.1.0
+
+[![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/4?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/4)
+
+![Milestone Due Date](https://img.shields.io/badge/12%2F12%2F2024-blue?style=for-the-badge&label=Due%20Date)
+
+A Ruby gem that provides an elegant DSL for defining and managing object attributes with built-in support for type
+validation, coercion, change tracking, and more.
+
+## Problem Statement
+
+Ruby's built-in attribute methods (`attr_reader`, `attr_writer`, `attr_accessor`) provide basic attribute functionality
+but lack important features needed for domain-driven design such as type validation, coercion, and change tracking.
+Developers often end up writing repetitive boilerplate code to handle these common needs.
+
+## Solution
+
+Domainic::Attributer provides a rich DSL for defining object attributes that handles common attribute-related tasks
+while maintaining Ruby's expressiveness. It distinguishes between constructor arguments and optional attributes while
+providing a consistent interface for both.
+
+## Key Features
+
+* **Positional Arguments vs Named Options**: Clear distinction between required constructor arguments and optional
+  attributes
+* **Type Validation**: Built-in type checking with support for custom validators
+* **Value Coercion**: Automatic value transformation with custom coercion support
+* **Default Values**: Support for both static defaults and dynamic generators
+* **Change Tracking**: Callback system for monitoring attribute changes
+* **Visibility Control**: Fine-grained control over attribute reader/writer visibility
+* **Extensible Design**: Support for custom naming conventions and attribute behaviors
+
+## Usage Examples
+
+```ruby
+class UserCreator
+  include Domainic::Attributer
+
+  argument :login, String do
+    desc 'The login for the User'
+    coerce_with ->(value) { value.to_s }
+    validate_with ->(value) { Uri::MailTo::EMAIL_REGEXP.match?(value) }
+    non_nilable
+  end
+
+  option :password, String do
+    desc 'The user password'
+    non_nilable
+    required
+  end
+
+  option :role, Symbol do
+    desc 'The role of the User'
+    default :basic
+    validate_with ->(value) { USER_ROLES.include?(value) }
+  end
+end
+
+# Usage:
+UserCreator.new('hello@example.com', password: 'secure123')
+UserCreator.new('hello@example.com', password: 'secure123', role: :admin)
+```
+
+## Technical Details
+
+### Attribute Types
+
+* **Arguments**: Positional parameters required during object initialization
+* **Options**: Named parameters that may be optional or required
+
+### Validation Features
+
+* Non-nilable attributes
+* Required vs optional options
+* Type validation
+* Custom validation rules
+
+### Coercion System
+
+* Automatic type coercion
+* Custom coercion handlers
+* Value transformation hooks
+
+### Change Tracking
+
+* Before/after change callbacks
+* Custom change handlers
+* Value transformation tracking
+
+### Visibility Controls
+
+* Public/protected/private readers
+* Public/protected/private writers
+* Mixed visibility support
+
+## Dependencies
+
+* Ruby 3.1+
+* No external runtime dependencies
+
+## Performance Considerations
+
+* Minimal runtime overhead
+* Lazy initialization of attribute handlers
+* Efficient memory usage through shared handlers
+
+## Future Considerations
+
+* Integration points with domainic-validator
+* Extension points for domainic-type
+* Potential for custom attribute types

--- a/docs/milestones/domainic-attributer-v0.2.0.md
+++ b/docs/milestones/domainic-attributer-v0.2.0.md
@@ -1,0 +1,129 @@
+# domainic-attributer v0.2.0
+
+[![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/3?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/3)
+
+![Milestone Due Date](https://img.shields.io/badge/01%2F01%2F2025-blue?style=for-the-badge&label=Due%20Date)
+
+## Overview
+
+A significant release focusing on developer experience, error handling, and documentation clarity. This release
+introduces several improvements that may impact existing code, necessitating a minor version bump.
+
+## Confirmed Changes
+
+### 1. Nil Handling in Coercion
+
+* Prevent coercion of nil values for non-nilable attributes
+* Provide clear documentation about nil handling in coercion methods
+* Modify coercion logic to respect nilability constraints
+
+### 2. Documentation Improvements
+
+* Clarify attribute validation and coercion behavior
+* Explain attribute constraint application across object lifecycle
+* Provide comprehensive examples of validation mechanisms
+* Explicitly document that constraints apply to ALL attribute assignments
+
+### 3. Callback Error Handling
+
+* Implement comprehensive error handling for callback execution
+* Introduce configurable error handling strategies:
+  1. Raise an error and stop execution (default)
+  2. Log the error and continue
+  3. Collect errors and raise a composite error
+* Create custom `CallbackError` and `CompositeCallbackError` classes
+* Add configuration option for error handling strategy
+
+## Release Goals
+
+* Improve nil value handling
+* Enhance error handling for callbacks
+* Provide crystal-clear documentation
+* Increase overall library robustness
+
+## Breaking Changes
+
+1. Nil Coercion Prevention
+  * Non-nilable attributes will no longer coerce nil values
+  * Existing code may need to be updated to explicitly handle nil cases
+2. Callback Error Handling
+  * New error handling strategies
+  * Introduction of custom error classes
+  * Potential changes to callback execution behavior
+
+### Nil Coercion
+
+```ruby
+# Before (0.1.x)
+option :count, Integer do
+  coerce_with :to_i  # Would attempt to coerce nil
+end
+
+# After (0.2.0)
+option :count, Integer do
+  coerce_with :to_i  # Nil will be prevented for non-nilable attributes
+  # Explicitly handle nil if needed
+  coerce_with ->(val) { val.nil? ? 0 : val.to_i }
+end
+```
+
+### Callback Error Handling
+
+```ruby
+# Before (0.1.x)
+# No explicit error handling
+
+# After (0.2.0)
+class MyClass
+  include Domainic::Attributer
+
+  option :value do
+    on_change ->(old, new) { ... }
+
+    # Optional: Configure error handling
+    on_change_error_strategy :log  # or :raise, :collect
+  end
+end
+```
+
+## Acceptance Criteria
+
+* [x] Nil coercion prevention implemented
+* [x] Comprehensive documentation updates
+* [x] Callback error handling mechanism complete
+* [x] All existing tests pass
+* [x] New tests cover nil handling and error strategies
+* [x] Migration guide is clear and comprehensive
+
+## Release Preparation Workflow
+
+1. **Feature Implementation** (Now * Dec 25th)
+  * Finalize code changes
+  * Comprehensive testing
+  * Documentation updates
+2. **Final Review** (Dec 26th * Dec 31st)
+  * Thorough testing
+  * Documentation review
+  * Migration guide verification
+3. **Release** (January 1st)
+  * Tag release
+  * Publish to RubyGems
+  * Update documentation
+
+## Communication Plan
+
+* Detailed changelog highlighting breaking changes
+* Clear migration guide
+* Community notification about new features
+
+## Risks
+
+* Potential confusion with breaking changes
+* Complexity of error handling strategies
+* Performance implications of new error handling
+
+## Post-Release Considerations
+
+* Monitor community feedback
+* Be prepared to provide additional clarification
+* Potential follow-up patch releases for any discovered issues

--- a/docs/milestones/domainic-boundary-v0.1.0.md
+++ b/docs/milestones/domainic-boundary-v0.1.0.md
@@ -1,0 +1,119 @@
+# domainic-boundary v0.1.0
+
+[![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/7?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/7)
+
+![Milestone Due Date](https://img.shields.io/badge/TBD-blue?style=for-the-badge&label=Due%20Date)
+
+Domainic::Boundary is a sophisticated Ruby gem that provides a robust implementation of the Gateway pattern, designed to
+create clear, controlled interfaces between different domains in complex software architectures. By establishing
+explicit, type-safe communication channels, the gem helps manage the interactions between bounded contexts with
+precision and clarity.
+
+## Problem Statement
+
+In large, complex software systems, domains often need to interact while maintaining clear boundaries and preventing
+tight coupling. Existing communication patterns frequently lead to:
+
+* Implicit dependencies
+* Lack of clear interface contracts
+* Difficult-to-maintain cross-domain interactions
+* Reduced system modularity
+
+## Solution
+
+Domainic::Boundary introduces a declarative, type-safe gateway system that allows domains to define explicit, documented
+interfaces for cross-domain communication. Each gateway provides a controlled, well-defined mechanism for interaction,
+promoting loose coupling and clear architectural boundaries.
+
+## Key Features
+
+* **Explicit Domain Interfaces**
+  * Type-safe parameter definitions
+  * Documented method exposures
+  * Clear input and output specifications
+  * Controlled domain interactions
+* **Gateway Definition**
+  * Declarative interface creation
+  * Command-based method exposures
+  * Comprehensive parameter validation
+  * Return type specifications
+* **Interaction Control**
+  * Explicit method exposures
+  * Type checking for inputs and outputs
+  * Metadata-rich interface descriptions
+
+## Usage Examples
+
+```ruby
+module IdentityProvider
+  class Gateway < Domainic::Boundary::Gateway
+    expose :create_user do
+      desc 'Create a new User with login and password'
+      implementation CreateUserCommand, :call
+      param :login, EmailAddress, "The User's Login", required: true
+      param :password, String, "The User's Password", required: true
+      param :role, Symbol, "The User's role", default: :member
+      returns CreateUserCommandResult
+    end
+
+    expose :authenticate_user do
+      desc 'Authenticate a user with credentials'
+      implementation AuthenticateUserCommand, :call
+      param :login, EmailAddress, "The User's Login", required: true
+      param :password, String, "The User's Password", required: true
+      returns AuthenticationResult
+    end
+  end
+end
+
+# Usage
+result = IdentityProvider::Gateway.create_user(login: 'user@example.com', password: 'secure_password')
+```
+
+## Technical Details
+
+### Gateway Characteristics
+
+* Explicit method exposures
+* Type-safe parameter definitions
+* Command-based implementations
+* Rich metadata and documentation
+
+### Communication Strategies
+
+* Synchronous domain interactions
+* Explicit interface contracts
+* Controlled method exposures
+
+## Design Philosophy
+
+Domainic::Boundary prioritizes:
+
+* Clear domain boundaries
+* Minimal implicit dependencies
+* Type safety
+* Explicit communication patterns
+* Architectural modularity
+
+## Dependencies
+
+* Ruby 3.1+
+* Optional integration with Domainic::Command
+* Optional integration with Domainic::Validation
+* Optional integration with Domainic::Type
+
+## Future Considerations
+
+* Async gateway interactions
+* Advanced logging and tracing
+* Performance optimizations
+* Event-driven communication patterns
+* Middleware support for gateways
+
+## Performance Considerations
+
+* Lightweight gateway object creation
+* Efficient method dispatch
+* Minimal runtime overhead
+* Lazy parameter validation
+* Optimized for complex domain interactions

--- a/docs/milestones/domainic-command-v0.1.0.md
+++ b/docs/milestones/domainic-command-v0.1.0.md
@@ -1,0 +1,110 @@
+# domainic-command v0.1.0
+
+[![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/6?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/6)
+
+![Milestone Due Date](https://img.shields.io/badge/TBD-blue?style=for-the-badge&label=Due%20Date)
+
+Domainic::Command is a powerful Ruby gem that brings the Command design pattern to life, offering a robust framework for
+encapsulating and managing complex business operations. By treating commands as first-class objects, the gem provides a
+structured, testable, and extensible approach to implementing domain logic.
+
+## Problem Statement
+
+Complex business operations often become tangled, difficult to test, and hard to maintain. Traditional approaches mix
+concerns, making code less readable and more prone to errors. Developers need a way to isolate, compose, and manage
+business logic with clarity and precision.
+
+## Solution
+
+Domainic::Command provides a clean, declarative approach to defining executable operations. Each command becomes a
+self-contained object with clear input arguments, output expectations, and execution logic, promoting separation of
+concerns and improving code maintainability.
+
+## Key Features
+
+* **Declarative Command Definition**
+  * Clear argument specifications
+  * Explicit return type declarations
+  * Built-in validation for inputs and outputs
+  * Support for required and optional arguments
+* **Comprehensive Command Lifecycle**
+  * Input validation
+  * Execution context management
+  * Return value tracking
+  * Error handling capabilities
+* **Flexible Execution Model**
+  * Synchronous command execution
+  * Potential for async/background processing
+  * Composable command chains
+  * Introspection of command metadata
+
+## Usage Examples
+
+```ruby
+class CreateUser < Domainic::Command
+  argument :login, EmailAddress, "The User's login", required: true
+  argument :password, String, "The User's password", required: true
+  argument :role, Symbol, "User's initial role", default: :member
+
+  returns :user, User, 'The created User', required: true
+
+  def execute
+    context.user = User.create!(
+      email: context.login,
+      password: context.password,
+      role: context.role
+    )
+  end
+end
+
+# Executing the command
+result = CreateUser.call(login: 'user@example.com', password: 'secure_password')
+result.success? #=> true
+result.data.user #=> <# User:0x000000ab0c1d @login="user@example.com", @password_digest="...", @role=:member>
+```
+
+## Technical Details
+
+### Command Characteristics
+
+* Explicit argument definitions
+* Type-checked inputs
+* Standardized execution interface
+* Metadata-rich command objects
+
+### Execution Strategies
+
+* Synchronous execution
+* Potential background job integration
+* Contextual execution support
+
+## Design Philosophy
+
+Domainic::Command prioritizes:
+
+* Clarity of intent
+* Testability of business logic
+* Minimal boilerplate
+* Flexible composition
+* Type safety
+
+## Dependencies
+
+* Ruby 3.1+
+* Optional integration with Domainic::Attributer
+* Optional integration with Domainic::Validation
+
+## Future Considerations
+
+* Advanced command composition
+* Async/background execution support
+* Comprehensive logging and tracing
+* Integration with workflow systems
+* Performance optimizations
+
+## Performance Considerations
+
+* Lightweight command object creation
+* Minimal runtime overhead
+* Efficient validation mechanisms
+* Lazy argument processing

--- a/docs/milestones/domainic-type-v0.1.0.md
+++ b/docs/milestones/domainic-type-v0.1.0.md
@@ -1,0 +1,228 @@
+# domainic-attributer v0.1.0
+
+[![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/5?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/5)
+
+![Milestone Due Date](https://img.shields.io/badge/TBD-blue?style=for-the-badge&label=Due%20Date)
+
+## Problem Statement
+
+Ruby lacks a robust, expressive type system that can capture complex domain constraints. While several type checking
+solutions exist, they often focus on basic type validation or static analysis. Developers need a more sophisticated
+runtime type system that can:
+
+* Express complex structural and behavioral constraints
+* Provide rich, composable type definitions
+* Support domain-specific type requirements
+* Maintain Ruby's expressiveness and flexibility
+* Enable precise runtime type checking
+
+Current solutions force developers to:
+
+* Write verbose, repetitive validation code
+* Mix validation logic with domain logic
+* Create custom type checking systems
+* Sacrifice expressiveness for type safety
+
+## Context
+
+We need to create a standalone type system that brings sophisticated type constraints to Ruby while maintaining its
+elegant, expressive nature. The system should serve as a foundational tool that can be used:
+
+1. **Independently**
+  * Standalone type validation
+  * Complex data structure validation
+  * API contract enforcement
+  * Domain model constraints
+2. **As Part of Larger Systems**
+  * Integration with ORMs
+  * Validation frameworks
+  * Domain-driven design tools
+  * API frameworks
+
+3. **In Various Contexts**
+  * Web applications
+  * Data processing systems
+  * Domain modeling
+  * Service interfaces
+
+## Research & Discovery
+
+### Type System Access
+
+Two main approaches were evaluated:
+
+1. **Global Prefix Module**:
+
+   ```ruby
+   Domainic::Type.configure do |config|
+     config.enable_global_prefix(:T)
+   end
+
+   T.Array      # => Domainic::Type::ArrayType
+   T::Array     # => Domainic::Type::ArrayType
+   T.Array?     # => Union(Domainic::Type::ArrayType, nil)
+   ```
+
+2. **Module Installation**:
+
+   ```ruby
+   module MyTypes
+     include Domainic::Type::Definitions
+   end
+
+   MyTypes.Array      # => Domainic::Type::ArrayType
+   ```
+
+### Type Constraint Expression
+
+Explored fluent interfaces for complex constraints:
+
+```ruby
+Array.of(String)
+  .having_minimum_count(2)
+  .having_maximum_count(5)
+  .beginning_with("foo")
+  .ending_with("bar")
+  .containing("baz")
+```
+
+### Error Message Composition
+
+Evaluated multiple approaches and settled on structured formatting:
+
+```ruby
+Expected an Array, got an Array:
+  * Expected all elements must be: a String, but got [Integer at index 0]
+  * Expected not: being empty
+```
+
+## Decision
+
+### 1. Architecture
+
+1. **Core Components**:
+  * Base type behavior module
+  * Constraint system
+  * Error message builder
+  * Type registry
+2. **Design Philosophy**:
+  * Expressiveness over verbosity
+  * Performance through lazy evaluation
+  * Minimal memory overhead
+  * Developer productivity focus
+
+### 2. Type System Features
+
+1. **Type Access**:
+  * Support both global prefix and module installation
+  * Use underscore prefix for conflict resolution
+  * Support both dot and double colon notation
+2. **Error Messages**:
+  * Structured, hierarchical format
+  * Clear type and constraint violations
+  * Support for nested constraints
+  * Actionable error messages
+3. **Core Types** (v0.1.0):
+  * Anything/Any
+  * Array/List
+  * Boolean/Bool
+  * Duck/Interface/RespondsTo
+  * Enum/Literal
+  * Float/Decimal
+  * Hash/Dictionary/Map
+  * Integer/Int/Number
+  * String/Text
+  * Symbol
+  * Union/Either
+  * Void
+4. **Constraint System**:
+  * Base constraint behavior
+  * Composable constraints
+  * Extension points
+  * Type-safe implementation
+
+### 3. Technical Requirements
+
+1. **Performance**:
+  * Lazy constraint evaluation
+  * Minimal object allocation
+  * Efficient constraint chaining
+2. **Safety**:
+  * Thread-safe operations
+  * Type-safe implementations
+  * Clear validation boundaries
+3. **Integration**:
+  * Simple integration interface
+  * Extensible constraint system
+  * Custom type support
+
+## Consequences
+
+### Positive
+
+1. Expressive type definitions
+2. Clear validation messages
+3. Flexible deployment options
+4. Strong integration capabilities
+5. Performance through lazy evaluation
+6. Clean extension points
+7. Standalone usability
+8. Framework independence
+
+### Negative
+
+1. Initial implementation complexity
+2. Learning curve for constraint authors
+3. Potential memory overhead with complex chains
+4. Need to handle Ruby core conflicts
+
+### Neutral
+
+1. Similar to existing type systems
+2. Documentation overhead
+3. Regular maintenance needs
+
+## Implementation Plan
+
+### Phase 1: Foundation (v0.1.0)
+
+1. Core Infrastructure
+  * Base type behavior
+  * Constraint system
+  * Error handling
+  * Type registry
+2. Basic Types
+  * Simple types (Integer, String)
+  * Basic constraints
+  * Initial test suite
+
+### Phase 2: Enhancement (v0.2.0)
+
+1. Advanced Features
+  * Complex types
+  * Nested constraints
+  * Custom validators
+2. Documentation & Examples
+  * Standalone usage
+  * Integration patterns
+  * Extension guides
+
+### Phase 3: Optimization (v0.3.0)
+
+1. Performance
+  * Constraint caching
+  * Memory optimization
+  * Validation shortcuts
+2. Extensions
+  * Community types
+  * Custom constraints
+  * Additional validators
+
+## Open Questions
+
+1. Version-specific Ruby feature handling
+2. Core class conflict resolution strategy
+3. Type inference support scope
+4. Runtime optimization approaches
+5. Custom constraint verification
+6. Framework integration patterns

--- a/docs/projects/domainic-v0.1.0/README.md
+++ b/docs/projects/domainic-v0.1.0/README.md
@@ -1,0 +1,105 @@
+# Domainic v0.1.0
+
+[![Project Status](https://img.shields.io/badge/In%20Progress-orange?style=for-the-badge&label=Status)](https://github.com/orgs/domainic/projects/13)
+
+## Short Description
+
+The inaugural release of the Domainic ecosystem, establishing a comprehensive foundation for domain-driven design in
+Ruby. This milestone introduces a complete set of tools for building robust, maintainable Ruby applications with a focus
+on domain modeling, clean architecture, and type safety.
+
+## Included Milestones
+
+* [x] [domainic-attributer v0.1.0](https://github.com/domainic/domainic/milestone/4)
+* [ ] [domainic-attributer v0.2.0](https://github.com/domainic/domainic/milestone/3)
+* [ ] [domainic-boundary v0.1.0](https://github.com/domainic/domainic/milestone/7)
+* [ ] [domainic-command v0.1.0](https://github.com/domainic/domainic/milestone/6)
+* [ ] [domainic-type v0.1.0](https://github.com/domainic/domainic/milestone/5)
+
+## Key Components
+
+### Domainic::Attributer
+
+* Advanced attribute management system
+* Comprehensive type validation and coercion
+* Flexible attribute definition DSL
+* Robust error handling
+
+### Domainic::Boundary
+
+* Explicit domain interfaces and boundaries
+* Type-safe gateway pattern implementation
+* Controlled cross-domain communication
+* Clear architectural boundaries
+
+### Domainic::Command
+
+* First-class command objects for business operations
+* Clear argument and return type specifications
+* Standardized execution interface
+* Rich command metadata
+
+### Domainic::Type
+
+* Sophisticated type constraint system
+* Granular structural and content-based validations
+* Chainable type definitions
+* Support for complex nested types
+
+## Release Highlights
+
+* Complete domain-driven design toolkit
+* Comprehensive type safety across all components
+* Seamless integration between gems
+* Clear, declarative APIs throughout
+* Focus on developer experience and productivity
+
+## Architectural Vision
+
+This release introduces a cohesive ecosystem of Ruby libraries designed to support sophisticated domain modeling:
+
+* Domainic::Attributer provides the foundation for building expressive, type-safe domain objects
+* Domainic::Type enables precise definition of complex type constraints
+* Domainic::Command encapsulates business operations as first-class objects
+* Domainic::Boundary manages clean separation between domains
+
+These components work together to enable robust, maintainable domain-driven applications while maintaining Ruby's
+expressiveness.
+
+## Future Roadmap
+
+* Enhanced integration between components
+* Advanced command composition patterns
+* Extended type constraint capabilities
+* Performance optimizations across the ecosystem
+* Additional architectural patterns and tools
+
+## Key Features
+
+* Comprehensive type safety system
+* Rich domain object modeling
+* Clear architectural boundaries
+* First-class command objects
+* Explicit domain interfaces
+* Flexible validation strategies
+* Advanced error handling
+
+## Target Audience
+
+* Ruby developers building complex domain models
+* Teams implementing domain-driven design
+* Developers seeking architectural clarity
+* Projects requiring robust type safety
+* Applications with complex domain interactions
+
+## Release Philosophy
+
+**Prioritizing**:
+
+* Clean architecture
+* Type safety
+* Developer productivity
+* Domain isolation
+* Minimal runtime overhead
+* Clear interfaces
+* Testability

--- a/docs/projects/domainic-v0.1.0/updates/2024-12-12-01.md
+++ b/docs/projects/domainic-v0.1.0/updates/2024-12-12-01.md
@@ -1,0 +1,31 @@
+# domainic-attributer v0.1.0 Released
+
+We're excited to announce our first milestone with the release of domainic-attributer v0.1.0 on December 12th! This
+marks the beginning of the Domainic ecosystem, a comprehensive suite of Ruby gems for domain-driven design.
+
+## Released Components
+
+### domainic-attributer v0.1.0 ✅
+
+The first stable release provides robust attribute management with comprehensive type validation, coercion, and error
+handling capabilities. You can start using it today:
+
+```ruby
+gem 'domainic-attributer', '~> 0.1.0'
+```
+
+## In Progress
+
+The following components are actively under development for the v0.1.0 ecosystem release:
+
+- domainic-attributer v0.2.0 - Enhanced error handling and nil management
+- domainic-type v0.1.0 - Sophisticated type constraints
+- domainic-command v0.1.0 - First-class command objects
+- domainic-boundary v0.1.0 - Domain interface management
+
+## What's Next
+
+Over the coming weeks, we'll be focusing on completing and releasing the remaining components to deliver a complete
+domain-driven design toolkit for Ruby developers.
+
+Stay tuned for more updates as we progress toward the full Domainic v0.1.0 release!

--- a/docs/projects/domainic-v0.1.0/updates/2024-12-12-02.md
+++ b/docs/projects/domainic-v0.1.0/updates/2024-12-12-02.md
@@ -1,0 +1,36 @@
+# domainic-attributer v0.2.0
+
+Following the successful release of domainic-attributer v0.1.0 on December 12th, we're excited to announce that
+domainic-attributer v0.2.0 is scheduled for release on January 1st, 2025!
+
+## domainic-attributer v0.2.0 Release Plan
+
+The upcoming release focuses on enhancing developer experience, error handling, and documentation clarity. Key
+improvements include:
+
+### Nil Handling & Coercion
+
+* Improved nil value handling with explicit nilability constraints
+* Enhanced coercion behavior respecting nilability rules
+* Clear documentation about nil handling in coercion methods
+
+### Enhanced Error Handling
+
+* New callback error handling strategies
+* Custom error classes for better error management
+* Configurable error handling approaches
+
+### Documentation Improvements
+
+* Comprehensive examples of validation mechanisms
+* Clear explanation of attribute lifecycle constraints
+* Enhanced migration guides and examples
+
+## Timeline
+
+* Feature Implementation: Now * Dec 25th
+* Final Review: Dec 26th * Dec 31st
+* Release: January 1st, 2025
+
+Stay tuned for more updates about the full Domainic v0.1.0 ecosystem as we continue development of domainic-type,
+domainic-command, and domainic-boundary!


### PR DESCRIPTION
## Description

Create a dedicated docs folder to provide a centralized, maintainable location for project and milestone documentation that was previously scattered across GitHub UI elements (project descriptions, milestone descriptions, etc.).

This change improves documentation accessibility and maintainability by:

* Moving documentation from GitHub UI into versioned repository
* Creating a clear organization for projects and milestones
* Enabling proper formatting and structure
* Making documentation available offline
* Simplifying review and maintenance processes

Structure:

* docs/projects/*       Project documentation and updates
* docs/milestones/*     Milestone planning and completion docs

GitHub project and milestone descriptions will now link to these docs rather than duplicating content, creating a single source of truth while keeping the documentation properly versioned with the codebase.

Project updates remain in both GitHub UI and docs to balance immediate visibility with historical record-keeping.