### PR TITLE
Release Domainic::Type v0.1.0-alpha.3.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       domainic-attributer (~> 0.1)
       domainic-type (~> 0.1.0.alpha.3)
     domainic-attributer (0.2.0)
-    domainic-type (0.1.0.alpha.3.0.1)
+    domainic-type (0.1.0.alpha.3.0.2)
 
 PATH
   remote: domainic-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ documentation across the Domainic ecosystem.
 ### Experimental
 
 * [**domainic-type**](../domainic-type/) - Flexible type validation system
-  * **Current Version**: 0.1.0-alpha.3.0.1
+  * **Current Version**: 0.1.0-alpha.3.0.2
   * [Experiment Details](./experiments/domainic-type-alpha-3/)
   * [Testing & Feedback](./experiments/domainic-type-alpha-3/README.md)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,8 +65,8 @@ If you have suggestions on how this process could be improved, please submit a p
 
 |        Version        | Support |
 |:---------------------:|:-------:|
-|  `0.1.0-alpha.3.0.1`  |   🧪    |
-| `> 0.1.0-alpha.3.0.1` |    ❌   |
+|  `0.1.0-alpha.3.0.2`  |   🧪    |
+| `> 0.1.0-alpha.3.0.2` |    ❌   |
 
 ### Key
 

--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -4,15 +4,18 @@
 
 ### [Unreleased]
 
+### [0.1.0-alpha.3.0.2] - 2024-12-25
+
 #### Added
 
-* [#146](https://github/com/domainic/domainic/pull/146) `Domainic::Type::InstanceType` for type checking instances.
+* [#146](https://github.com/domainic/domainic/pull/146) added `Domainic::Type::InstanceType` for type checking
+  instances.
 
 ### [0.1.0-alpha.3.0.1] - 2024-12-23
 
 #### Fixed
 
-* [#138](https://github.com/domainic/domainic/issues/138) error messages only show failed constraints.
+* [#138](https://github.com/domainic/domainic/issues/138) fixed error messages now only show failed constraints.
 
 ### 0.1.0-alpha.3.0.0 - 2024-12-23
 
@@ -24,7 +27,8 @@
 > As this is an experimental release, features may change significantly based on feedback. Refer to
 > docs/experiments/domainic-type-v0.1.0-alpha.3/README.md for full details and current testing focus.
 
-[Unreleased]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.1...HEAD
+[Unreleased]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.2...HEAD
+[0.1.0-alpha.3.0.2]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.1...domainic-type-v0.1.0-alpha.3.0.2
 [0.1.0-alpha.3.0.1]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.0...domainic-type-v0.1.0-alpha.3.0.1
 
 |                               |                         |                                       |                                 |

--- a/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
+++ b/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
@@ -239,9 +239,9 @@ also known as `_List`, `_Array?`, `_List?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/sizable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Array` type provides comprehensive validation for array values with constraints for content, ordering, and size.
@@ -317,7 +317,7 @@ also known as `_Decimal`, `_Real`, `_Float?`, `_Decimal?`, `_Real?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Float` type validates floating-point numbers with comprehensive numeric constraints:
@@ -351,9 +351,9 @@ also known as `_Map`, `_Hash?`, `_Map?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb),
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb),
-> and [HashType](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/types/core/hash_type.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb),
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb),
+> and [HashType](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/types/core/hash_type.rb)
 > for the full list of available methods and aliases!
 
 The `_Hash` type provides validation for hash structures with constraints for keys, values, and overall composition:
@@ -406,7 +406,7 @@ also known as `_Int`, `_Integer?`, `_Int?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Integer` type validates integer values with comprehensive numeric constraints:
@@ -458,9 +458,9 @@ also known as `_Text`, `_String?`, `_Text?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_String` type validates string values with comprehensive text manipulation constraints:
@@ -497,9 +497,9 @@ also known as `_Interned`, `_Symbol?`, `_Interned?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Symbol` type validates symbols and supports all string-like constraints applied to the symbol's name:

--- a/domainic-type/domainic-type.gemspec
+++ b/domainic-type/domainic-type.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.0.1'
-DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.0.1'
+DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.0.2'
+DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.0.2'
 DOMAINIC_TYPE_REPO_URL = 'https://github.com/domainic/domainic'
 DOMAINIC_TYPE_HOME_URL = "#{DOMAINIC_TYPE_REPO_URL}/tree/domainic-type-v" \
                          "#{DOMAINIC_TYPE_SEMVER}/domainic-type".freeze

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -14,7 +14,7 @@ gems:
   source:
     type: rubygems
 - name: domainic-type
-  version: 0.1.0.alpha.3.0.1
+  version: 0.1.0.alpha.3.0.2
   source:
     type: rubygems
 - name: fileutils


### PR DESCRIPTION
This release introduces instance type validation capabilities with the new`Domainic::Type::InstanceType` class and associated constraints. It provides powerful features for validating objects against specific classes, modules, and attribute structures.

Key changes:

* Added `Domainic::Type::InstanceType` for constraining objects to specific classes/modules and validating attributes
* Introduced `_Instance` and `_Instance?` methods in `Domainic::Type::Definitions` for creating instance type constraints
* Added `InstanceOfConstraint` for precise instance type checking
* Added `AttributePresenceConstraint` for validating object attribute presence and typing
* Enhanced documentation with details and usage examples for `InstanceType`

Changelog:

* added `Domainic::Type::Constraint::InstanceOfConstraint`
* added `Domainic::Type::Constraint::AttributePresenceConstraint`
* added `Domainic::Type::InstanceType`
* added `Domainic::Type::Definitions._Instance`
* added `Domainic::Type::Definitions._Instance?`

see #145