### PR TITLE
Bump domainic-type version and update documentation for alpha 3 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,9 @@ PATH
   specs:
     domainic (0.1.0)
       domainic-attributer (~> 0.1)
-      domainic-type (~> 0.1)
+      domainic-type (~> 0.1.0.alpha.3)
     domainic-attributer (0.2.0)
-    domainic-type (0.1.0)
+    domainic-type (0.1.0.alpha.3.0.0)
 
 PATH
   remote: domainic-dev

--- a/domainic-type/README.md
+++ b/domainic-type/README.md
@@ -1,8 +1,13 @@
 # Domainic::Type
 
-[![Domainic::Type Version](https://img.shields.io/badge/unreleased-orange?label=gem%20version&logo=rubygems&logoColor=white&logoSize=auto&style=for-the-badge)](https://rubygems.org/gems/domainic-type)
+[![Domainic::Type Version](https://img.shields.io/gem/v/domainic-type?style=for-the-badge&logo=rubygems&logoColor=white&logoSize=auto&label=Gem%20Version)](https://rubygems.org/gems/domainic-type)
 [![Domainic::Type License](https://img.shields.io/github/license/domainic/domainic?logo=opensourceinitiative&logoColor=white&logoSize=auto&style=for-the-badge)](./LICENSE)
 [![Domainic::Type Open Issues](https://img.shields.io/github/issues-search/domainic/domainic?label=open%20issues&logo=github&logoSize=auto&query=is%3Aopen%20label%3Adomainic-type&color=red&style=for-the-badge)](https://github.com/domainic/domainic/issues?q=state%3Aopen%20label%3Adomainic-type%20)
+
+> [!IMPORTANT]  
+> We're running an experiment with Domainic::Type! Help us explore flexible type validation in Ruby by trying our
+> [alpha release](../docs/experiments/domainic-type-alpha-3/README.md). Your feedback is invaluable for shaping
+> the future of domain-driven design in Ruby.
 
 A flexible type validation system for Ruby, offering composable, readable type constraints with elegant error messages.
 
@@ -16,11 +21,11 @@ you, not against you!
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'domainic-type'
+gem 'domainic-type', '~> 0.1.0.alpha.3'
 ```
 
 Or install it yourself as:
 
 ```bash
-gem install domainic-type
+gem install domainic-type --pre
 ```

--- a/domainic-type/domainic-type.gemspec
+++ b/domainic-type/domainic-type.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-DOMAINIC_TYPE_GEM_VERSION = '0.1.0'
-DOMAINIC_TYPE_SEMVER = '0.1.0'
+DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.0.0'
+DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.0.0'
 DOMAINIC_TYPE_REPO_URL = 'https://github.com/domainic/domainic'
 DOMAINIC_TYPE_HOME_URL = "#{DOMAINIC_TYPE_REPO_URL}/tree/domainic-type-v" \
                          "#{DOMAINIC_TYPE_SEMVER}/domainic-type".freeze

--- a/domainic.gemspec
+++ b/domainic.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'domainic-attributer', '~> 0.1'
-  spec.add_dependency 'domainic-type', '~> 0.1'
+  spec.add_dependency 'domainic-type', '~> 0.1.0.alpha.3'
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -14,7 +14,7 @@ gems:
   source:
     type: rubygems
 - name: domainic-type
-  version: 0.1.0
+  version: 0.1.0.alpha.3.0.0
   source:
     type: rubygems
 - name: fileutils


### PR DESCRIPTION
This bumps the version of domainic-type to v0.1.0-alpha.3.0.0 and updates the necessary documentation for release.

see #131