### PR TITLE
Add UUIDType and CUIDType with Definition Helpers

### DIFF
--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -78,6 +78,9 @@ types:
   anything:
     constant: Domainic::Type::AnythingType
     require_path: domainic/type/types/specification/anything_type
+  cuid:
+    constant: Domainic::Type::CUIDType
+    require_path: domainic/type/types/identifier/cuid_type
   duck:
     constant: Domainic::Type::DuckType
     require_path: domainic/type/types/specification/duck_type

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -114,6 +114,9 @@ types:
   uri:
     constant: Domainic::Type::URIType
     require_path: domainic/type/types/network/uri_type
+  uuid:
+    constant: Domainic::Type::UUIDType
+    require_path: domainic/type/types/identifier/uuid_type
   void:
     constant: Domainic::Type::VoidType
     require_path: domainic/type/types/specification/void_type

--- a/domainic-type/lib/domainic/type/definitions.rb
+++ b/domainic-type/lib/domainic/type/definitions.rb
@@ -103,6 +103,36 @@ module Domainic
       end
       alias _Bool? _Boolean?
 
+      # Creates a CUIDType instance
+      #
+      # @example
+      #   type = _CUID.v2
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::CUIDType] the created type
+      # @rbs (**__todo__ options) -> CUIDType
+      def _CUID(**options)
+        require 'domainic/type/types/identifier/cuid_type'
+        Domainic::Type::CUIDType.new(**options)
+      end
+      alias _Cuid _CUID
+
+      # Creates a nilable CUIDType instance.
+      #
+      # @example
+      #   _CUID? === "la6m1dv00000gv25zp9ru12g" # => true
+      #   _CUID? === nil                        # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (CUIDType or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _CUID?(**options)
+        _Nilable(_CUID(**options))
+      end
+      alias _Cuid? _CUID?
+
       # Creates a DuckType instance.
       #
       # DuckType allows specifying behavior based on method availability.
@@ -280,6 +310,33 @@ module Domainic
         _Nilable(_Hostname(**options))
       end
 
+      # Creates a UnionType of IntegerType, UUIDType, and CUIDType
+      #
+      # @example
+      #   _ID === 1234567890                             # => true
+      #   _ID === '123e4567-e89b-42d3-a456-426614174000' # => true
+      #   _ID === 'la6m1dv00000gv25zp9ru12g'             # => true
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      # @rbs () -> UnionType
+      def _ID
+        _Union(_Integer, _UUID, _CUID)
+      end
+
+      # Creates a nilable UnionType of IntegerType, UUIDType, and CUIDType
+      #
+      # @example
+      #   _ID === 1234567890                             # => true
+      #   _ID === '123e4567-e89b-42d3-a456-426614174000' # => true
+      #   _ID === 'la6m1dv00000gv25zp9ru12g'             # => true
+      #   _ID === nil                                    # => true
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      # @rbs () -> UnionType
+      def _ID?
+        _Nilable(_ID)
+      end
+
       # Create an InstanceType instance.
       #
       # @example
@@ -417,6 +474,36 @@ module Domainic
         _Nilable(symbol)
       end
       alias _Interned? _Symbol?
+
+      # Creates a UUIDType instance
+      #
+      # @example
+      #   type = _UUID.v4_compact
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UUIDType] the created type
+      # @rbs (**__todo__ options) -> UUIDType
+      def _UUID(**options)
+        require 'domainic/type/types/identifier/uuid_type'
+        Domainic::Type::UUIDType.new(**options)
+      end
+      alias _Uuid _UUID
+
+      # Creates a nilable UUIDType instance.
+      #
+      # @example
+      #   _UUID? === '123e4567-e89b-42d3-a456-426614174000' # => true
+      #   _UUID? === nil                                    # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (UUIDType or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _UUID?(**options)
+        _Nilable(_UUID(**options))
+      end
+      alias _Uuid? _UUID?
 
       # Creates a UnionType instance.
       #

--- a/domainic-type/lib/domainic/type/types/identifier/cuid_type.rb
+++ b/domainic-type/lib/domainic/type/types/identifier/cuid_type.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+
+module Domainic
+  module Type
+    # A type for validating CUIDs according to official specifications
+    #
+    # This type provides comprehensive CUID validation following the official
+    # CUID specifications. It supports both v1 and v2 formats, with proper
+    # format-specific validation.
+    #
+    # Key features:
+    # - CUID v1 validation (25 characters, c-prefix)
+    # - CUID v2 validation (variable length 14-24 chars)
+    # - Length validation
+    # - Character set validation
+    #
+    # @example Basic usage
+    #   type = CUIDType.new
+    #   type.validate("ch72gsb320000udocl363eofy")  # => true
+    #   type.validate("invalid")                     # => false
+    #
+    # @example With version constraints
+    #   type = CUIDType.new.being_version(2)
+    #   type.validate("clh3am1f30000udocbhqg4151")  # => true
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class CUIDType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+
+      # Contains CUID validation regular expressions and version-specific modules
+      #
+      # This module provides validation patterns for both CUID v1 and v2 formats,
+      # following the official specification.
+      #
+      # @since 0.1.0
+      module CUID
+        # Regular expression for CUID v1 format
+        #
+        # Validates CUIDs in v1 format: c-prefix + 24 lowercase alphanumeric chars
+        # Example: "ch72gsb320000udocl363eofy"
+        #
+        # @since 0.1.0
+        V1_REGEXP = /\Ac[a-z0-9]{24}\z/ #: Regexp
+
+        # Regular expression for CUID v2 format
+        #
+        # Validates CUIDs in v2 format: k-p prefix + 13-23 lowercase alphanumeric chars
+        # Example: "clh3am1f30000udocbhqg4151"
+        #
+        # @since 0.1.0
+        V2_REGEXP = /\A[k-p][a-z0-9]{13,23}\z/ #: Regexp
+
+        # Regular expression for any valid CUID (v1 or v2)
+        ALL_REGEXP = Regexp.union(V1_REGEXP, V2_REGEXP) #: Regexp
+      end
+
+      # Core CUID constraints
+      intrinsically_constrain :self, :type, String, description: :not_described
+
+      # Accept either v1 or v2 format by default
+      intrinsically_constrain :self, :match_pattern, CUID::ALL_REGEXP,
+                              description: 'CUID format', concerning: :format
+
+      # Length constraint covers both v1 (25 chars) and v2 (14-24 chars)
+      intrinsically_constrain :length, :range, { minimum: 14, maximum: 25 },
+                              description: 'having', concerning: :size
+
+      # Constrain CUID to specific version
+      #
+      # Creates a constraint ensuring the CUID matches a specific version (1 or 2).
+      #
+      # @example
+      #   type.being_version(1)
+      #   type.validate("ch72gsb320000udocl363eofy")  # => true
+      #
+      # @param version [Integer] CUID version (1 or 2)
+      # @return [self] self for method chaining
+      # @raise [ArgumentError] if version is neither 1 nor 2
+      # @rbs (Integer version) -> self
+      def being_version(version)
+        case version
+        when 1 then being_version_one
+        when 2 then being_version_two
+        else
+          raise ArgumentError, "Invalid version: #{version}. Must be 1 or 2"
+        end
+      end
+      alias version being_version
+
+      # Constrain CUID to Version 1
+      #
+      # Creates a constraint ensuring the CUID is a Version 1 CUID.
+      # Version 1 CUIDs are 25 characters long and start with 'c'.
+      #
+      # @example
+      #   type.being_version_one
+      #   type.validate("ch72gsb320000udocl363eofy")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_one
+        constrain :length, :range, { minimum: 25, maximum: 25 },
+                  concerning: :size, description: 'having v1 length'
+        constrain :self, :match_pattern, CUID::V1_REGEXP,
+                  description: 'v1 CUID format',
+                  concerning: :version
+      end
+      alias being_v1 being_version_one
+      alias v1 being_version_one
+      alias version_one being_version_one
+
+      # Constrain CUID to Version 2
+      #
+      # Creates a constraint ensuring the CUID is a Version 2 CUID.
+      # Version 2 CUIDs are 14-24 characters and start with k-p.
+      #
+      # @example
+      #   type.being_version_two
+      #   type.validate("clh3am1f30000udocbhqg4151")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_two
+        constrain :length, :range, { minimum: 14, maximum: 24 },
+                  concerning: :size, description: 'having v2 length'
+        constrain :self, :match_pattern, CUID::V2_REGEXP,
+                  description: 'v2 CUID format',
+                  concerning: :version
+      end
+      alias being_v2 being_version_two
+      alias v2 being_version_two
+      alias version_two being_version_two
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/types/identifier/uuid_type.rb
+++ b/domainic-type/lib/domainic/type/types/identifier/uuid_type.rb
@@ -1,0 +1,513 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+
+module Domainic
+  # NOTE: This file is located at lib/domainic/type/types/identifier/uuid_type.rb
+  module Type
+    # A type for validating UUIDs according to RFC 4122 standards
+    #
+    # This type provides comprehensive UUID validation following RFC 4122 standards.
+    # It supports both standard (hyphenated) and compact formats for all UUID versions
+    # (1 through 7), while enforcing proper formatting and version-specific constraints.
+    #
+    # Key features:
+    # - RFC 4122 compliant UUID format validation
+    # - Support for versions 1-7
+    # - Standard (hyphenated) and compact format support
+    # - Length validation (36 chars for standard, 32 for compact)
+    # - Version-specific validation
+    #
+    # @example Basic usage
+    #   type = UUIDType.new
+    #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => true
+    #   type.validate("invalid")                                # => false
+    #
+    # @example With version constraints
+    #   type = UUIDType.new.being_version(4)
+    #   type.validate("123e4567-e89b-42d3-a456-426614174000")  # => true
+    #
+    # @example With format constraints
+    #   type = UUIDType.new.being_compact
+    #   type.validate("123e4567e89b12d3a456426614174000")      # => true
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class UUIDType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+
+      # Contains UUID validation regular expressions and version-specific modules
+      #
+      # This module provides both standard (hyphenated) and compact format regular
+      # expressions for UUID validation, along with version-specific submodules for
+      # more granular validation requirements.
+      #
+      # @since 0.1.0
+      module UUID
+        # Regular expression for standard (hyphenated) UUID format
+        #
+        # Validates UUIDs in the format: 8-4-4-4-12 hexadecimal digits with hyphens
+        # Example: "123e4567-e89b-12d3-a456-426614174000"
+        #
+        # @since 0.1.0
+        STANDARD_REGEXP = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i #: Regexp
+
+        # Regular expression for compact (non-hyphenated) UUID format
+        #
+        # Validates UUIDs in the format: 32 continuous hexadecimal digits
+        # Example: "123e4567e89b12d3a456426614174000"
+        #
+        # @since 0.1.0
+        COMPACT_REGEXP = /\A[0-9a-f]{8}[0-9a-f]{4}[1-7][0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}\z/i #: Regexp
+
+        # Version 1 UUID validation patterns
+        #
+        # Provides regular expressions for validating time-based Version 1 UUIDs.
+        # These UUIDs are generated using a timestamp and node ID.
+        #
+        # @since 0.1.0
+        module V1
+          # Standard format regex for Version 1 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 1 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-1[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #: Regexp
+
+          # Compact format regex for Version 1 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 1 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}1[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #: Regexp
+        end
+
+        # Version 2 UUID validation patterns
+        #
+        # Provides regular expressions for validating DCE Security Version 2 UUIDs.
+        # These UUIDs incorporate local domain identifiers.
+        #
+        # @since 0.1.0
+        module V2
+          # Standard format regex for Version 2 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 2 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-2[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #:Regexp
+
+          # Compact format regex for Version 2 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 2 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}2[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #:Regexp
+        end
+
+        # Version 3 UUID validation patterns
+        #
+        # Provides regular expressions for validating name-based Version 3 UUIDs
+        # using MD5 hashing.
+        #
+        # @since 0.1.0
+        module V3
+          # Standard format regex for Version 3 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 3 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-3[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #:Regexp
+
+          # Compact format regex for Version 3 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 3 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}3[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #:Regexp
+        end
+
+        # Version 4 UUID validation patterns
+        #
+        # Provides regular expressions for validating randomly generated Version 4
+        # UUIDs. These are the most commonly used UUID format.
+        #
+        # @since 0.1.0
+        module V4
+          # Standard format regex for Version 4 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 4 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #:Regexp
+
+          # Compact format regex for Version 4 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 4 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}4[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #:Regexp
+        end
+
+        # Version 5 UUID validation patterns
+        #
+        # Provides regular expressions for validating name-based Version 5 UUIDs
+        # using SHA-1 hashing.
+        #
+        # @since 0.1.0
+        module V5
+          # Standard format regex for Version 5 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 5 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-5[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #:Regexp
+
+          # Compact format regex for Version 5 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 5 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}5[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #:Regexp
+        end
+
+        # Version 6 UUID validation patterns
+        #
+        # Provides regular expressions for validating ordered-time Version 6 UUIDs.
+        # These UUIDs are similar to Version 1 but with improved timestamp ordering.
+        #
+        # @since 0.1.0
+        module V6
+          # Standard format regex for Version 6 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 6 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-6[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #:Regexp
+
+          # Compact format regex for Version 6 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 6 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}6[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #:Regexp
+        end
+
+        # Version 7 UUID validation patterns
+        #
+        # Provides regular expressions for validating Unix Epoch time-based Version 7
+        # UUIDs. These UUIDs use millisecond precision timestamps.
+        #
+        # @since 0.1.0
+        module V7
+          # Standard format regex for Version 7 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 7 UUIDs
+          STANDARD_REGEXP = /\A[a-f0-9]{8}-[a-f0-9]{4}-7[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\z/ #:Regexp
+
+          # Compact format regex for Version 7 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 7 UUIDs
+          COMPACT_REGEXP = /\A[a-f0-9]{8}[a-f0-9]{4}7[a-f0-9]{3}[89ab][a-f0-9]{3}[a-f0-9]{12}\z/ #:Regexp
+        end
+      end
+
+      # Core UUID constraints based on RFC 4122
+      intrinsically_constrain :self, :type, String, description: :not_described
+
+      # The base UUID type should accept either standard or compact format
+      intrinsically_constrain :self, :match_pattern,
+                              Regexp.union(UUID::STANDARD_REGEXP, UUID::COMPACT_REGEXP),
+                              description: 'matching UUID format', concerning: :format
+
+      # Length constraint is handled by the format-specific methods
+      intrinsically_constrain :length, :range,
+                              { minimum: 32, maximum: 36 },
+                              description: 'having valid length', concerning: :size
+
+      # Constrain UUID to compact format
+      #
+      # Creates a constraint ensuring the UUID is in compact format (32 characters,
+      # no hyphens). Useful when working with systems that prefer compact UUIDs.
+      #
+      # @example
+      #   type.being_compact
+      #   type.validate("123e4567e89b12d3a456426614174000")  # => true
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => false
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_compact
+        constrain :length, :range, { minimum: 32, maximum: 32 },
+                  concerning: :size, description: 'having compact format length'
+        constrain :self, :match_pattern, UUID::COMPACT_REGEXP,
+                  description: 'matching compact UUID format',
+                  concerning: :format
+      end
+      alias compact being_compact
+
+      # Constrain UUID to standard format
+      #
+      # Creates a constraint ensuring the UUID is in standard format (36 characters,
+      # with hyphens). This is the default format per RFC 4122.
+      #
+      # @example
+      #   type.being_standard
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => true
+      #   type.validate("123e4567e89b12d3a456426614174000")      # => false
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_standard
+        constrain :length, :range, { minimum: 36, maximum: 36 },
+                  concerning: :size, description: 'having standard format length'
+        constrain :self, :match_pattern, UUID::STANDARD_REGEXP,
+                  description: 'matching standard UUID format',
+                  concerning: :format
+      end
+      alias standard being_standard
+
+      # Constrain UUID to specific version
+      #
+      # Creates a constraint ensuring the UUID matches a specific version (1-7) in
+      # either standard or compact format.
+      #
+      # @example
+      #   type.being_version(4)
+      #   type.validate("123e4567-e89b-42d3-a456-426614174000")  # => true
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => false
+      #
+      # @param version [Integer] UUID version (1-7)
+      # @param format [Symbol] :standard or :compact
+      # @return [self] self for method chaining
+      # @raise [ArgumentError] if format is neither :standard nor :compact
+      # @rbs (Integer version, ?format: :compact | :standard) -> self
+      def being_version(version, format: :standard)
+        case format
+        when :compact
+          constrain :length, :range, { minimum: 32, maximum: 32 },
+                    concerning: :size, description: 'having length'
+        when :standard
+          constrain :length, :range, { minimum: 36, maximum: 36 },
+                    concerning: :size, description: 'having length'
+        else
+          raise ArgumentError, "Invalid format: #{format}. Must be :compact or :standard"
+        end
+
+        constrain :self, :match_pattern, UUID.const_get("V#{version}::#{format.upcase}_REGEXP"),
+                  concerning: :version
+      end
+
+      # Constrain UUID to Version 5 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 5 UUID in compact format.
+      # Version 5 UUIDs are name-based using SHA-1 hashing.
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_five_compact
+        being_version(5, format: :compact)
+      end
+      alias being_v5_compact being_version_five_compact
+      alias v5_compact being_version_five_compact
+
+      # Constrain UUID to Version 5 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 5 UUID in standard format.
+      # Version 5 UUIDs are name-based using SHA-1 hashing.
+      #
+      # @example
+      #   type.being_v5
+      #   type.validate("123e4567-e89b-52d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_five_standard
+        being_version(5)
+      end
+      alias being_v5 being_version_five_standard
+      alias being_v5_standard being_version_five_standard
+      alias being_version_five being_version_five_standard
+      alias v5 being_version_five_standard
+
+      # Constrain UUID to Version 4 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 4 UUID in compact format.
+      # Version 4 UUIDs are randomly generated and are the most commonly used format.
+      #
+      # @example
+      #   type.being_v4_compact
+      #   type.validate("123e4567e89b42d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_four_compact
+        being_version(4, format: :compact)
+      end
+      alias being_v4_compact being_version_four_compact
+      alias v4_compact being_version_four_compact
+
+      # Constrain UUID to Version 4 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 4 UUID in standard format.
+      # Version 4 UUIDs are randomly generated and are the most commonly used format.
+      #
+      # @example
+      #   type.being_v4
+      #   type.validate("123e4567-e89b-42d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_four_standard
+        being_version(4)
+      end
+      alias being_v4 being_version_four_standard
+      alias being_v4_standard being_version_four_standard
+      alias being_version_four being_version_four_standard
+      alias v4 being_version_four_standard
+
+      # Constrain UUID to Version 1 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 1 UUID in compact format.
+      # Version 1 UUIDs are time-based using a timestamp and node ID.
+      #
+      # @example
+      #   type.being_v1_compact
+      #   type.validate("123e4567e89b12d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_one_compact
+        being_version(1, format: :compact)
+      end
+      alias being_v1_compact being_version_one_compact
+      alias v1_compact being_version_one_compact
+
+      # Constrain UUID to Version 1 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 1 UUID in standard format.
+      # Version 1 UUIDs are time-based using a timestamp and node ID.
+      #
+      # @example
+      #   type.being_v1
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_one_standard
+        being_version(1)
+      end
+      alias being_v1 being_version_one_standard
+      alias being_v1_standard being_version_one_standard
+      alias being_version_one being_version_one_standard
+      alias v1 being_version_one_standard
+
+      # Constrain UUID to Version 7 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 7 UUID in compact format.
+      # Version 7 UUIDs use Unix Epoch timestamps with millisecond precision.
+      #
+      # @example
+      #   type.being_v7_compact
+      #   type.validate("123e4567e89b72d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_seven_compact
+        being_version(7, format: :compact)
+      end
+      alias being_v7_compact being_version_seven_compact
+      alias v7_compact being_version_seven_compact
+
+      # Constrain UUID to Version 7 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 7 UUID in standard format.
+      # Version 7 UUIDs use Unix Epoch timestamps with millisecond precision.
+      #
+      # @example
+      #   type.being_v7
+      #   type.validate("123e4567-e89b-72d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_seven_standard
+        being_version(7)
+      end
+      alias being_v7 being_version_seven_standard
+      alias being_v7_standard being_version_seven_standard
+      alias being_version_seven being_version_seven_standard
+      alias v7 being_version_seven_standard
+
+      # Constrain UUID to Version 6 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 6 UUID in compact format.
+      # Version 6 UUIDs are similar to Version 1 but with improved timestamp ordering.
+      #
+      # @example
+      #   type.being_v6_compact
+      #   type.validate("123e4567e89b62d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_six_compact
+        being_version(6, format: :compact)
+      end
+      alias being_v6_compact being_version_six_compact
+      alias v6_compact being_version_six_compact
+
+      # Constrain UUID to Version 6 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 6 UUID in standard format.
+      # Version 6 UUIDs are similar to Version 1 but with improved timestamp ordering.
+      #
+      # @example
+      #   type.being_v6
+      #   type.validate("123e4567-e89b-62d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_six_standard
+        being_version(6)
+      end
+      alias being_v6 being_version_six_standard
+      alias being_v6_standard being_version_six_standard
+      alias being_version_six being_version_six_standard
+      alias v6 being_version_six_standard
+
+      # Constrain UUID to Version 3 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 3 UUID in compact format.
+      # Version 3 UUIDs are name-based using MD5 hashing.
+      #
+      # @example
+      #   type.being_v3_compact
+      #   type.validate("123e4567e89b32d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_three_compact
+        being_version(3, format: :compact)
+      end
+      alias being_v3_compact being_version_three_compact
+      alias v3_compact being_version_three_compact
+
+      # Constrain UUID to Version 3 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 3 UUID in standard format.
+      # Version 3 UUIDs are name-based using MD5 hashing.
+      #
+      # @example
+      #   type.being_v3
+      #   type.validate("123e4567-e89b-32d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_three_standard
+        being_version(3)
+      end
+      alias being_v3 being_version_three_standard
+      alias being_v3_standard being_version_three_standard
+      alias being_version_three being_version_three_standard
+      alias v3 being_version_three_standard
+
+      # Constrain UUID to Version 2 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 2 UUID in compact format.
+      # Version 2 UUIDs are DCE Security version that incorporate local domain identifiers.
+      #
+      # @example
+      #   type.being_v2_compact
+      #   type.validate("123e4567e89b22d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_two_compact
+        being_version(2, format: :compact)
+      end
+      alias being_v2_compact being_version_two_compact
+      alias v2_compact being_version_two_compact
+
+      # Constrain UUID to Version 2 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 2 UUID in standard format.
+      # Version 2 UUIDs are DCE Security version that incorporate local domain identifiers.
+      #
+      # @example
+      #   type.being_v2
+      #   type.validate("123e4567-e89b-22d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      # @rbs () -> self
+      def being_version_two_standard
+        being_version(2)
+      end
+      alias being_v2 being_version_two_standard
+      alias being_v2_standard being_version_two_standard
+      alias being_version_two being_version_two_standard
+      alias v2 being_version_two_standard
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/definitions.rbs
+++ b/domainic-type/sig/domainic/type/definitions.rbs
@@ -86,6 +86,31 @@ module Domainic
 
       alias _Bool? _Boolean?
 
+      # Creates a CUIDType instance
+      #
+      # @example
+      #   type = _CUID.v2
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::CUIDType] the created type
+      def _CUID: (**__todo__ options) -> CUIDType
+
+      alias _Cuid _CUID
+
+      # Creates a nilable CUIDType instance.
+      #
+      # @example
+      #   _CUID? === "la6m1dv00000gv25zp9ru12g" # => true
+      #   _CUID? === nil                        # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (CUIDType or NilClass)
+      def _CUID?: (**__todo__ options) -> UnionType
+
+      alias _Cuid? _CUID?
+
       # Creates a DuckType instance.
       #
       # DuckType allows specifying behavior based on method availability.
@@ -234,6 +259,27 @@ module Domainic
       # @return [Domainic::Type::UnionType] the created type (Hostname or NilClass)
       def _Hostname?: (**__todo__ options) -> UnionType
 
+      # Creates a UnionType of IntegerType, UUIDType, and CUIDType
+      #
+      # @example
+      #   _ID === 1234567890                             # => true
+      #   _ID === '123e4567-e89b-42d3-a456-426614174000' # => true
+      #   _ID === 'la6m1dv00000gv25zp9ru12g'             # => true
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      def _ID: () -> UnionType
+
+      # Creates a nilable UnionType of IntegerType, UUIDType, and CUIDType
+      #
+      # @example
+      #   _ID === 1234567890                             # => true
+      #   _ID === '123e4567-e89b-42d3-a456-426614174000' # => true
+      #   _ID === 'la6m1dv00000gv25zp9ru12g'             # => true
+      #   _ID === nil                                    # => true
+      #
+      # @return [Domainic::Type::UnionType] the created type
+      def _ID?: () -> UnionType
+
       # Create an InstanceType instance.
       #
       # @example
@@ -348,6 +394,31 @@ module Domainic
       def _Symbol?: (**__todo__ options) -> UnionType
 
       alias _Interned? _Symbol?
+
+      # Creates a UUIDType instance
+      #
+      # @example
+      #   type = _UUID.v4_compact
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UUIDType] the created type
+      def _UUID: (**__todo__ options) -> UUIDType
+
+      alias _Uuid _UUID
+
+      # Creates a nilable UUIDType instance.
+      #
+      # @example
+      #   _UUID? === '123e4567-e89b-42d3-a456-426614174000' # => true
+      #   _UUID? === nil                                    # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (UUIDType or NilClass)
+      def _UUID?: (**__todo__ options) -> UnionType
+
+      alias _Uuid? _UUID?
 
       # Creates a UnionType instance.
       #

--- a/domainic-type/sig/domainic/type/types/identifier/cuid_type.rbs
+++ b/domainic-type/sig/domainic/type/types/identifier/cuid_type.rbs
@@ -1,0 +1,110 @@
+module Domainic
+  module Type
+    # A type for validating CUIDs according to official specifications
+    #
+    # This type provides comprehensive CUID validation following the official
+    # CUID specifications. It supports both v1 and v2 formats, with proper
+    # format-specific validation.
+    #
+    # Key features:
+    # - CUID v1 validation (25 characters, c-prefix)
+    # - CUID v2 validation (variable length 14-24 chars)
+    # - Length validation
+    # - Character set validation
+    #
+    # @example Basic usage
+    #   type = CUIDType.new
+    #   type.validate("ch72gsb320000udocl363eofy")  # => true
+    #   type.validate("invalid")                     # => false
+    #
+    # @example With version constraints
+    #   type = CUIDType.new.being_version(2)
+    #   type.validate("clh3am1f30000udocbhqg4151")  # => true
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class CUIDType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      # Contains CUID validation regular expressions and version-specific modules
+      #
+      # This module provides validation patterns for both CUID v1 and v2 formats,
+      # following the official specification.
+      #
+      # @since 0.1.0
+      module CUID
+        # Regular expression for CUID v1 format
+        #
+        # Validates CUIDs in v1 format: c-prefix + 24 lowercase alphanumeric chars
+        # Example: "ch72gsb320000udocl363eofy"
+        #
+        # @since 0.1.0
+        V1_REGEXP: Regexp
+
+        # Regular expression for CUID v2 format
+        #
+        # Validates CUIDs in v2 format: k-p prefix + 13-23 lowercase alphanumeric chars
+        # Example: "clh3am1f30000udocbhqg4151"
+        #
+        # @since 0.1.0
+        V2_REGEXP: Regexp
+
+        # Regular expression for any valid CUID (v1 or v2)
+        ALL_REGEXP: Regexp
+      end
+
+      # Constrain CUID to specific version
+      #
+      # Creates a constraint ensuring the CUID matches a specific version (1 or 2).
+      #
+      # @example
+      #   type.being_version(1)
+      #   type.validate("ch72gsb320000udocl363eofy")  # => true
+      #
+      # @param version [Integer] CUID version (1 or 2)
+      # @return [self] self for method chaining
+      # @raise [ArgumentError] if version is neither 1 nor 2
+      def being_version: (Integer version) -> self
+
+      alias version being_version
+
+      # Constrain CUID to Version 1
+      #
+      # Creates a constraint ensuring the CUID is a Version 1 CUID.
+      # Version 1 CUIDs are 25 characters long and start with 'c'.
+      #
+      # @example
+      #   type.being_version_one
+      #   type.validate("ch72gsb320000udocl363eofy")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_one: () -> self
+
+      alias being_v1 being_version_one
+
+      alias v1 being_version_one
+
+      alias version_one being_version_one
+
+      # Constrain CUID to Version 2
+      #
+      # Creates a constraint ensuring the CUID is a Version 2 CUID.
+      # Version 2 CUIDs are 14-24 characters and start with k-p.
+      #
+      # @example
+      #   type.being_version_two
+      #   type.validate("clh3am1f30000udocbhqg4151")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_two: () -> self
+
+      alias being_v2 being_version_two
+
+      alias v2 being_version_two
+
+      alias version_two being_version_two
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/types/identifier/uuid_type.rbs
+++ b/domainic-type/sig/domainic/type/types/identifier/uuid_type.rbs
@@ -1,0 +1,469 @@
+module Domainic
+  # NOTE: This file is located at lib/domainic/type/types/identifier/uuid_type.rb
+  module Type
+    # A type for validating UUIDs according to RFC 4122 standards
+    #
+    # This type provides comprehensive UUID validation following RFC 4122 standards.
+    # It supports both standard (hyphenated) and compact formats for all UUID versions
+    # (1 through 7), while enforcing proper formatting and version-specific constraints.
+    #
+    # Key features:
+    # - RFC 4122 compliant UUID format validation
+    # - Support for versions 1-7
+    # - Standard (hyphenated) and compact format support
+    # - Length validation (36 chars for standard, 32 for compact)
+    # - Version-specific validation
+    #
+    # @example Basic usage
+    #   type = UUIDType.new
+    #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => true
+    #   type.validate("invalid")                                # => false
+    #
+    # @example With version constraints
+    #   type = UUIDType.new.being_version(4)
+    #   type.validate("123e4567-e89b-42d3-a456-426614174000")  # => true
+    #
+    # @example With format constraints
+    #   type = UUIDType.new.being_compact
+    #   type.validate("123e4567e89b12d3a456426614174000")      # => true
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class UUIDType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      # Contains UUID validation regular expressions and version-specific modules
+      #
+      # This module provides both standard (hyphenated) and compact format regular
+      # expressions for UUID validation, along with version-specific submodules for
+      # more granular validation requirements.
+      #
+      # @since 0.1.0
+      module UUID
+        # Regular expression for standard (hyphenated) UUID format
+        #
+        # Validates UUIDs in the format: 8-4-4-4-12 hexadecimal digits with hyphens
+        # Example: "123e4567-e89b-12d3-a456-426614174000"
+        #
+        # @since 0.1.0
+        STANDARD_REGEXP: Regexp
+
+        # Regular expression for compact (non-hyphenated) UUID format
+        #
+        # Validates UUIDs in the format: 32 continuous hexadecimal digits
+        # Example: "123e4567e89b12d3a456426614174000"
+        #
+        # @since 0.1.0
+        COMPACT_REGEXP: Regexp
+
+        # Version 1 UUID validation patterns
+        #
+        # Provides regular expressions for validating time-based Version 1 UUIDs.
+        # These UUIDs are generated using a timestamp and node ID.
+        #
+        # @since 0.1.0
+        module V1
+          # Standard format regex for Version 1 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 1 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 1 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 1 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+
+        # Version 2 UUID validation patterns
+        #
+        # Provides regular expressions for validating DCE Security Version 2 UUIDs.
+        # These UUIDs incorporate local domain identifiers.
+        #
+        # @since 0.1.0
+        module V2
+          # Standard format regex for Version 2 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 2 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 2 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 2 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+
+        # Version 3 UUID validation patterns
+        #
+        # Provides regular expressions for validating name-based Version 3 UUIDs
+        # using MD5 hashing.
+        #
+        # @since 0.1.0
+        module V3
+          # Standard format regex for Version 3 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 3 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 3 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 3 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+
+        # Version 4 UUID validation patterns
+        #
+        # Provides regular expressions for validating randomly generated Version 4
+        # UUIDs. These are the most commonly used UUID format.
+        #
+        # @since 0.1.0
+        module V4
+          # Standard format regex for Version 4 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 4 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 4 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 4 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+
+        # Version 5 UUID validation patterns
+        #
+        # Provides regular expressions for validating name-based Version 5 UUIDs
+        # using SHA-1 hashing.
+        #
+        # @since 0.1.0
+        module V5
+          # Standard format regex for Version 5 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 5 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 5 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 5 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+
+        # Version 6 UUID validation patterns
+        #
+        # Provides regular expressions for validating ordered-time Version 6 UUIDs.
+        # These UUIDs are similar to Version 1 but with improved timestamp ordering.
+        #
+        # @since 0.1.0
+        module V6
+          # Standard format regex for Version 6 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 6 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 6 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 6 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+
+        # Version 7 UUID validation patterns
+        #
+        # Provides regular expressions for validating Unix Epoch time-based Version 7
+        # UUIDs. These UUIDs use millisecond precision timestamps.
+        #
+        # @since 0.1.0
+        module V7
+          # Standard format regex for Version 7 UUIDs
+          # @return [Regexp] Pattern matching hyphenated Version 7 UUIDs
+          STANDARD_REGEXP: Regexp
+
+          # Compact format regex for Version 7 UUIDs
+          # @return [Regexp] Pattern matching non-hyphenated Version 7 UUIDs
+          COMPACT_REGEXP: Regexp
+        end
+      end
+
+      # Constrain UUID to compact format
+      #
+      # Creates a constraint ensuring the UUID is in compact format (32 characters,
+      # no hyphens). Useful when working with systems that prefer compact UUIDs.
+      #
+      # @example
+      #   type.being_compact
+      #   type.validate("123e4567e89b12d3a456426614174000")  # => true
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => false
+      #
+      # @return [self] self for method chaining
+      def being_compact: () -> self
+
+      alias compact being_compact
+
+      # Constrain UUID to standard format
+      #
+      # Creates a constraint ensuring the UUID is in standard format (36 characters,
+      # with hyphens). This is the default format per RFC 4122.
+      #
+      # @example
+      #   type.being_standard
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => true
+      #   type.validate("123e4567e89b12d3a456426614174000")      # => false
+      #
+      # @return [self] self for method chaining
+      def being_standard: () -> self
+
+      alias standard being_standard
+
+      # Constrain UUID to specific version
+      #
+      # Creates a constraint ensuring the UUID matches a specific version (1-7) in
+      # either standard or compact format.
+      #
+      # @example
+      #   type.being_version(4)
+      #   type.validate("123e4567-e89b-42d3-a456-426614174000")  # => true
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => false
+      #
+      # @param version [Integer] UUID version (1-7)
+      # @param format [Symbol] :standard or :compact
+      # @return [self] self for method chaining
+      # @raise [ArgumentError] if format is neither :standard nor :compact
+      def being_version: (Integer version, ?format: :compact | :standard) -> self
+
+      # Constrain UUID to Version 5 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 5 UUID in compact format.
+      # Version 5 UUIDs are name-based using SHA-1 hashing.
+      #
+      # @return [self] self for method chaining
+      def being_version_five_compact: () -> self
+
+      alias being_v5_compact being_version_five_compact
+
+      alias v5_compact being_version_five_compact
+
+      # Constrain UUID to Version 5 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 5 UUID in standard format.
+      # Version 5 UUIDs are name-based using SHA-1 hashing.
+      #
+      # @example
+      #   type.being_v5
+      #   type.validate("123e4567-e89b-52d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_five_standard: () -> self
+
+      alias being_v5 being_version_five_standard
+
+      alias being_v5_standard being_version_five_standard
+
+      alias being_version_five being_version_five_standard
+
+      alias v5 being_version_five_standard
+
+      # Constrain UUID to Version 4 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 4 UUID in compact format.
+      # Version 4 UUIDs are randomly generated and are the most commonly used format.
+      #
+      # @example
+      #   type.being_v4_compact
+      #   type.validate("123e4567e89b42d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_four_compact: () -> self
+
+      alias being_v4_compact being_version_four_compact
+
+      alias v4_compact being_version_four_compact
+
+      # Constrain UUID to Version 4 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 4 UUID in standard format.
+      # Version 4 UUIDs are randomly generated and are the most commonly used format.
+      #
+      # @example
+      #   type.being_v4
+      #   type.validate("123e4567-e89b-42d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_four_standard: () -> self
+
+      alias being_v4 being_version_four_standard
+
+      alias being_v4_standard being_version_four_standard
+
+      alias being_version_four being_version_four_standard
+
+      alias v4 being_version_four_standard
+
+      # Constrain UUID to Version 1 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 1 UUID in compact format.
+      # Version 1 UUIDs are time-based using a timestamp and node ID.
+      #
+      # @example
+      #   type.being_v1_compact
+      #   type.validate("123e4567e89b12d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_one_compact: () -> self
+
+      alias being_v1_compact being_version_one_compact
+
+      alias v1_compact being_version_one_compact
+
+      # Constrain UUID to Version 1 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 1 UUID in standard format.
+      # Version 1 UUIDs are time-based using a timestamp and node ID.
+      #
+      # @example
+      #   type.being_v1
+      #   type.validate("123e4567-e89b-12d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_one_standard: () -> self
+
+      alias being_v1 being_version_one_standard
+
+      alias being_v1_standard being_version_one_standard
+
+      alias being_version_one being_version_one_standard
+
+      alias v1 being_version_one_standard
+
+      # Constrain UUID to Version 7 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 7 UUID in compact format.
+      # Version 7 UUIDs use Unix Epoch timestamps with millisecond precision.
+      #
+      # @example
+      #   type.being_v7_compact
+      #   type.validate("123e4567e89b72d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_seven_compact: () -> self
+
+      alias being_v7_compact being_version_seven_compact
+
+      alias v7_compact being_version_seven_compact
+
+      # Constrain UUID to Version 7 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 7 UUID in standard format.
+      # Version 7 UUIDs use Unix Epoch timestamps with millisecond precision.
+      #
+      # @example
+      #   type.being_v7
+      #   type.validate("123e4567-e89b-72d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_seven_standard: () -> self
+
+      alias being_v7 being_version_seven_standard
+
+      alias being_v7_standard being_version_seven_standard
+
+      alias being_version_seven being_version_seven_standard
+
+      alias v7 being_version_seven_standard
+
+      # Constrain UUID to Version 6 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 6 UUID in compact format.
+      # Version 6 UUIDs are similar to Version 1 but with improved timestamp ordering.
+      #
+      # @example
+      #   type.being_v6_compact
+      #   type.validate("123e4567e89b62d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_six_compact: () -> self
+
+      alias being_v6_compact being_version_six_compact
+
+      alias v6_compact being_version_six_compact
+
+      # Constrain UUID to Version 6 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 6 UUID in standard format.
+      # Version 6 UUIDs are similar to Version 1 but with improved timestamp ordering.
+      #
+      # @example
+      #   type.being_v6
+      #   type.validate("123e4567-e89b-62d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_six_standard: () -> self
+
+      alias being_v6 being_version_six_standard
+
+      alias being_v6_standard being_version_six_standard
+
+      alias being_version_six being_version_six_standard
+
+      alias v6 being_version_six_standard
+
+      # Constrain UUID to Version 3 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 3 UUID in compact format.
+      # Version 3 UUIDs are name-based using MD5 hashing.
+      #
+      # @example
+      #   type.being_v3_compact
+      #   type.validate("123e4567e89b32d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_three_compact: () -> self
+
+      alias being_v3_compact being_version_three_compact
+
+      alias v3_compact being_version_three_compact
+
+      # Constrain UUID to Version 3 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 3 UUID in standard format.
+      # Version 3 UUIDs are name-based using MD5 hashing.
+      #
+      # @example
+      #   type.being_v3
+      #   type.validate("123e4567-e89b-32d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_three_standard: () -> self
+
+      alias being_v3 being_version_three_standard
+
+      alias being_v3_standard being_version_three_standard
+
+      alias being_version_three being_version_three_standard
+
+      alias v3 being_version_three_standard
+
+      # Constrain UUID to Version 2 compact format
+      #
+      # Creates a constraint ensuring the UUID is a Version 2 UUID in compact format.
+      # Version 2 UUIDs are DCE Security version that incorporate local domain identifiers.
+      #
+      # @example
+      #   type.being_v2_compact
+      #   type.validate("123e4567e89b22d3a456426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_two_compact: () -> self
+
+      alias being_v2_compact being_version_two_compact
+
+      alias v2_compact being_version_two_compact
+
+      # Constrain UUID to Version 2 standard format
+      #
+      # Creates a constraint ensuring the UUID is a Version 2 UUID in standard format.
+      # Version 2 UUIDs are DCE Security version that incorporate local domain identifiers.
+      #
+      # @example
+      #   type.being_v2
+      #   type.validate("123e4567-e89b-22d3-a456-426614174000")  # => true
+      #
+      # @return [self] self for method chaining
+      def being_version_two_standard: () -> self
+
+      alias being_v2 being_version_two_standard
+
+      alias being_v2_standard being_version_two_standard
+
+      alias being_version_two being_version_two_standard
+
+      alias v2 being_version_two_standard
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/cuid_type_spec.rb
+++ b/domainic-type/spec/domainic/type/cuid_type_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/identifier/cuid_type'
+
+RSpec.describe Domainic::Type::CUIDType do
+  let(:type) { described_class.new }
+
+  describe '.validate' do
+    subject(:validate) { type.validate(cuid) }
+
+    context 'when validating a valid CUID v1' do
+      let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating a valid CUID v2' do
+      let(:cuid) { 'la6m1dv00000gv25zp9ru12g' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid CUID' do
+      let(:cuid) { 'not-a-cuid' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when validating a non-string' do
+      let(:cuid) { :symbol }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.validate!' do
+    subject(:validate!) { type.validate!(cuid) }
+
+    context 'when validating a valid CUID v1' do
+      let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating a valid CUID v2' do
+      let(:cuid) { 'la6m1dv00000gv25zp9ru12g' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid CUID' do
+      let(:cuid) { 'not-a-cuid' }
+
+      it { expect { validate! }.to raise_error(TypeError, /Expected CUID/) }
+    end
+  end
+
+  describe '#being_version_one' do
+    subject(:being_version_one) { type.being_version_one.validate(cuid) }
+
+    context 'when CUID is v1' do
+      let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when CUID is v2' do
+      let(:cuid) { 'la6m1dv00000gv25zp9ru12g' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when CUID is invalid' do
+      let(:cuid) { 'not-a-cuid' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_version_two' do
+    subject(:being_version_two) { type.being_version_two.validate(cuid) }
+
+    context 'when CUID is v2' do
+      let(:cuid) { 'la6m1dv00000gv25zp9ru12g' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when CUID is v1' do
+      let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when CUID is invalid' do
+      let(:cuid) { 'not-a-cuid' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_version' do
+    subject(:being_version) { type.being_version(version).validate(cuid) }
+
+    context 'with version 1' do
+      let(:version) { 1 }
+
+      context 'when CUID is v1' do
+        let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when CUID is v2' do
+        let(:cuid) { 'la6m1dv00000gv25zp9ru12g' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with version 2' do
+      let(:version) { 2 }
+
+      context 'when CUID is v2' do
+        let(:cuid) { 'la6m1dv00000gv25zp9ru12g' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when CUID is v1' do
+        let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with invalid version' do
+      let(:version) { 3 }
+      let(:cuid) { 'ch72gsb320000udocl363eofy' }
+
+      it 'raises ArgumentError' do
+        expect { being_version }.to raise_error(ArgumentError, /Invalid version/)
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/definitions_spec.rb
+++ b/domainic-type/spec/domainic/type/definitions_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe Domainic::Type::Definitions do
     end
   end
 
+  describe '._CUID' do
+    subject(:cuid_type) { definitions._CUID }
+
+    it 'is expected to return an CUIDType' do
+      expect(cuid_type).to be_a(Domainic::Type::CUIDType)
+    end
+  end
+
   describe '._Duck' do
     subject(:duck_type) { definitions._Duck }
 
@@ -100,6 +108,14 @@ RSpec.describe Domainic::Type::Definitions do
     end
   end
 
+  describe '._ID' do
+    subject(:id_type) { definitions._ID }
+
+    it 'is expected to return an UnionType' do
+      expect(id_type).to be_a(Domainic::Type::UnionType)
+    end
+  end
+
   describe '._Instance' do
     subject(:instance_type) { definitions._Instance }
 
@@ -121,6 +137,14 @@ RSpec.describe Domainic::Type::Definitions do
 
     it 'is expected to validate values of the specified type' do
       expect(nilable_type.validate('test')).to be true
+    end
+  end
+
+  describe '._UUID' do
+    subject(:uuid_type) { definitions._UUID }
+
+    it 'is expected to return an UUIDType' do
+      expect(uuid_type).to be_a(Domainic::Type::UUIDType)
     end
   end
 

--- a/domainic-type/spec/domainic/type/uuid_type_spec.rb
+++ b/domainic-type/spec/domainic/type/uuid_type_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/identifier/uuid_type'
+
+RSpec.describe Domainic::Type::UUIDType do
+  let(:type) { described_class.new }
+
+  describe '.validate' do
+    subject(:validate) { type.validate(uuid) }
+
+    context 'when validating a valid UUID' do
+      let(:uuid) { '123e4567-e89b-12d3-a456-426614174000' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid UUID' do
+      let(:uuid) { 'not-a-uuid' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when validating a non-string' do
+      let(:uuid) { :symbol }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.validate!' do
+    subject(:validate!) { type.validate!(uuid) }
+
+    context 'when validating a valid UUID' do
+      let(:uuid) { '123e4567-e89b-12d3-a456-426614174000' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid UUID' do
+      let(:uuid) { 'not-a-uuid' }
+
+      it { expect { validate! }.to raise_error(TypeError, /Expected UUID/) }
+    end
+  end
+
+  describe '#being_compact' do
+    subject(:being_compact) { type.being_compact.validate(uuid) }
+
+    context 'when UUID is in compact format' do
+      let(:uuid) { '123e4567e89b12d3a456426614174000' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when UUID is in standard format' do
+      let(:uuid) { '123e4567-e89b-12d3-a456-426614174000' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_standard' do
+    subject(:being_standard) { type.being_standard.validate(uuid) }
+
+    context 'when UUID is in standard format' do
+      let(:uuid) { '123e4567-e89b-12d3-a456-426614174000' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when UUID is in compact format' do
+      let(:uuid) { '123e4567e89b12d3a456426614174000' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_version' do
+    subject(:being_version) { type.being_version(version, format: format).validate(uuid) }
+
+    context 'with standard format' do
+      let(:format) { :standard }
+
+      context 'when UUID matches version' do
+        let(:version) { 4 }
+        let(:uuid) { '123e4567-e89b-42d3-a456-426614174000' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when UUID does not match version' do
+        let(:version) { 4 }
+        let(:uuid) { '123e4567-e89b-12d3-a456-426614174000' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with compact format' do
+      let(:format) { :compact }
+
+      context 'when UUID matches version' do
+        let(:version) { 4 }
+        let(:uuid) { '123e4567e89b42d3a456426614174000' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when UUID does not match version' do
+        let(:version) { 4 }
+        let(:uuid) { '123e4567e89b12d3a456426614174000' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with invalid format', rbs: :skip do
+      let(:version) { 4 }
+      let(:format) { :invalid }
+      let(:uuid) { '123e4567-e89b-42d3-a456-426614174000' }
+
+      it 'raises ArgumentError' do
+        expect { being_version }.to raise_error(ArgumentError, /Invalid format/)
+      end
+    end
+  end
+
+  describe 'RFC compliance' do
+    context 'when UUID has incorrect version number' do
+      subject(:validation) { type.validate('123e4567-e89b-82d3-a456-426614174000') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when UUID has incorrect variant' do
+      subject(:validation) { type.validate('123e4567-e89b-42d3-c456-426614174000') }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Description

This introduces comprehensive identifier type validation for UUIDs and CUIDs, along with helper methods in `Domainic::Type::Definitions`. The implementation follows RFC 4122 for UUIDs and the official CUID spec, providing robust validation for both standard and specialized formats.

## Changes Made

* Added `UUIDType` with support for:
  - RFC 4122 compliant validation
  - All UUID versions (1-7)
  - Both standard and compact formats
  - Version-specific constraints

* Added `CUIDType` with support for:
  - CUID v1 (25 chars, c-prefix)
  - CUID v2 (14-24 chars, k-p prefix)
  - Version-specific validation

* Added Definition helpers:
  - `_UUID` and `_UUID?` for UUID validation
  - `_CUID` and `_CUID?` for CUID validation
  - `_ID` and `_ID?` for unified identifier validation (Integer|UUID|CUID)
  - Appropriate RBS definitions and documentation

## Checklist

* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed

## Additional Notes

The `_ID` helper was added to provide a convenient way to validate common Ruby identifier types in a single constraint. This is particularly useful for APIs and database interfaces that need to handle multiple ID formats.