### PR TITLE
Add documentation for Domainic::Type alpha 3 experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@
 [![Domainic License](https://img.shields.io/github/license/domainic/domainic?logo=opensourceinitiative&logoColor=white&logoSize=auto&style=for-the-badge)](./LICENSE)
 [![Domainic Open Issues](https://img.shields.io/github/issues-search/domainic/domainic?label=open%20issues&logo=github&logoSize=auto&query=is%3Aopen&color=red&style=for-the-badge)](https://github.com/domainic/domainic/issues?q=state%3Aopen)
 
+> [!IMPORTANT]  
+> We're running an experiment with Domainic::Type! Help us explore flexible type validation in Ruby by trying our
+> [alpha release](./docs/experiments/domainic-type-alpha-3/README.md). Your feedback is invaluable for shaping
+> the future of domain-driven design in Ruby.
+
 A suite of Ruby libraries crafted to arm engineers with the magic of domain-driven design.
 
-> **Note**: The Domainic gem is currently in pre-release. Until v0.1.0, components must be installed individually.
+> [!WARNING]
+> The Domainic gem is currently in pre-release. Until v0.1.0, components must be installed individually.
 
 ## About
 

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -1,0 +1,104 @@
+# 🧪 Domainic Experiments Documentation
+
+Welcome to the Domainic Experiments documentation! This directory contains comprehensive documentation for our
+experimental releases * gems that are pushing the boundaries of what's possible with domain-driven design in Ruby. Think
+of this space as the laboratory notebook where we document our explorations, gather feedback, and evolve our
+understanding of what makes great domain-driven design tools.
+
+## What are Experiments
+
+Unlike traditional alpha or beta releases, experiments represent ideas and implementations that are in an early,
+exploratory phase. We release these as gems with alpha versioning, but we treat them as experiments to emphasize their
+evolving nature. Each experiment might change significantly based on community feedback, real-world usage patterns, and
+our growing understanding of developer needs.
+
+Each experimental release is:
+
+* 🔬 **Exploratory** - Testing new approaches and ideas
+* 🔄 **Iterative** - Evolving based on feedback and learnings
+* 🤝 **Collaborative** - Shaped by community input and real-world usage
+* 🎯 **Focused** - Targeting specific aspects of domain-driven design
+
+## 🚨 Current Experiments
+
+### Domainic::Type Alpha 3
+
+**Status:** Active  
+**Started:** December 2024  
+**Gem:** `domainic-type`
+
+A flexible type validation system for Ruby, offering composable, readable type constraints with elegant error messages.
+This experiment explores how we can bring powerful yet developer-friendly type validation to Ruby while maintaining the
+language's expressiveness and elegance.
+
+[Learn more about Domainic::Type Alpha 3](./domainic-type-alpha-3/README.md)
+
+## Documentation Structure
+
+Each experiment's documentation follows this structure:
+
+```markdown
+experiments/
+├── README.md                 # This file
+└── {experiment_name}/        # e.g., type/
+    ├── README.md             # Experiment overview and installation
+    ├── KNOWN_ISSUES.md       # Current limitations and known issues
+    ├── CHANGELOG.md          # Changes between versions
+    ├── TROUBLESHOOTING.md    # Common issues and solutions
+    └── EXAMPLES.md           # Detailed usage guides
+```
+
+## Important Notes
+
+* 🔬 Documentation here covers experimental gem releases
+* 🔄 APIs may evolve or be completely redesigned based on feedback
+* 📝 Documentation will be frequently updated
+* 💡 Your feedback is essential and valued!
+
+## Versioning
+
+## Versioning
+
+Our experimental gems use alpha versioning with this pattern:
+
+* Target version with alpha tag and build numbers: `{target}-alpha.{alpha}.{build}`
+* Alpha versions increment: `-alpha.1.0.0` → `-alpha.2.0.0`
+* Experiment completes at target version without tags
+* Released versions follow [BreakVer](https://www.taoensso.com/break-versioning)
+
+Example for 0.1.0:
+
+```ruby
+'0.1.0-alpha.1.0.0' # First alpha
+'0.1.0-alpha.2.0.0' # Second alpha
+'0.1.0'             # Completed experiment
+```
+
+## Get Involved
+
+We'd love to hear your thoughts, ideas, and experiences with these experiments! Here's how you can get involved:
+
+1. Install the experimental gems you're interested in
+2. Try them out in non-production projects
+3. Join discussions in our issue tracker
+4. Share your use cases and requirements
+5. Provide feedback on what works and what doesn't
+
+Remember, there are no "wrong" answers in experiments * every piece of feedback helps us learn and improve!
+
+## Historical Experiments
+
+_This section will be populated as experiments graduate from experimental status or are archived._
+
+## Feedback Guidelines
+
+When providing feedback on experiments, consider:
+
+* What worked well?
+* What was confusing or unclear?
+* Are error messages helpful and clear?
+* What features are missing?
+* What would make the gem more useful?
+* Are there specific use cases not well supported?
+
+Please include code examples when possible to illustrate your points.

--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Experimental Changes
+
+## Domainic::Type
+
+### [Unreleased]
+
+### [0.1.0-alpha.3.0.0] * 2024-12-23
+
+* Initial alpha release
+
+[Previous alpha versions were internal testing only]
+
+> [!NOTE]
+> As this is an experimental release, features may change significantly based on feedback. Refer to
+> docs/experiments/domainic-type-v0.1.0-alpha.3/README.md for full details and current testing focus.

--- a/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
+++ b/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
@@ -1,0 +1,505 @@
+# Example Usage
+
+This document provides comprehensive examples of using Domainic::Type, from basic type validation to complex type composition.
+
+## Table of Contents
+
+* [Basic Usage](#basic-usage)
+  * [Initialize a type with constraints](#initialize-a-type-with-constraints)
+  * [Class with built-in type validations](#class-with-built-in-type-validations)
+  * [A simple case statement](#a-simple-case-statement)
+* [Advanced Usage](#advanced-usage)
+  * [Using domainic-type with other gems](#using-domainic-type-with-other-gems)
+  * [Creating Custom Types](#creating-custom-types)
+  * [Advanced Type Composition](#advanced-type-composition)
+* [Error Message Examples](#error-message-examples)
+* [Using Types](#using-types)
+  * [_Anything](#_anything)
+  * [_Array](#_array)
+  * [_Boolean](#_boolean)
+  * [_Duck](#_duck)
+  * [_Enum](#_enum)
+  * [_Float](#_float)
+  * [_Hash](#_hash)
+  * [_Integer](#_integer)
+  * [_Nilable](#_nilable)
+  * [_String](#_string)
+  * [_Symbol](#_symbol)
+  * [_Union](#_union)
+  * [_Void](#_void)
+
+## Basic Usage
+
+The following examples demonstrate fundamental usage patterns of Domainic::Type. These examples cover essential concepts
+like type validation, constraint application, and integration with Ruby classes.
+
+### Initialize a type with constraints
+
+Domainic::Type provides two syntaxes for creating and constraining types: a hash-based syntax for simple constraints and
+a method chaining syntax for more complex constraints. Both approaches are valid and can be used interchangeably based
+on your preference and needs.
+
+```ruby
+# Hash syntax - good for simple constraints
+_Array(of: _String, having_size: 3)
+
+# Method chaining - more expressive for complex constraints
+_Array.of(_String).having_size(3) # Equivalent to the above
+```
+
+### Class with built-in type validations
+
+Type validation can be integrated directly into your Ruby classes through attribute setters. This pattern ensures type
+safety at the point of value assignment, preventing invalid states from propagating through your system.
+
+```ruby
+require 'domainic/type/definitions'
+
+class Jedi
+  include Domainic::Type::Definitions
+
+  attr_reader :name, :midi_chlorians
+
+  def initialize(name, midi_chlorians:)
+    self.name = name
+    self.midi_chlorians = midi_chlorians
+  end
+
+  def name=(name)
+    _String.having_maximum_length(255).validate!(name)
+    @name = name
+  end
+
+  def midi_chlorians=(midi_chlorians)
+    _Either(_Integer, _Float).being_positive.validate!(midi_chlorians)
+    @midi_chlorians = midi_chlorians
+  end
+end
+
+jedi = Jedi.new('Yoda', midi_chlorians: 900.0)
+# => #<Jedi:0x00007f8b1b8b3b08 @name="Yoda", @midi_chlorians=900.0>
+
+jedi = Jedi.new('A' * 256, midi_chlorians: 900.0)
+# => TypeError: Expected String(having maximum length of 255) but got String(having length of 256)
+```
+
+### A simple case statement
+
+Domainic types can be used in case statements thanks to Ruby's pattern matching capabilities. This enables powerful
+type-based control flow that remains readable and maintainable.
+
+```ruby
+require 'domainic/type/definitions'
+
+class SuperSaiyan
+  include Domainic::Type::Definitions
+
+  def categorize(power)
+    case power
+    when _Integer.being_less_than(9000)
+      puts 'You\'re no Super Saiyan'
+    when _Integer.being_equal_to(9000)
+      puts 'Impressive...'
+    when _Integer.being_greater_than(9000)
+      puts 'It\'s over 9000!'
+    end
+  end
+end
+```
+
+## Advanced Usage
+
+These examples demonstrate more sophisticated use cases and integration patterns for Domainic::Type.
+
+### Using domainic-type with other gems
+
+Domainic::Type is designed to work seamlessly with other Ruby gems and libraries. Here's an example of combining it with
+Domainic::Attributer for declarative attribute validation:
+
+```ruby
+require 'domainic/attributer'
+require 'domainic/type/definitions'
+
+class Spaceship
+  extend Domainic::Type::Definitions
+  include Domainic::Attributer
+
+  argument :name, _String.having_maximum_length(255).matching(SHIP_NAME_REGEX)
+  argument :crew_count, _Integer.being_positive
+end
+```
+
+### Creating Custom Types
+
+You can create reusable custom types by extending the Definitions module in your own type container. This is useful for
+domain-specific types that are used frequently in your application:
+
+```ruby
+require 'domainic/type/definitions'
+
+module Types
+  extend Domainic::Type::Definitions
+
+  EmailAddress = _String.matching(URI::MailTo::EMAIL_REGEXP)
+end
+
+Types::EmailAddress.validate!('example@example.com') # => true
+Types::EmailAddress.validate!('example@@example') # => TypeError
+```
+
+### Advanced Type Composition
+
+Domainic::Type shines in complex scenarios where multiple types need to be composed together. Here are examples of
+advanced type composition for real-world use cases:
+
+```ruby
+# API response validation
+ApiResponse = _Hash.of(_Symbol => _Union(
+  # Success case
+  _Hash.of(
+    _Symbol => _Union(
+      _String,
+      _Array.of(_Integer.being_positive),
+      _Hash.of(_Symbol => _Boolean)
+    )
+  ),
+  # Error case
+  _Hash.of(
+    error: _String,
+    code: _Integer.being_positive
+  )
+))
+
+# Form validation
+FormData = _Hash.of(
+  username: _String.being_alphanumeric.having_size_between(3, 20),
+  email: _String.matching(URI::MailTo::EMAIL_REGEXP),
+  age: _Nilable(_Integer.being_greater_than_or_equal_to(18)),
+  interests: _Array.of(_String).having_maximum_size(5)
+)
+```
+
+## Error Message Examples
+
+Domainic::Type strives to provide clear, actionable error messages. Here are examples of various error scenarios and
+their corresponding messages:
+
+```ruby
+# Type mismatch
+_String.validate!(42)
+# => TypeError: Expected String, got Integer
+
+# Constraint violation
+_String.being_uppercase.validate!("hello")
+# => TypeError: Expected String(being upper case), got String(not upper case)
+
+# Multiple constraints
+_Integer.being_positive.being_even.validate!(-2)
+# => TypeError: Expected Integer(being positive), got Integer(negative)
+
+# Nested type validation
+_Array.of(_String.being_uppercase).validate!(["Hello", "WORLD"])
+# => TypeError: Expected Array of String(being upper case), got Array containing String(not upper case)
+
+# Complex union validation
+_Union(
+  _String.being_uppercase,
+  _Integer.being_positive
+).validate!(-42)
+# => TypeError: Expected Union(String(being upper case) or Integer(being positive)), got Integer(negative)
+```
+
+## Using Types
+
+Each type in Domainic::Type has its own set of constraints and capabilities. Below is a comprehensive reference of all
+available types.
+
+> [!WARNING]
+> Nilable variants like _Array? and _Boolean? will return a _Union type and not respond to any of the available
+> constraint methods of the type. If you need to constraint your type use _Nilable([_Type].[constraint_methods]) instead.
+
+### _Anything
+
+also known as `_Any`
+
+The `_Anything` type acts as a wildcard, accepting any value except those explicitly excluded. This is useful when you
+want to restrict values to "anything except X":
+
+```ruby
+_Anything.but(_String, _Integer) === 1.0 # => true
+_Any.but(_String, _Integer) === ['a', 1] # => true
+_Anything.but(_String, _Integer) === 'a' # => false
+_Anything === 'a' # => true
+```
+
+### _Array
+
+also known as `_List`, `_Array?`, `_List?`
+
+The `_Array` type provides comprehensive validation for array values with constraints for content, ordering, and size.
+It includes nilable variants and supports rich composition with other types:
+
+```ruby
+_Array.of(_String) === %w[a b c] # => true
+_Array.of(_String) === [1, 2, 3] # => false
+_Array.of(_String) === 'a b c' # => false
+_Array?.of(_String) === nil # => true
+
+# Available Constraints
+_Array.being_distinct # Constrains the array to contain only distinct values
+_Array.being_duplicative # Constrains the array to contain only duplicative values
+_Array.being_empty # Constrains the array to be empty
+_Array.being_populated # Constrains the array to be populated
+_Array.being_sorted # Constrains the array to be sorted
+_Array.being_unsorted # Constrains the array to be unsorted
+_Array.containing(value) # Constrains the array to contain the specified value
+_Array.ending_with(value) # Constrains the array to end with the specified value
+_Array.excluding(value) # Constrains the array to exclude the specified value
+_Array.having_maximum_size(size) # Constrains the array to have a maximum size
+_Array.having_minimum_size(size) # Constrains the array to have a minimum size
+_Array.having_size(size) # Constrains the array to have a specific size
+_Array.having_size_between(minimum, maximum) # Constrains the array to have a size between the specified min and max
+_Array.of(type) # Constrains the array to contain only values of the specified type
+_Array.starting_with(value) # Constrains the array to start with the specified value
+```
+
+### _Boolean
+
+also known as `_Bool`, `_Boolean?`, `_Bool?`
+
+The `_Boolean` type provides strict boolean validation, only accepting `true` or `false`. Includes nilable variants:
+
+```ruby
+_Boolean === false # => true
+_Boolean === 'true' # => false
+_Boolean? === nil # => true
+```
+
+### _Duck
+
+also known as `_Interface`, `_Protocol`, `_RespondingTo`
+
+The `_Duck` type implements duck typing validation, checking for the presence of specified methods. This is particularly
+useful when working with interfaces or protocols:
+
+```ruby
+object = Struct.new(:foo, :bar).new('foo', 'bar')
+_Duck.responding_to(:foo, :bar) === object # => true
+_Duck.responding_to(:foo) === object # => true
+_Duck.responding_to(:foo).not_responding_to(:bar) === object # => false
+```
+
+### _Enum
+
+also known as `_Literal`, `_Enum?`, `_Literal?`
+
+The `_Enum` type validates values against a predefined set of literals. Useful for ensuring values come from a fixed set
+of options:
+
+```ruby
+_Enum('a', 'b', 'c') === 'a' # => true
+_Enum('a', 'b', 'c') === 'd' # => false
+_Enum.literal('a', 'b', 'c') === 'a' # => true
+```
+
+### _Float
+
+also known as `_Decimal`, `_Real`, `_Float?`, `_Decimal?`, `_Real?`
+
+The `_Float` type validates floating-point numbers with comprehensive numeric constraints:
+
+```ruby
+_Float === 1.0 # => true
+
+# Available Constraints
+_Float.being_divisible_by(value, tolerance: 1e-10) # Constrains the float to be divisible by the specified value
+_Float.being_equal_to(value) # Constrains the float to be equal to the specified value
+_Float.being_even # Constrains the float to be even
+_Float.being_finite # Constrains the float to be finite
+_Float.being_greater_than(value) # Constrains the float to be greater than the specified value
+_Float.being_greater_than_or_equal_to(value) # Constrains the float to be greater than or equal to the specified value
+_Float.being_infinite # Constrains the float to be infinite
+_Float.being_less_than(value) # Constrains the float to be less than the specified value
+_Float.being_less_than_or_equal_to(value) # Constrains the float to be less than or equal to the specified value
+_Float.being_negative # Constrains the float to be negative
+_Float.being_odd # Constrains the float to be odd
+_Float.being_positive # Constrains the float to be positive
+_Float.being_zero # Constrains the float to be zero
+_Float.not_being_divisible_by(value, tolerance: 1e-10) # Constrains the float to not be divisible by the specified value
+_Float.not_being_equal_to(value) # Constrains the float to not be equal to the specified value
+_Float.not_being_even # Constrains the float to not be even
+```
+
+### _Hash
+
+also known as `_Map`, `_Hash?`, `_Map?`
+
+The `_Hash` type provides validation for hash structures with constraints for keys, values, and overall composition:
+
+```ruby
+_Hash.of(_Symbol => _String) === { a: 'a', b: 'b', c: 'c' } # => true
+_Hash.of(_Symbol => _String) === { 'a' => 1, 'b' => 2, 'c' => 3 } # => false
+
+# Available Constraints
+_Hash.being_distinct # Constrains the hash to contain only distinct values
+_Hash.being_duplicative # Constrains the hash to contain only duplicative values
+_Hash.being_empty # Constrains the hash to be empty
+_Hash.being_populated # Constrains the hash to be populated
+_Hash.being_sorted # Constrains the hash to be sorted
+_Hash.being_unsorted # Constrains the hash to be unsorted
+_Hash.containing_keys(keys) # Constrains the hash to contain the specified keys
+_Hash.containing_values(values) # Constrains the hash to contain the specified values
+_Hash.ending_with(value) # Constrains the hash to end with the specified value
+_Hash.excluding_keys(keys) # Constrains the hash to exclude the specified keys
+_Hash.excluding_values(values) # Constrains the hash to exclude the specified values
+_Hash.having_maximum_size(size) # Constrains the hash to have a maximum size
+_Hash.having_minimum_size(size) # Constrains the hash to have a minimum size
+_Hash.having_size(size) # Constrains the hash to have a specific size
+_Hash.having_size_between(minimum, maximum) # Constrains the hash to have a size between the specified min and max
+_Hash.of(key_type => value_type) # Constrains the hash to contain only values of the specified type
+_Hash.starting_with(value) # Constrains the hash to start with the specified value
+```
+
+### _Integer
+
+also known as `_Int`, `_Integer?`, `_Int?`
+
+The `_Integer` type validates integer values with comprehensive numeric constraints:
+
+```ruby
+_Integer === 1 # => true
+
+# Available Constraints
+_Integer.being_divisible_by(value, tolerance: 1e-10) # Constrains the integer to be divisible by the specified value
+_Integer.being_equal_to(value) # Constrains the integer to be equal to the specified value
+_Integer.being_even # Constrains the integer to be even
+_Integer.being_finite # Constrains the integer to be finite
+_Integer.being_greater_than(value) # Constrains the integer to be greater than the specified value
+_Integer.being_greater_than_or_equal_to(value) # Constrains the integer to be greater than or equal to the specified value
+_Integer.being_infinite # Constrains the integer to be infinite
+_Integer.being_less_than(value) # Constrains the integer to be less than the specified value
+_Integer.being_less_than_or_equal_to(value) # Constrains the integer to be less than or equal to the specified value
+_Integer.being_negative # Constrains the integer to be negative
+_Integer.being_odd # Constrains the integer to be odd
+_Integer.being_positive # Constrains the integer to be positive
+_Integer.being_zero # Constrains the integer to be zero
+_Integer.not_being_divisible_by(value) # Constrains integer to not be divisible by value
+_Integer.not_being_equal_to(value) # Constrains integer to not equal value
+_Integer.not_being_even # Constrains integer to be odd (alias for being_odd)
+```
+
+### _Nilable
+
+also known as `_Nullable`
+
+The `_Nilable` type wraps another type to allow nil values while maintaining all the original type's constraints when
+the value is not nil:
+
+```ruby
+_Nilable(_Array.of(_String)) === %w[a b c] # => true
+_Nilable(_Array.of(_String)) === nil # => true
+_Nilable(_Array.of(_String)) === [1, 2, 3] # => false
+
+# Complex nilable types maintain all constraints
+_Nilable(
+  _String.being_uppercase.having_minimum_size(3)
+) === "ABC" # => true
+```
+
+### _String
+
+also known as `_Text`, `_String?`, `_Text?`
+
+The `_String` type validates string values with comprehensive text manipulation constraints:
+
+```ruby
+_String === 'hello' # => true
+
+# Available Constraints
+_String.being_alphanumeric # Constrains string to only alphanumeric characters
+_String.being_ascii # Constrains string to only ASCII characters
+_String.being_empty # Constrains string to be empty
+_String.being_equal_to(value) # Constrains string to equal specified value
+_String.being_lowercase # Constrains string to be lowercase
+_String.being_mixedcase # Constrains string to have mixed case
+_String.being_only_letters # Constrains string to only letters
+_String.being_only_numbers # Constrains string to only numbers
+_String.being_ordered # Constrains string characters to be in order
+_String.being_printable # Constrains string to only printable characters
+_String.being_titlecase # Constrains string to be in title case
+_String.being_unordered # Constrains string characters to not be in order
+_String.being_uppercase # Constrains string to be uppercase
+_String.containing(substring) # Constrains string to contain substring
+_String.excluding(substring) # Constrains string to not contain substring
+_String.having_size(size) # Constrains string to specific length
+_String.having_size_between(min, max) # Constrains string length to range
+_String.matching(pattern) # Constrains string to match pattern
+_String.not_matching(pattern) # Constrains string to not match pattern
+```
+
+### _Symbol
+
+also known as `_Interned`, `_Symbol?`, `_Interned?`
+
+The `_Symbol` type validates symbols and supports all string-like constraints applied to the symbol's name:
+
+```ruby
+_Symbol === :hello # => true
+_Symbol === 'hello' # => false
+
+# Supports all String constraints
+_Symbol.being_uppercase # Constrains symbol name to be uppercase
+_Symbol.matching(/^[A-Z_]+$/) # Constrains symbol name to match pattern
+_Symbol.having_maximum_size(20) # Constrains symbol name length
+
+# Common use case: Rails-style keys
+_Symbol
+  .matching(/^[a-z_][a-z0-9_]*$/)
+  .having_maximum_size(63)
+```
+
+### _Union
+
+also known as `_Either`
+
+The `_Union` type combines multiple types with OR logic, allowing values that match any of the specified types:
+
+```ruby
+# Simple union
+_Union(_String, _Integer) === 'hello' # => true
+_Union(_String, _Integer) === 42 # => true
+_Union(_String, _Integer) === 3.14 # => false
+
+# Union with constraints
+_Union(
+  _String.being_uppercase,
+  _Integer.being_positive
+) === 'HELLO' # => true
+
+# Complex nested unions
+_Union(
+  _Array.of(_String),
+  _Hash.of(_Symbol => _Integer),
+  _Nilable(_Boolean)
+) === { foo: 42 } # => true
+```
+
+### _Void
+
+The `_Void` type accepts any value. It's useful as a placeholder or for explicitly marking void returns in interface
+definitions:
+
+```ruby
+_Void === nil # => true
+_Void === false # => true
+_Void === anything # => true
+
+# Common use case: Interface definition
+class Interface
+  extend Domainic::Type::Definitions
+
+  def self.method_returns_nothing
+    _Void
+  end
+end
+```

--- a/docs/experiments/domainic-type-alpha-3/KNOWN_ISSUES.md
+++ b/docs/experiments/domainic-type-alpha-3/KNOWN_ISSUES.md
@@ -1,0 +1,8 @@
+# Known Issues
+
+This document tracks known issues in the domainic-type alpha 3 experiment. Issues will be added as they're discovered through
+testing and feedback.
+
+## Current Issues
+
+[No known issues yet * experiment in progress]

--- a/docs/experiments/domainic-type-alpha-3/README.md
+++ b/docs/experiments/domainic-type-alpha-3/README.md
@@ -1,0 +1,215 @@
+# 🧪 Domainic::Type Alpha 3
+
+Welcome to the Domainic::Type Alpha 3 experiment! This is a Ruby gem exploring flexible, composable type
+validation with clear error messages.
+
+## Documentation Structure
+
+This experiment includes several documentation files:
+
+* [EXAMPLES](./EXAMPLES.md) - Comprehensive examples from basic to advanced usage, covering all types and features
+* [TROUBLESHOOTING](./TROUBLESHOOTING.md) - Common issues, gotchas, debugging tips, and known behavior quirks
+* [CHANGELOG](./CHANGELOG.md) - Version history and changes between experiment versions
+* [KNOWN_ISSUES](./KNOWN_ISSUES.md) - Tracks discovered issues and their current status
+
+## Quick Start
+
+```ruby
+gem 'domainic-type', '0.1.0-alpha.3.0.0'
+```
+
+```ruby
+require 'domainic/type'
+include Domainic::Type::Definitions
+
+# Simple type validation
+string_type = _String
+string_type.validate!("hello")  # => true
+string_type.validate!(123)      # => TypeError: Expected String, but got Integer
+
+# Chain ALL the constraints!
+username = _String
+  .being_lowercase
+  .being_alphanumeric
+  .having_size_between(3, 20)
+  .not_matching(/^admin/i)
+
+# Complex array validation
+admin_list = _Array
+  .of(_String)
+  .being_distinct
+  .being_ordered
+  .excluding("root")
+  .having_minimum_size(1)
+
+# Hash with specific key/value types
+config = _Hash
+  .of(Symbol => _String)
+  .containing_keys(:host, :port)
+  .excluding_values(nil, "")
+```
+
+## What We're Exploring
+
+This experiment focuses on three main areas:
+
+### 1. Error Message Composition 🎯
+
+We're particularly interested in how error messages compose when using multiple constraints. Try these scenarios:
+
+```ruby
+# Scenario 1: Multiple String Constraints
+name_type = _String
+  .being_titlecase
+  .matching(/^[A-Z][a-z]+$/)
+  .having_size_between(2, 30)
+
+name_type.validate!("a")  # What error message do you get?
+
+# Scenario 2: Nested Type Constraints
+user_type = _Hash
+  .of(Symbol => _Union(_String, _Integer))
+  .containing_keys(:name, :age)
+  .excluding_values(nil)
+
+user_type.validate!({
+  name: 123,
+  age: "twenty"
+})  # How clear is this error?
+
+# Scenario 3: Array Element Validation
+numbers = _Array
+  .of(_Integer)
+  .being_ordered
+  .having_size(3)
+  .containing(42)
+
+numbers.validate!(["1", 2, 3])  # Is the error helpful?
+```
+
+### 2. Built-in Types
+
+Currently supported types:
+
+* `_String`
+* `_Integer`
+* `_Float`
+* `_Array`
+* `_Hash`
+* `_Symbol`
+* `_Boolean`
+* `_Union`
+* `_Enum`
+* `_Duck`
+* `_Anything`
+* `_Nilable`
+
+Try them out! What types are missing? What would make existing types more useful?
+
+### 3. Constraints
+
+Each type comes with its own set of constraints. Here are some highlights:
+
+String constraints:
+
+```ruby
+_String
+  .being_ascii
+  .being_alphanumeric
+  .being_lowercase
+  .being_uppercase
+  .being_titlecase
+  .matching(/pattern/)
+  .containing("substring")
+  .having_size_between(min, max)
+```
+
+Numeric constraints:
+
+```ruby
+_Integer
+  .being_positive
+  .being_negative
+  .being_even
+  .being_odd
+  .being_divisible_by(3)
+  .being_between(1, 100)
+```
+
+Array/Hash constraints:
+
+```ruby
+_Array
+  .being_empty
+  .being_ordered
+  .being_distinct
+  .containing(1, 2, 3)
+  .excluding(4, 5, 6)
+  .having_size(5)
+
+_Hash
+  .containing_keys(:a, :b)
+  .excluding_values(nil)
+  .having_minimum_size(2)
+```
+
+What constraints would you add? What would make existing constraints more powerful?
+
+## Providing Feedback
+
+We want to make providing feedback as easy as possible! Leave a comment on one of the mega-issues described below or
+just open an issue on GitHub describing what you found. No formal template required - tell us what worked, what didn't,
+what confused you, or what you wish existed.
+
+Some things we'd love to hear about:
+
+* Confusing or unhelpful error messages
+* Missing types or constraints you need
+* Unexpected errors or behavior
+* Creative ways you worked around limitations
+* Ideas for making the library more useful
+* Your use cases and how you're using types
+
+Include code examples if you can, but don't worry if you can't!
+
+### Feedback Categories
+
+We've set up mega-issues for collecting certain types of feedback:
+
+* [Error Messages](https://github.com/domainic/domainic/issues/132) * Share confusing or unhelpful error messages
+* [Unexpected Behavior](https://github.com/domainic/domainic/issues/133) * Report surprising or unexpected behavior
+* [Feature Requests](https://github.com/domainic/domainic/issues/134) * Suggest new types, constraints, or capabilities
+* [General Feedback](https://github.com/domainic/domainic/issues/135) * Everything else!
+
+## Inspiration
+
+This experiment draws inspiration from several existing type systems and validation libraries:
+
+* [ValueSemantics](https://github.com/tomdalling/value_semantics) (Ruby)
+* [Literal](https://github.com/joeldrapper/literal) (Ruby)
+* [Sorbet](https://github.com/sorbet/sorbet) & [RBS](https://github.com/ruby/rbs) (Ruby)
+* [TypeScript](https://github.com/microsoft/TypeScript)
+
+## Going Wild
+
+Don't hold back! Try complex combinations of types and constraints. Chain constraints together in creative ways. Push
+the boundaries of what's possible. The more you experiment, the more we learn!
+
+```ruby
+# Example: Go nuts!
+response_type = _Hash
+  .of(_Symbol => _Union(
+    _String.being_uppercase.matching(/^[A-Z]{2,5}$/),
+    _Array.of(_Integer.being_positive.being_less_than(100)),
+    _Hash.of(_Symbol => _Boolean)
+  ))
+  .containing_keys(:status, :data)
+  .having_minimum_size(2)
+```
+
+## Questions
+
+Not sure about something? Just open an issue! The only bad question is the unasked question!
+
+Remember: This is an experiment! Things might break, error messages might be confusing, and features might be missing.
+That's exactly what we want to learn about!

--- a/docs/experiments/domainic-type-alpha-3/TROUBLESHOOTING.md
+++ b/docs/experiments/domainic-type-alpha-3/TROUBLESHOOTING.md
@@ -1,0 +1,139 @@
+# Troubleshooting
+
+This guide covers common issues you might encounter while experimenting with Domainic::Type.
+
+## Common Gotchas
+
+### Type vs Constraint Errors
+
+If you're seeing unexpected errors, check if you're dealing with a type failure or a constraint failure:
+
+```ruby
+# Type failure - value isn't even the right type
+_String.validate!(123)  
+# => TypeError: Expected String, but got Integer
+
+# Constraint failure - right type but fails constraints
+_String.being_uppercase.validate!("hello")
+# => TypeError: Expected String(being upper case), but got String(not upper case)
+```
+
+### Constraint Overrides
+
+Some constraints are mutually exclusive and will override each other based on order. The last called constraint wins:
+
+```ruby
+# The being_duplicative constraint will override being_distinct
+_Array
+  .being_distinct        # This constraint is ignored
+  .being_duplicative    # This is the active constraint
+  .validate!([1, 1, 2]) # => true
+
+# The being_distinct constraint will override being_duplicative
+_Array
+  .being_duplicative    # This constraint is ignored
+  .being_distinct      # This is the active constraint
+  .validate!([1, 1, 2]) # => TypeError
+```
+
+Other examples of mutually exclusive constraints:
+
+* `being_empty` vs `being_populated`
+* `being_ordered` vs `being_unordered`
+* `being_positive` vs `being_negative`
+* `being_even` vs `being_odd`
+
+### Nil Handling
+
+By default, most types reject nil values. Use _Nilable if you want to allow nil:
+
+```ruby
+# Will reject nil:
+_String.validate!(nil)  # => TypeError
+
+# Will allow nil:
+_Nilable(_String).validate!(nil)  # => true
+
+# Will allow nil:
+_String?.validate!(nil) # => true
+```
+
+### Union Type Gotchas
+
+When using _Union types, remember that constraints apply to all possible types:
+
+```ruby
+# This might not work as expected:
+_Union(_String, _Integer)
+  .being_uppercase  # Can't apply string constraint to integer!
+  .validate!(123)
+
+# Instead, constrain the specific types:
+_Union(
+  _String.being_uppercase,
+  _Integer
+).validate!(123)  # Works!
+```
+
+### Hash Key/Value Types
+
+When setting types for hash keys and values, the syntax can be tricky:
+
+```ruby
+# This works:
+_Hash.of(Symbol => String)
+
+# This also works and gives you more control:
+_Hash.of(_Symbol => _String.being_uppercase)
+
+# This won't work:
+_Hash.of(symbol: string)  # Don't use Ruby hash syntax!
+```
+
+## Debugging Tips
+
+### Inspect Type Definitions
+
+You can print any type to see its constraints:
+
+```ruby
+type = _String.being_uppercase.having_minimum_size(5)
+puts type  # Shows full type definition with constraints
+```
+
+### Step-by-Step Validation
+
+Break down complex type validations into steps:
+
+```ruby
+complex_type = _Hash
+  .of(_Symbol => _Array.of(_String.being_uppercase))
+  .having_minimum_size(1)
+
+# Test the inner type first
+string_type = _String.being_uppercase
+string_type.validate!("TEST")  # Does this work?
+
+# Then the array type
+array_type = _Array.of(string_type)
+array_type.validate!(["TEST"])  # Does this work?
+
+# Finally the full hash
+complex_type.validate!({ key: ["TEST"] })  # Now where does it fail?
+```
+
+### Common Error Patterns
+
+* If a type check fails immediately, you probably have a basic type mismatch
+* If validation fails after type checking, look at your constraints
+* If you're seeing method errors, check if you're using the right type for your constraints
+
+## Still Stuck
+
+Remember: This is an experiment! If something isn't working and you can't figure out why:
+
+1. Open an issue! No need to figure it all out first.
+2. Include your code example, what you expected, and what happened instead.
+3. If you found a workaround, share that too - it helps us learn!
+
+Every "stuck" moment is valuable feedback that helps us improve the library.

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -10,6 +10,8 @@ significant changes.
   * **December 12, 2024**
     * [domainic-attributer v0.1.0 Released](./domainic-v0.1.0/updates/2024-12-12-01.md)
     * [domainic-attributer v0.2.0 Development Started](./domainic-v0.1.0/updates/2024-12-12-02.md)
+  * **December 23, 2024**
+    * [🧪 Experiment Launch: Domainic::Type Alpha 3](./domainic-v0.1.0/updates/2024-12-23-01.md)
 
 ## Related Documentation
 

--- a/docs/projects/domainic-v0.1.0/updates/2024-12-23-01.md
+++ b/docs/projects/domainic-v0.1.0/updates/2024-12-23-01.md
@@ -1,0 +1,71 @@
+# 🧪 Experiment Launch: Domainic::Type Alpha 3
+
+We're excited to announce the experimental release of Domainic::Type! This marks our first public experiment in the
+Domainic ecosystem, exploring flexible type validation with composable constraints.
+
+## What's Being Tested
+
+The experiment focuses on three key areas:
+
+1. **Error Message Composition**
+  * How well do error messages combine across multiple constraints?
+  * Are messages clear and helpful when dealing with complex types?
+  * Do nested type validations provide meaningful error context?
+
+2. **Type System Completeness**
+  * Current types include String, Integer, Float, Array, Hash, Symbol, Boolean, etc.
+  * Looking for feedback on missing types and use cases
+  * Testing type composition with unions, enums, and duck types
+
+3. **Constraint System**
+  * Rich set of built-in constraints for each type
+  * Testing constraint composition and chaining
+  * Seeking feedback on missing constraints and use cases
+
+## Feedback Collection
+
+All feedback will be gathered through GitHub issues. We've intentionally kept the barrier to feedback low * no templates
+required, just share what you find! Key feedback areas:
+
+* Error message clarity and usefulness
+* Missing types or constraints
+* Unexpected behaviors
+* Creative workarounds
+* Real-world use cases
+
+## Documentation
+
+The experiment is documented in the `docs/experiments/domainic-type-alpha-3` directory:
+
+* README.md - Overview and quick start
+* TROUBLESHOOTING.md - Common issues and solutions
+* Examples and known issues docs to follow
+
+## Next Steps
+
+1. Release `domainic-type v0.1.0-alpha.3.0.0` to RubyGems
+2. Monitor and gather feedback through GitHub issues
+3. Iterate based on community input
+4. Work toward a stable v0.1.0 release
+
+## Getting Started
+
+```ruby
+gem 'domainic-type', '0.1.0-alpha.3.0.0'
+```
+
+We encourage everyone to experiment freely with the library. Chain constraints in creative ways, try complex type
+compositions, and don't worry about breaking things * that's how we learn!
+
+## Progress Tracking
+
+* [x] Core type system implementation
+* [x] Initial constraint system
+* [x] Basic error message composition
+* [x] Experiment documentation
+* [ ] Community feedback collection
+* [ ] Iteration based on feedback
+* [ ] Stable v0.1.0 release
+
+View the full experiment documentation in `docs/experiments/domainic-type-alpha-3` for more details on testing areas and
+how to provide feedback.


### PR DESCRIPTION
Add comprehensive documentation for the Domainic::Type alpha 3 experiment including:

* Main experiments README explaining purpose and structure
* Domainic::Type experiment docs:
 * README.md with quick start, test areas, feedback guidelines
 * EXAMPLES.md with basic to advanced usage patterns
 * TROUBLESHOOTING.md covering common issues and gotchas
 * CHANGELOG.md for tracking experiment versions
 * KNOWN_ISSUES.md template for tracking discovered issues

Key additions:
* Clear test focus areas (error messages, types, constraints)
* Detailed examples for all types and constraints
* Issue templates for collecting feedback
* Documentation of mutual constraint overrides
* Version scheme for experiments

see #131