### PR TITLE
Fix `Domainic::Type::Constraint::Set#violation_description`

### DIFF
--- a/domainic-type/lib/domainic/type/constraint/set.rb
+++ b/domainic-type/lib/domainic/type/constraint/set.rb
@@ -225,7 +225,7 @@ module Domainic
         # @rbs () -> String
         def violation_description
           Type::ACCESSORS.flat_map do |accessor|
-            @lookup[accessor].values.filter_map(&:full_violation_description)
+            @lookup[accessor].values.reject(&:successful?).filter_map(&:full_violation_description)
           end.join(', ').strip
         end
 


### PR DESCRIPTION
Modified violation_description method in Set class to only include descriptions from constraints that failed validation. This creates more focused and clearer error messages by excluding status of constraints that passed.

Added comprehensive specs to verify:

* Only failed constraint descriptions are included
* Empty string returned when all constraints pass
* All violation descriptions included when all constraints fail

Changed:
  * changed `Domainic::Type::Constraint::Set#violation_description`

fixes #138