### PR TITLE
Add `Domainic::Type::Definitions`

### DIFF
--- a/domainic-type/lib/domainic/type/definitions.rb
+++ b/domainic-type/lib/domainic/type/definitions.rb
@@ -1,0 +1,364 @@
+# frozen_string_literal: true
+
+module Domainic
+  module Type
+    # A module providing convenient factory methods for creating type instances.
+    #
+    # This module serves as a temporary access point for type creation in the Domainic::Type
+    # system, offering a collection of factory methods with consistent naming patterns.
+    # Each method creates and configures a specific type instance, with optional nilable
+    # variants and aliases for common use cases.
+    #
+    # @note This module is considered temporary and may be significantly altered or removed
+    #   before the final release. It should not be considered part of the stable API.
+    #
+    # @example Basic type creation
+    #   include Domainic::Type::Definitions
+    #
+    #   string_type = _String()
+    #   array_type = _Array()
+    #   hash_type = _Hash()
+    #
+    # @example Creating nilable types
+    #   nullable_string = _String?()
+    #   nullable_array = _Array?()
+    #
+    # @example Using union types
+    #   string_or_symbol = _Union(String, Symbol)
+    #   boolean = _Boolean()  # Union of TrueClass and FalseClass
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    module Definitions
+      # rubocop:disable Naming/MethodName
+
+      # Creates an AnythingType instance.
+      #
+      # @example
+      #   type = _Anything
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::AnythingType] the created type
+      # @rbs (**__todo__ options) -> AnythingType
+      def _Anything(**options)
+        require 'domainic/type/types/specification/anything_type'
+        Domainic::Type::AnythingType.new(**options)
+      end
+      alias _Any _Anything
+
+      # Creates an ArrayType instance.
+      #
+      # @example
+      #   type = _Array
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::ArrayType] the created type
+      # @rbs (**__todo__ options) -> ArrayType
+      def _Array(**options)
+        require 'domainic/type/types/core/array_type'
+        Domainic::Type::ArrayType.new(**options)
+      end
+      alias _List _Array
+
+      # Creates a nilable ArrayType instance.
+      #
+      # @example
+      #   type = _Array?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Array or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Array?(**options)
+        array = _Array(**options)
+        _Nilable(array)
+      end
+      alias _List? _Array?
+
+      # Creates a Boolean type.
+      #
+      # Represents a union of TrueClass and FalseClass.
+      #
+      # @example
+      #   type = _Boolean
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      # @rbs () -> UnionType
+      def _Boolean
+        _Union(TrueClass, FalseClass).freeze
+      end
+      alias _Bool _Boolean
+
+      # Creates a nilable Boolean type.
+      #
+      # @example
+      #   type = _Boolean?
+      #
+      # @return [Domainic::Type::UnionType] the created type (TrueClass, FalseClass, or NilClass)
+      # @rbs () -> UnionType
+      def _Boolean?
+        _Nilable(_Boolean)
+      end
+      alias _Bool? _Boolean?
+
+      # Creates a DuckType instance.
+      #
+      # DuckType allows specifying behavior based on method availability.
+      #
+      # @example
+      #   type = _Duck(respond_to: :to_s)
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::DuckType] the created type
+      # @rbs (**__todo__ options) -> DuckType
+      def _Duck(**options)
+        require 'domainic/type/types/specification/duck_type'
+        Domainic::Type::DuckType.new(**options)
+      end
+      alias _Interface _Duck
+      alias _Protocol _Duck
+      alias _RespondingTo _Duck
+
+      # Creates an EnumType instance.
+      #
+      # EnumType restricts values to a specific set of literals.
+      #
+      # @example
+      #   type = _Enum(:red, :green, :blue)
+      #
+      # @param literals [Array<Object>] the allowed literals
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::EnumType] the created type
+      # @rbs (*untyped literals, **__todo__ options) -> EnumType
+      def _Enum(*literals, **options)
+        require 'domainic/type/types/specification/enum_type'
+        Domainic::Type::EnumType.new(*literals, **options)
+      end
+      alias _Literal _Enum
+
+      # Creates a nilable EnumType instance.
+      #
+      # @example
+      #   type = _Enum?(:red, :green, :blue)
+      #
+      # @param literals [Array<Object>] the allowed literals
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Enum or NilClass)
+      # @rbs (*untyped literals, **__todo__ options) -> UnionType
+      def _Enum?(*literals, **options)
+        enum = _Enum(*literals, **options)
+        _Nilable(enum)
+      end
+      alias _Literal? _Enum?
+
+      # Creates a FloatType instance.
+      #
+      # @example
+      #   type = _Float
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::FloatType] the created type
+      # @rbs (**__todo__ options) -> FloatType
+      def _Float(**options)
+        require 'domainic/type/types/core/float_type'
+        Domainic::Type::FloatType.new(**options)
+      end
+      alias _Decimal _Float
+      alias _Real _Float
+
+      # Creates a nilable FloatType instance.
+      #
+      # @example
+      #   type = _Float?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Float or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Float?(**options)
+        float = _Float(**options)
+        _Nilable(float)
+      end
+      alias _Decimal? _Float?
+      alias _Real? _Float?
+
+      # Creates a HashType instance.
+      #
+      # @example
+      #   type = _Hash
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::HashType] the created type
+      # @rbs (**__todo__ options) -> HashType
+      def _Hash(**options)
+        require 'domainic/type/types/core/hash_type'
+        Domainic::Type::HashType.new(**options)
+      end
+      alias _Map _Hash
+
+      # Creates a nilable HashType instance.
+      #
+      # @example
+      #   type = _Hash?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Hash or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Hash?(**options)
+        hash = _Hash(**options)
+        _Nilable(hash)
+      end
+      alias _Map? _Hash?
+
+      # Creates an IntegerType instance.
+      #
+      # @example
+      #   type = _Integer
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::IntegerType] the created type
+      # @rbs (**__todo__ options) -> IntegerType
+      def _Integer(**options)
+        require 'domainic/type/types/core/integer_type'
+        Domainic::Type::IntegerType.new(**options)
+      end
+      alias _Int _Integer
+      alias _Number _Integer
+
+      # Creates a nilable IntegerType instance.
+      #
+      # @example
+      #   type = _Integer?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Integer or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Integer?(**options)
+        integer = _Integer(**options)
+        _Nilable(integer)
+      end
+      alias _Int? _Integer?
+      alias _Number? _Integer?
+
+      # Creates a Nilable (nullable) type.
+      #
+      # Combines one or more types with `NilClass` to allow nil values.
+      #
+      # @example
+      #   type = _Nilable(String, Symbol)
+      #
+      # @param types [Array<Class, Module, Behavior>] the base types
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (NilClass or other specified types)
+      # @rbs (*Class | Module | Behavior[untyped, untyped, untyped] types, **__todo__ options) -> UnionType
+      def _Nilable(*types, **options)
+        _Union(NilClass, *types, **options)
+      end
+      alias _Nullable _Nilable
+
+      # Creates a StringType instance.
+      #
+      # @example
+      #   type = _String
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::StringType] the created type
+      # @rbs (**__todo__ options) -> StringType
+      def _String(**options)
+        require 'domainic/type/types/core/string_type'
+        Domainic::Type::StringType.new(**options)
+      end
+      alias _Text _String
+
+      # Creates a nilable StringType instance.
+      #
+      # @example
+      #   type = _String?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (String or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _String?(**options)
+        string = _String(**options)
+        _Nilable(string)
+      end
+      alias _Text? _String?
+
+      # Creates a SymbolType instance.
+      #
+      # @example
+      #   type = _Symbol
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::SymbolType] the created type
+      # @rbs (**__todo__ options) -> SymbolType
+      def _Symbol(**options)
+        require 'domainic/type/types/core/symbol_type'
+        Domainic::Type::SymbolType.new(**options)
+      end
+      alias _Interned _Symbol
+
+      # Creates a nilable SymbolType instance.
+      #
+      # @example
+      #   type = _Symbol?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Symbol or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Symbol?(**options)
+        symbol = _Symbol(**options)
+        _Nilable(symbol)
+      end
+      alias _Interned? _Symbol?
+
+      # Creates a UnionType instance.
+      #
+      # Allows combining multiple types into a single union type.
+      #
+      # @example
+      #   type = _Union(String, Symbol)
+      #
+      # @param types [Array<Class, Module, Behavior>] the types included in the union
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      # @rbs (*Class | Module | Behavior[untyped, untyped, untyped] types, **__todo__ options) -> UnionType
+      def _Union(*types, **options)
+        require 'domainic/type/types/specification/union_type'
+        Domainic::Type::UnionType.new(*types, **options)
+      end
+      alias _Either _Union
+
+      # Creates a VoidType instance.
+      #
+      # Represents an operation that returns no value.
+      #
+      # @example
+      #   type = _Void
+      #
+      # @return [Domainic::Type::VoidType] the created type
+      # @rbs () -> VoidType
+      def _Void
+        require 'domainic/type/types/specification/void_type'
+        Domainic::Type::VoidType.new
+      end
+      # rubocop:enable Naming/MethodName
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/definitions.rbs
+++ b/domainic-type/sig/domainic/type/definitions.rbs
@@ -1,0 +1,304 @@
+module Domainic
+  module Type
+    # A module providing convenient factory methods for creating type instances.
+    #
+    # This module serves as a temporary access point for type creation in the Domainic::Type
+    # system, offering a collection of factory methods with consistent naming patterns.
+    # Each method creates and configures a specific type instance, with optional nilable
+    # variants and aliases for common use cases.
+    #
+    # @note This module is considered temporary and may be significantly altered or removed
+    #   before the final release. It should not be considered part of the stable API.
+    #
+    # @example Basic type creation
+    #   include Domainic::Type::Definitions
+    #
+    #   string_type = _String()
+    #   array_type = _Array()
+    #   hash_type = _Hash()
+    #
+    # @example Creating nilable types
+    #   nullable_string = _String?()
+    #   nullable_array = _Array?()
+    #
+    # @example Using union types
+    #   string_or_symbol = _Union(String, Symbol)
+    #   boolean = _Boolean()  # Union of TrueClass and FalseClass
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    module Definitions
+      # Creates an AnythingType instance.
+      #
+      # @example
+      #   type = _Anything
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::AnythingType] the created type
+      def _Anything: (**__todo__ options) -> AnythingType
+
+      alias _Any _Anything
+
+      # Creates an ArrayType instance.
+      #
+      # @example
+      #   type = _Array
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::ArrayType] the created type
+      def _Array: (**__todo__ options) -> ArrayType
+
+      alias _List _Array
+
+      # Creates a nilable ArrayType instance.
+      #
+      # @example
+      #   type = _Array?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Array or NilClass)
+      def _Array?: (**__todo__ options) -> UnionType
+
+      alias _List? _Array?
+
+      # Creates a Boolean type.
+      #
+      # Represents a union of TrueClass and FalseClass.
+      #
+      # @example
+      #   type = _Boolean
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      def _Boolean: () -> UnionType
+
+      alias _Bool _Boolean
+
+      # Creates a nilable Boolean type.
+      #
+      # @example
+      #   type = _Boolean?
+      #
+      # @return [Domainic::Type::UnionType] the created type (TrueClass, FalseClass, or NilClass)
+      def _Boolean?: () -> UnionType
+
+      alias _Bool? _Boolean?
+
+      # Creates a DuckType instance.
+      #
+      # DuckType allows specifying behavior based on method availability.
+      #
+      # @example
+      #   type = _Duck(respond_to: :to_s)
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::DuckType] the created type
+      def _Duck: (**__todo__ options) -> DuckType
+
+      alias _Interface _Duck
+
+      alias _Protocol _Duck
+
+      alias _RespondingTo _Duck
+
+      # Creates an EnumType instance.
+      #
+      # EnumType restricts values to a specific set of literals.
+      #
+      # @example
+      #   type = _Enum(:red, :green, :blue)
+      #
+      # @param literals [Array<Object>] the allowed literals
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::EnumType] the created type
+      def _Enum: (*untyped literals, **__todo__ options) -> EnumType
+
+      alias _Literal _Enum
+
+      # Creates a nilable EnumType instance.
+      #
+      # @example
+      #   type = _Enum?(:red, :green, :blue)
+      #
+      # @param literals [Array<Object>] the allowed literals
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Enum or NilClass)
+      def _Enum?: (*untyped literals, **__todo__ options) -> UnionType
+
+      alias _Literal? _Enum?
+
+      # Creates a FloatType instance.
+      #
+      # @example
+      #   type = _Float
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::FloatType] the created type
+      def _Float: (**__todo__ options) -> FloatType
+
+      alias _Decimal _Float
+
+      alias _Real _Float
+
+      # Creates a nilable FloatType instance.
+      #
+      # @example
+      #   type = _Float?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Float or NilClass)
+      def _Float?: (**__todo__ options) -> UnionType
+
+      alias _Decimal? _Float?
+
+      alias _Real? _Float?
+
+      # Creates a HashType instance.
+      #
+      # @example
+      #   type = _Hash
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::HashType] the created type
+      def _Hash: (**__todo__ options) -> HashType
+
+      alias _Map _Hash
+
+      # Creates a nilable HashType instance.
+      #
+      # @example
+      #   type = _Hash?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Hash or NilClass)
+      def _Hash?: (**__todo__ options) -> UnionType
+
+      alias _Map? _Hash?
+
+      # Creates an IntegerType instance.
+      #
+      # @example
+      #   type = _Integer
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::IntegerType] the created type
+      def _Integer: (**__todo__ options) -> IntegerType
+
+      alias _Int _Integer
+
+      alias _Number _Integer
+
+      # Creates a nilable IntegerType instance.
+      #
+      # @example
+      #   type = _Integer?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Integer or NilClass)
+      def _Integer?: (**__todo__ options) -> UnionType
+
+      alias _Int? _Integer?
+
+      alias _Number? _Integer?
+
+      # Creates a Nilable (nullable) type.
+      #
+      # Combines one or more types with `NilClass` to allow nil values.
+      #
+      # @example
+      #   type = _Nilable(String, Symbol)
+      #
+      # @param types [Array<Class, Module, Behavior>] the base types
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (NilClass or other specified types)
+      def _Nilable: (*Class | Module | Behavior[untyped, untyped, untyped] types, **__todo__ options) -> UnionType
+
+      alias _Nullable _Nilable
+
+      # Creates a StringType instance.
+      #
+      # @example
+      #   type = _String
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::StringType] the created type
+      def _String: (**__todo__ options) -> StringType
+
+      alias _Text _String
+
+      # Creates a nilable StringType instance.
+      #
+      # @example
+      #   type = _String?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (String or NilClass)
+      def _String?: (**__todo__ options) -> UnionType
+
+      alias _Text? _String?
+
+      # Creates a SymbolType instance.
+      #
+      # @example
+      #   type = _Symbol
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::SymbolType] the created type
+      def _Symbol: (**__todo__ options) -> SymbolType
+
+      alias _Interned _Symbol
+
+      # Creates a nilable SymbolType instance.
+      #
+      # @example
+      #   type = _Symbol?
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Symbol or NilClass)
+      def _Symbol?: (**__todo__ options) -> UnionType
+
+      alias _Interned? _Symbol?
+
+      # Creates a UnionType instance.
+      #
+      # Allows combining multiple types into a single union type.
+      #
+      # @example
+      #   type = _Union(String, Symbol)
+      #
+      # @param types [Array<Class, Module, Behavior>] the types included in the union
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      def _Union: (*Class | Module | Behavior[untyped, untyped, untyped] types, **__todo__ options) -> UnionType
+
+      alias _Either _Union
+
+      # Creates a VoidType instance.
+      #
+      # Represents an operation that returns no value.
+      #
+      # @example
+      #   type = _Void
+      #
+      # @return [Domainic::Type::VoidType] the created type
+      def _Void: () -> VoidType
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/definitions_spec.rb
+++ b/domainic-type/spec/domainic/type/definitions_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/definitions'
+
+RSpec.describe Domainic::Type::Definitions do
+  subject(:definitions) { dummy_class.new }
+
+  let(:dummy_class) do
+    Class.new do
+      include Domainic::Type::Definitions
+    end
+  end
+
+  describe '._Anything' do
+    subject(:anything_type) { definitions._Anything }
+
+    it 'is expected to return an AnythingType' do
+      expect(anything_type).to be_a(Domainic::Type::AnythingType)
+    end
+  end
+
+  describe '._Array' do
+    subject(:array_type) { definitions._Array }
+
+    it 'is expected to return an ArrayType' do
+      expect(array_type).to be_a(Domainic::Type::ArrayType)
+    end
+  end
+
+  describe '._Array?' do
+    subject(:nullable_array_type) { definitions._Array? }
+
+    it 'is expected to return a UnionType' do
+      expect(nullable_array_type).to be_a(Domainic::Type::UnionType)
+    end
+
+    it 'is expected to validate nil values' do
+      expect(nullable_array_type.validate(nil)).to be true
+    end
+
+    it 'is expected to validate array values' do
+      expect(nullable_array_type.validate([])).to be true
+    end
+  end
+
+  describe '._Boolean' do
+    subject(:boolean_type) { definitions._Boolean }
+
+    it 'is expected to return a frozen UnionType' do
+      expect(boolean_type).to be_a(Domainic::Type::UnionType).and(be_frozen)
+    end
+
+    it 'is expected to validate true' do
+      expect(boolean_type.validate(true)).to be true
+    end
+
+    it 'is expected to validate false' do
+      expect(boolean_type.validate(false)).to be true
+    end
+  end
+
+  describe '._Duck' do
+    subject(:duck_type) { definitions._Duck }
+
+    it 'is expected to return a DuckType' do
+      expect(duck_type).to be_a(Domainic::Type::DuckType)
+    end
+  end
+
+  describe '._Enum' do
+    subject(:enum_type) { definitions._Enum(:foo, :bar) }
+
+    it 'is expected to return an EnumType' do
+      expect(enum_type).to be_a(Domainic::Type::EnumType)
+    end
+  end
+
+  describe '._Hash' do
+    subject(:hash_type) { definitions._Hash }
+
+    it 'is expected to return a HashType' do
+      expect(hash_type).to be_a(Domainic::Type::HashType)
+    end
+  end
+
+  describe '._Nilable' do
+    subject(:nilable_type) { definitions._Nilable(String) }
+
+    it 'is expected to return a UnionType' do
+      expect(nilable_type).to be_a(Domainic::Type::UnionType)
+    end
+
+    it 'is expected to validate nil values' do
+      expect(nilable_type.validate(nil)).to be true
+    end
+
+    it 'is expected to validate values of the specified type' do
+      expect(nilable_type.validate('test')).to be true
+    end
+  end
+
+  describe '._Union' do
+    subject(:union_type) { definitions._Union(String, Symbol) }
+
+    it 'is expected to return a UnionType' do
+      expect(union_type).to be_a(Domainic::Type::UnionType)
+    end
+  end
+
+  describe '._Void' do
+    subject(:void_type) { definitions._Void }
+
+    it 'is expected to return a VoidType' do
+      expect(void_type).to be_a(Domainic::Type::VoidType)
+    end
+  end
+end


### PR DESCRIPTION
Introduces a possibly temporary module providing factory methods for type creation in the Domainic::Type system. This module serves as an initial access point for the type system while the final API is being developed.

Key additions:

* Factory methods for all core types (Array, Hash, String, etc.)
* Nilable variants for common types (String?, Array?, etc.)
* Union type helpers (_Boolean, _Nilable, _Union)
* Duck typing support (_Duck, _Interface)
* Enum/literal type support (_Enum, _Literal)

This implementation is marked as temporary and may undergo significant changes or removal before the final release. It should not be considered part of the stable API at this point.

Changelog:
  * added `Domainic::Type::Definitions`