### PR TITLE
Rename `intrinsic` to `intrinsically_constrain` with deprecation

### DIFF
--- a/domainic-type/lib/domainic/type/behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior.rb
@@ -105,6 +105,8 @@ module Domainic
         #
         # @see Constraint::Set#add
         #
+        # @deprecated Use {#intrinsically_constrain} instead
+        #
         # @return [void]
         # @rbs (
         #   Type::accessor accessor,
@@ -113,7 +115,10 @@ module Domainic
         #   **untyped options
         #   ) -> void
         def intrinsic(...)
-          intrinsic_constraints.add(...)
+          warn 'Domainic::Type::Behavior.intrinsic is deprecated and will be remove in a future release. Use ' \
+               "Domainic::Type::Behavior.intrinsically_constrain instead.\n" \
+               "Called from: #{caller_locations(1..1)&.first}"
+          intrinsically_constrain(...)
         end
 
         # Get the set of intrinsic constraints for this type.
@@ -122,6 +127,21 @@ module Domainic
         # @rbs () -> Constraint::Set
         def intrinsic_constraints
           @intrinsic_constraints ||= Constraint::Set.new
+        end
+
+        # Add an intrinsic constraint to this type.
+        #
+        # @see Constraint::Set#add
+        #
+        # @return [void]
+        # @rbs (
+        #   Type::accessor accessor,
+        #   String | Symbol constraint_type,
+        #   ?untyped expectation,
+        #   **untyped options
+        #   ) -> void
+        def intrinsically_constrain(...)
+          intrinsic_constraints.add(...)
         end
 
         # Delegate unknown methods to a new instance.

--- a/domainic-type/lib/domainic/type/types/core/array_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/array_type.rb
@@ -42,7 +42,7 @@ module Domainic
       include Behavior
       include Behavior::EnumerableBehavior
 
-      intrinsic :self, :type, Array, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Array, abort_on_failure: true, description: :not_described
     end
   end
 end

--- a/domainic-type/lib/domainic/type/types/core/float_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/float_type.rb
@@ -33,7 +33,7 @@ module Domainic
       include Behavior
       include Behavior::NumericBehavior
 
-      intrinsic :self, :type, Float, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Float, abort_on_failure: true, description: :not_described
     end
   end
 end

--- a/domainic-type/lib/domainic/type/types/core/hash_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/hash_type.rb
@@ -42,7 +42,7 @@ module Domainic
       include Behavior
       include Behavior::EnumerableBehavior
 
-      intrinsic :self, :type, Hash, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Hash, abort_on_failure: true, description: :not_described
 
       # Validate that the hash contains specific keys
       #

--- a/domainic-type/lib/domainic/type/types/core/integer_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/integer_type.rb
@@ -32,7 +32,7 @@ module Domainic
       include Behavior
       include Behavior::NumericBehavior
 
-      intrinsic :self, :type, Integer, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Integer, abort_on_failure: true, description: :not_described
     end
   end
 end

--- a/domainic-type/lib/domainic/type/types/core/string_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/string_type.rb
@@ -45,7 +45,7 @@ module Domainic
       include Behavior
       include Behavior::StringBehavior
 
-      intrinsic :self, :type, String, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
     end
   end
 end

--- a/domainic-type/lib/domainic/type/types/core/symbol_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/symbol_type.rb
@@ -45,7 +45,7 @@ module Domainic
       include Behavior
       include Behavior::StringBehavior
 
-      intrinsic :self, :type, Symbol, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Symbol, abort_on_failure: true, description: :not_described
     end
   end
 end

--- a/domainic-type/sig/domainic/type/behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior.rbs
@@ -87,6 +87,8 @@ module Domainic
         #
         # @see Constraint::Set#add
         #
+        # @deprecated Use {#intrinsically_constrain} instead
+        #
         # @return [void]
         def intrinsic: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> void
 
@@ -94,6 +96,13 @@ module Domainic
         #
         # @return [Constraint::Set] The constraint set
         def intrinsic_constraints: () -> Constraint::Set
+
+        # Add an intrinsic constraint to this type.
+        #
+        # @see Constraint::Set#add
+        #
+        # @return [void]
+        def intrinsically_constrain: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> void
 
         # Delegate unknown methods to a new instance.
         #

--- a/domainic-type/spec/domainic/type/behavior/enumerable_behavior_spec.rb
+++ b/domainic-type/spec/domainic/type/behavior/enumerable_behavior_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Domainic::Type::Behavior::EnumerableBehavior do
       include Domainic::Type::Behavior
       include Domainic::Type::Behavior::EnumerableBehavior
 
-      intrinsic :self, :type, Enumerable, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Enumerable, abort_on_failure: true, description: :not_described
     end
   end
 

--- a/domainic-type/spec/domainic/type/behavior/numeric_behavior_spec.rb
+++ b/domainic-type/spec/domainic/type/behavior/numeric_behavior_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Domainic::Type::Behavior::NumericBehavior do
       include Domainic::Type::Behavior
       include Domainic::Type::Behavior::NumericBehavior
 
-      intrinsic :self, :type, Numeric, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, Numeric, abort_on_failure: true, description: :not_described
     end
   end
 

--- a/domainic-type/spec/domainic/type/behavior/string_behavior_spec.rb
+++ b/domainic-type/spec/domainic/type/behavior/string_behavior_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Domainic::Type::Behavior::StringBehavior do
       include Domainic::Type::Behavior
       include Domainic::Type::Behavior::StringBehavior
 
-      intrinsic :self, :type, String, abort_on_failure: true, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
     end
   end
 


### PR DESCRIPTION
## Description

Deprecates `Behavior.intrinsic` in favor of the more descriptive `intrinsically_constrain` method name. This change improves code readability by better communicating the method's purpose of defining intrinsic constraints for a type.

## Changes Made

* Added deprecation warning to existing `intrinsic` method
* Added new `intrinsically_constrain` method
* Updated all core type definitions to use new method name
* Updated behavior specs to use new method name

## Checklist

* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed

## Additional Notes

* Deprecation includes helpful warning message with call location for debugging
* No functional changes, only method renaming