### PR TITLE
Add environment specific rubocop configurations

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,13 +2,19 @@ default: true
 
 MD007:
   indent: 2
+
 MD013:
   line_length: 120
   tables: false
+
+# Allow CHANGELOG.md like nesting
 MD024:
   allow_different_nesting: true
+
 MD029:
   style: ordered
+
+# Allow collapsible details
 MD033:
   allowed_elements:
     - details

--- a/.rubocop-base.yml
+++ b/.rubocop-base.yml
@@ -1,0 +1,36 @@
+require:
+  - rubocop-performance
+  - rubocop-rspec
+
+AllCops:
+  Exclude:
+    - vendor/**/*
+  NewCops: enable
+  TargetRubyVersion: 3.1
+
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
+Metrics/ClassLength:
+  Max: 500
+
+Metrics/ModuleLength:
+  Max: 500
+
+Naming/FileName:
+  Exclude:
+    - '**/domainic-*'
+
+RSpec/ExampleLength:
+  Max: 15
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/NestedGroups:
+  AllowedGroups:
+    - describe
+
+Style/Documentation:
+  AllowedConstants:
+    - Domainic

--- a/.rubocop-codacy.yml
+++ b/.rubocop-codacy.yml
@@ -1,0 +1,1 @@
+inherit_from: .rubocop-base.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,42 +1,9 @@
+inherit_from: .rubocop-base.yml
+
 require:
   - rubocop-on-rbs
   - rubocop-ordered_methods
-  - rubocop-performance
-  - rubocop-rspec
   - rubocop-yard
-
-AllCops:
-  Exclude:
-    - vendor/**/*
-  NewCops: enable
-  TargetRubyVersion: 3.1
-
-Layout/LeadingCommentSpace:
-  AllowRBSInlineAnnotation: true
-
-Metrics/ClassLength:
-  Max: 500
-
-Metrics/ModuleLength:
-  Max: 500
-
-Naming/FileName:
-  Exclude:
-    - '**/domainic-*'
 
 RBS:
   Enabled: true
-
-RSpec/ExampleLength:
-  Max: 15
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 10
-
-RSpec/NestedGroups:
-  AllowedGroups:
-    - describe
-
-Style/Documentation:
-  AllowedConstants:
-    - Domainic


### PR DESCRIPTION
## Description

This breaks our rubocop configuration into environment specific files to attempt to resolve compatibility issues with some of the rubocop extensions we use and codacy.

## Related Issues

error from Codacy:

```markdown
An error occurred during this step. Please retry your analysis or contact support.
KubernetesDockerRunner: Container for codacy/codacy-rubocop:5.4.181 exited with non-zero code 1
Error executing the tool
java.lang.Exception: 
Rubocop exited with code 2
stdout: 
stderr: cannot load such file -- rubocop-on-rbs
/usr/local/bundle/gems/rubocop-1.68.0/lib/rubocop/feature_loader.rb:46:in `rescue in rescue in load'
```

## Changes Made

* added .rubocop-base.yml
* added .rubocop-codacy.yml
* changed .rubocop.yml to inherit from .rubocop-base.yml

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed

## Additional Notes

This may not work, I won't know until the next Codacy run. I am not sure if Codacy supports `inherit_from`. If this issue persists we will either contact codacy to ask them to add the offending extensions, or reconfigure how our rubocop configuration files are structured.
