### PR TITLE
Add project/milestone documentation generators

### DIFF
--- a/domainic-dev/lib/domainic/dev/cli/generate_cli.rb
+++ b/domainic-dev/lib/domainic/dev/cli/generate_cli.rb
@@ -2,6 +2,7 @@
 
 require 'domainic/dev/cli/command/generate_signatures_command'
 require 'domainic/dev/generator/gem_generator'
+require 'domainic/dev/generator/project_doc_generator'
 require 'thor'
 
 module Domainic
@@ -31,6 +32,13 @@ module Domainic
           'gem',
           'gem NAME',
           'Generate a new Domainic gem'
+        )
+
+        register(
+          Generator::ProjectDocGenerator,
+          'project_doc',
+          'project_doc <NAME> <ID>',
+          'Generate project documentation'
         )
         # steep:ignore:end
       end

--- a/domainic-dev/lib/domainic/dev/cli/generate_cli.rb
+++ b/domainic-dev/lib/domainic/dev/cli/generate_cli.rb
@@ -4,6 +4,7 @@ require 'domainic/dev/cli/command/generate_signatures_command'
 require 'domainic/dev/generator/gem_generator'
 require 'domainic/dev/generator/milestone_doc_generator'
 require 'domainic/dev/generator/project_doc_generator'
+require 'domainic/dev/generator/project_update_doc_generator'
 require 'thor'
 
 module Domainic
@@ -47,6 +48,13 @@ module Domainic
           'project_doc',
           'project_doc <NAME> <ID>',
           'Generate project documentation'
+        )
+
+        register(
+          Generator::ProjectUpdateDocGenerator,
+          'project_update_doc',
+          'project_update_doc <PROJECT_NAME>',
+          'Generate a new project update document'
         )
         # steep:ignore:end
       end

--- a/domainic-dev/lib/domainic/dev/cli/generate_cli.rb
+++ b/domainic-dev/lib/domainic/dev/cli/generate_cli.rb
@@ -2,6 +2,7 @@
 
 require 'domainic/dev/cli/command/generate_signatures_command'
 require 'domainic/dev/generator/gem_generator'
+require 'domainic/dev/generator/milestone_doc_generator'
 require 'domainic/dev/generator/project_doc_generator'
 require 'thor'
 
@@ -32,6 +33,13 @@ module Domainic
           'gem',
           'gem NAME',
           'Generate a new Domainic gem'
+        )
+
+        register(
+          Generator::MilestoneDocGenerator,
+          'milestone_doc',
+          'milestone_doc <NAME> <ID>',
+          'Generate milestone documentation'
         )
 
         register(

--- a/domainic-dev/lib/domainic/dev/generator/milestone_doc_generator.rb
+++ b/domainic-dev/lib/domainic/dev/generator/milestone_doc_generator.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'domainic/dev'
+require 'domainic/dev/generator/base_generator'
+
+module Domainic
+  module Dev
+    module Generator
+      # A generator for creating new milestone documentation.
+      #
+      # This creates new milestone documentation in the `docs/milestone` directory.
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class MilestoneDocGenerator < BaseGenerator
+        # @rbs @due_date: String
+
+        argument :name, type: :string # steep:ignore NoMethod
+        argument :id, type: :numeric # steep:ignore NoMethod
+
+        class_option :due, type: :string, desc: 'The due date for the milestone', default: 'TBD' # steep:ignore
+
+        # rubocop:disable Layout/OrderedMethods
+
+        # Initialize a new MilestoneDocGenerator instance.
+
+        # @param arguments [Array<Object>] the generator arguments
+        # @param options [Array<Object>] additional options
+        # @return [void]
+        # @rbs (Array[untyped], *untyped) -> void
+        def initialize(arguments, *options)
+          super
+          parse_due_date!
+        end
+
+        # Ensure the milestone does not already exist.
+        #
+        # @raise [ArgumentError] if the milestone already exists
+        # @return [void]
+        # @rbs () -> void
+        def ensure_project_does_not_exist
+          return unless Domainic::Dev.root.join("docs/milestones/#{filename}").exist?
+
+          raise ArgumentError, "Milestone #{name} already exists."
+        end
+
+        def create_milestone_documentation
+          template('milestone.md.erb', "docs/milestones/#{filename}") # steep:ignore NoMethod
+        end
+
+        # @rbs! def id: () -> Integer
+        # @rbs! def name: () -> String
+
+        # rubocop:enable Layout/OrderedMethods
+        private
+
+        attr_reader :due_date
+
+        # The name of the project directory based on the project name.
+        #
+        # @return [String]
+        # @rbs () -> String
+        def filename
+          "#{name.split.join('-').downcase}.md"
+        end
+
+        def parse_due_date!
+          @due_date = if options[:due] == 'TBD' # steep:ignore NoMethod
+                        'TBD'
+                      else
+                        date = Date.parse(options[:due]) # steep:ignore NoMethod
+                        "#{date.month}%2F#{date.day}%2F#{date.year}"
+                      end
+        end
+      end
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/dev/generator/project_doc_generator.rb
+++ b/domainic-dev/lib/domainic/dev/generator/project_doc_generator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'domainic/dev'
+require 'domainic/dev/generator/base_generator'
+
+module Domainic
+  module Dev
+    module Generator
+      # A generator for creating new project documentation.
+      #
+      # This creates new project documentation in the `docs/projects` directory.
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class ProjectDocGenerator < BaseGenerator
+        argument :name, type: :string # steep:ignore NoMethod
+        argument :id, type: :numeric # steep:ignore NoMethod
+
+        # rubocop:disable Layout/OrderedMethods
+
+        # Ensure the project does not already exist.
+        #
+        # @raise [ArgumentError] if the project already exists
+        # @return [void]
+        # @rbs () -> void
+        def ensure_project_does_not_exist
+          return unless Domainic::Dev.root.join("docs/projects/#{directory_name}").exist?
+
+          raise ArgumentError, "Project #{name} already exists."
+        end
+
+        # Create the project directory.
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_project_directory
+          empty_directory("docs/projects/#{directory_name}") # steep:ignore NoMethod
+        end
+
+        def create_project_readme
+          template('README.md.erb', "docs/projects/#{directory_name}/README.md") # steep:ignore NoMethod
+        end
+
+        # @rbs! def id: () -> Integer
+        # @rbs! def name: () -> String
+
+        # rubocop:enable Layout/OrderedMethods
+        private
+
+        # The name of the project directory based on the project name.
+        #
+        # @return [String]
+        # @rbs () -> String
+        def directory_name
+          name.split.join('-').downcase
+        end
+      end
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/dev/generator/project_update_doc_generator.rb
+++ b/domainic-dev/lib/domainic/dev/generator/project_update_doc_generator.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'domainic/dev'
+require 'domainic/dev/generator/base_generator'
+
+module Domainic
+  module Dev
+    module Generator
+      # This generator creates a new document for a project update.
+      #
+      # @since 0.1.0
+      class ProjectUpdateDocGenerator < BaseGenerator
+        # @rbs @date_string: String
+        # @rbs @project_directory: Pathname
+        # @rbs @update_number: String
+
+        argument :project_name, type: :string # steep:ignore NoMethod
+
+        # rubocop:disable Layout/OrderedMethods
+
+        # Ensure the project exists
+        #
+        # @raise [ArgumentError] if the project does not exist
+        # @return [void]
+        # @rbs () -> void
+        def ensure_project_exists
+          raise ArgumentError, "Unknown project: #{project_name}" unless project_directory.exist?
+        end
+
+        # Create the updates directory if it does not exist
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_update_directory
+          empty_directory("#{project_directory}/updates") # steep:ignore NoMethod
+        end
+
+        # Create the new update document
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_update_document
+          # steep:ignore:start
+          template('update.md.erb', "#{project_directory}/updates/#{date_string}-#{update_number}.md")
+          # steep:ignore:end
+        end
+
+        # @rbs! def project_name: () -> String
+
+        # rubocop:enable Layout/OrderedMethods
+
+        private
+
+        # Today's date as a string in the format 'YYYY-MM-DD'
+        #
+        # @return [String]
+        # @rbs () -> String
+        def date_string
+          @date_string ||= Date.today.strftime('%Y-%m-%d')
+        end
+
+        # The directory for the project's documentation
+        #
+        # @return [Pathname]
+        # @rbs () -> Pathname
+        def project_directory
+          @project_directory ||= Domainic::Dev.root.join("docs/projects/#{project_name.split.join('_').downcase}")
+        end
+
+        # The update number for the new document
+        #
+        # @return [String]
+        # @rbs () -> String
+        def update_number
+          @update_number ||= begin
+            updates = project_directory.glob('updates/*.md').select do |file|
+              file.basename.to_s.start_with?(date_string)
+            end
+            updates.empty? ? '01' : (updates.count + 1).to_s.rjust(2, '0')
+          end
+        end
+      end
+    end
+  end
+end

--- a/domainic-dev/lib/domainic/dev/generator/templates/milestone_doc/milestone.md.erb
+++ b/domainic-dev/lib/domainic/dev/generator/templates/milestone_doc/milestone.md.erb
@@ -1,0 +1,7 @@
+# <%= name %>
+
+[![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/<%= id %>?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/<%= id %>)
+
+![Milestone Due Date](https://img.shields.io/badge/<%= due_date %>-blue?style=for-the-badge&label=Due%20Date)
+
+TODO: write the milestone documentation

--- a/domainic-dev/lib/domainic/dev/generator/templates/project_doc/README.md.erb
+++ b/domainic-dev/lib/domainic/dev/generator/templates/project_doc/README.md.erb
@@ -1,0 +1,7 @@
+# <%= name %>
+
+[![Project Status](https://img.shields.io/badge/In%20Progress-orange?style=for-the-badge&label=Status)](https://github.com/orgs/domainic/projects/<%= id %>)
+
+## Short Description
+
+TODO: Add a short description of the project and write the project readme

--- a/domainic-dev/lib/domainic/dev/generator/templates/project_update_doc/update.md.erb
+++ b/domainic-dev/lib/domainic/dev/generator/templates/project_update_doc/update.md.erb
@@ -1,0 +1,1 @@
+TODO: write the update documentation

--- a/domainic-dev/sig/domainic/dev/generator/milestone_doc_generator.rbs
+++ b/domainic-dev/sig/domainic/dev/generator/milestone_doc_generator.rbs
@@ -1,0 +1,43 @@
+module Domainic
+  module Dev
+    module Generator
+      # A generator for creating new milestone documentation.
+      #
+      # This creates new milestone documentation in the `docs/milestone` directory.
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class MilestoneDocGenerator < BaseGenerator
+        @due_date: String
+
+        # @param arguments [Array<Object>] the generator arguments
+        # @param options [Array<Object>] additional options
+        # @return [void]
+        def initialize: (Array[untyped], *untyped) -> void
+
+        # Ensure the milestone does not already exist.
+        #
+        # @raise [ArgumentError] if the milestone already exists
+        # @return [void]
+        def ensure_project_does_not_exist: () -> void
+
+        def create_milestone_documentation: () -> untyped
+
+        def name: () -> String
+
+        def id: () -> Integer
+
+        private
+
+        attr_reader due_date: untyped
+
+        # The name of the project directory based on the project name.
+        #
+        # @return [String]
+        def filename: () -> String
+
+        def parse_due_date!: () -> untyped
+      end
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev/generator/project_doc_generator.rbs
+++ b/domainic-dev/sig/domainic/dev/generator/project_doc_generator.rbs
@@ -1,0 +1,37 @@
+module Domainic
+  module Dev
+    module Generator
+      # A generator for creating new project documentation.
+      #
+      # This creates new project documentation in the `docs/projects` directory.
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class ProjectDocGenerator < BaseGenerator
+        # Ensure the project does not already exist.
+        #
+        # @raise [ArgumentError] if the project already exists
+        # @return [void]
+        def ensure_project_does_not_exist: () -> void
+
+        # Create the project directory.
+        #
+        # @return [void]
+        def create_project_directory: () -> void
+
+        def create_project_readme: () -> untyped
+
+        def id: () -> Integer
+
+        def name: () -> String
+
+        private
+
+        # The name of the project directory based on the project name.
+        #
+        # @return [String]
+        def directory_name: () -> String
+      end
+    end
+  end
+end

--- a/domainic-dev/sig/domainic/dev/generator/project_update_doc_generator.rbs
+++ b/domainic-dev/sig/domainic/dev/generator/project_update_doc_generator.rbs
@@ -1,0 +1,51 @@
+module Domainic
+  module Dev
+    module Generator
+      # This generator creates a new document for a project update.
+      #
+      # @since 0.1.0
+      class ProjectUpdateDocGenerator < BaseGenerator
+        @date_string: String
+
+        @update_number: String
+
+        @project_directory: Pathname
+
+        # Ensure the project exists
+        #
+        # @raise [ArgumentError] if the project does not exist
+        # @return [void]
+        def ensure_project_exists: () -> void
+
+        # Create the updates directory if it does not exist
+        #
+        # @return [void]
+        def create_update_directory: () -> void
+
+        # Create the new update document
+        #
+        # @return [void]
+        def create_update_document: () -> void
+
+        def project_name: () -> String
+
+        private
+
+        # Today's date as a string in the format 'YYYY-MM-DD'
+        #
+        # @return [String]
+        def date_string: () -> String
+
+        # The directory for the project's documentation
+        #
+        # @return [Pathname]
+        def project_directory: () -> Pathname
+
+        # The update number for the new document
+        #
+        # @return [String]
+        def update_number: () -> String
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This adds generators to domainic-dev that automate the generation of project and milestone documentation. This includes

* `bin/dev g project_doc <PROJECT_NAME> <PROJECT_GITHUB_ID>`
* `bin/dev g project_update_doc <PROJECT_NAME>`
* `bin/dev g milestone_doc <MILESTONE_NAME> <MILESTONE_GITHUB_ID> [options]`

## Related Issues

resolves #113 
resolves #114 
resolves #115 
resolves #116

## Changes Made

* added `Domainic::Dev::Generator::MilestoneDocGenerator`
* added `Domainic::Dev::Generator::ProjectDocGenerator`
* added `Domainic::Dev::Generator::ProjectUpdateDocGenerator`

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed