### PR TITLE
Release domainic-type v0.1.0-alpha.3.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       domainic-attributer (~> 0.1)
       domainic-type (~> 0.1.0.alpha.3)
     domainic-attributer (0.2.0)
-    domainic-type (0.1.0.alpha.3.0.2)
+    domainic-type (0.1.0.alpha.3.1.0)
 
 PATH
   remote: domainic-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ documentation across the Domainic ecosystem.
 ### Experimental
 
 * [**domainic-type**](../domainic-type/) - Flexible type validation system
-  * **Current Version**: 0.1.0-alpha.3.0.2
+  * **Current Version**: 0.1.0-alpha.3.1.0
   * [Experiment Details](./experiments/domainic-type-alpha-3/)
   * [Testing & Feedback](./experiments/domainic-type-alpha-3/README.md)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,8 +65,8 @@ If you have suggestions on how this process could be improved, please submit a p
 
 |        Version        | Support |
 |:---------------------:|:-------:|
-|  `0.1.0-alpha.3.0.2`  |   🧪    |
-| `> 0.1.0-alpha.3.0.2` |    ❌   |
+|  `0.1.0-alpha.3.1.0`  |   🧪    |
+| `> 0.1.0-alpha.3.1.0` |    ❌   |
 
 ### Key
 

--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Unreleased]
 
+### [0.1.0-alpha.3.1.0] - 2024-12-25
+
 #### Added
 
 * [#148](https://github.com/domainic/domainic/pull/148) added `Domainic::Type::Behavior.intrinsically_constrain` to
@@ -40,7 +42,8 @@
 > As this is an experimental release, features may change significantly based on feedback. Refer to
 > docs/experiments/domainic-type-v0.1.0-alpha.3/README.md for full details and current testing focus.
 
-[Unreleased]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.2...HEAD
+[Unreleased]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.1.0...HEAD
+[0.1.0-alpha.3.1.0]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.2...domainic-type-v0.1.0-alpha.3.1.0
 [0.1.0-alpha.3.0.2]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.1...domainic-type-v0.1.0-alpha.3.0.2
 [0.1.0-alpha.3.0.1]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.0.0...domainic-type-v0.1.0-alpha.3.0.1
 

--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### [Unreleased]
 
+#### Added
+
+* [#148](https://github.com/domainic/domainic/pull/148) added `Domainic::Type::Behavior.intrinsically_constrain` to
+  replace `Domainic::Type::Behavior.intrinsic`.
+* [#149](https://github.com/domainic/domainic/pull/149) added `Domainic::Type::EmailAddressType`,
+  `Domainic::Type::HostnameType`, and `Domainic::Type::URIType`.
+* [#150](https://github.com/domainic/domainic/pull/150) add `Domainic::Type::CUIDType` and `Domainic::Type::UUIDType`.
+
+#### Deprecated
+
+* [#148](https://github.com/domainic/domainic/pull/148) deprecated `Domainic::Type::Behavior.intrinsic` use
+  `Domainic::Type::Behavior.intrinsically_constrain` instead.
+
 ### [0.1.0-alpha.3.0.2] - 2024-12-25
 
 #### Added

--- a/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
+++ b/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
@@ -243,9 +243,9 @@ also known as `_List`, `_Array?`, `_List?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Array` type provides comprehensive validation for array values with constraints for content, ordering, and size.
@@ -324,9 +324,9 @@ also known as `_Email`, `_EmailAddress?`, `_Email?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_EmailAddress` type validates email addresses according to RFC 5321 and 5322 standards. It includes comprehensive
@@ -370,7 +370,7 @@ also known as `_Decimal`, `_Real`, `_Float?`, `_Decimal?`, `_Real?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Float` type validates floating-point numbers with comprehensive numeric constraints:
@@ -404,9 +404,9 @@ also known as `_Map`, `_Hash?`, `_Map?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb),
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb),
-> and [HashType](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/types/core/hash_type.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb),
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb),
+> and [HashType](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/types/core/hash_type.rb)
 > for the full list of available methods and aliases!
 
 The `_Hash` type provides validation for hash structures with constraints for keys, values, and overall composition:
@@ -442,9 +442,9 @@ also known as `_Hostname?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Hostname` type validates hostnames according to RFC 1034 and 1123 standards. It supports all string constraints in
@@ -503,7 +503,7 @@ also known as `_Int`, `_Integer?`, `_Int?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Integer` type validates integer values with comprehensive numeric constraints:
@@ -555,9 +555,9 @@ also known as `_Text`, `_String?`, `_Text?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_String` type validates string values with comprehensive text manipulation constraints:
@@ -594,9 +594,9 @@ also known as `_Interned`, `_Symbol?`, `_Interned?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Symbol` type validates symbols and supports all string-like constraints applied to the symbol's name:
@@ -669,9 +669,9 @@ also known as `_Url`, `_Uri?`, `_Url?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_URI` type validates URIs according to RFC 3986 standards. In addition to URI-specific validation, it supports all

--- a/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
+++ b/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
@@ -17,17 +17,21 @@ This document provides comprehensive examples of using Domainic::Type, from basi
   * [_Anything](#_anything)
   * [_Array](#_array)
   * [_Boolean](#_boolean)
+  * [_CUID](#_cuid)
   * [_Duck](#_duck)
+  * [_EmailAddress](#_emailaddress)
   * [_Enum](#_enum)
   * [_Float](#_float)
   * [_Hash](#_hash)
+  * [_Hostname](#_hostname)
+  * [_ID](#_id)
   * [_Instance](#_instance)
   * [_Integer](#_integer)
   * [_Nilable](#_nilable)
   * [_String](#_string)
-  * [_Symbol](#_symbol)
   * [_Union](#_union)
-  * [_Void](#_void)
+  * [_UUID](#_uuid)
+  * [_URI](#_uri)
 
 ## Basic Usage
 
@@ -283,6 +287,22 @@ _Boolean === 'true' # => false
 _Boolean? === nil # => true
 ```
 
+### _CUID
+
+also know as `_Cuid`, `_CUID?`, `_Cuid?`
+
+The `_CUID` type validates values against the CUID format, a collision-resistant alternative to UUIDs:
+
+```ruby
+_CUID === 'ckj9g7z9z0000b3z1z7z6z7z6' # => true
+_CUID === 'ckj9g7z9z0000b3z1z7z6z7z6z' # => false
+
+# Available Constraints
+_CUID.being_version(1_or_2) # Constrains the CUID to be version 1 or 2
+_CUID.being_version_one # Constrains the CUID to be version 1
+_CUID.being_version_two # Constrains the CUID to be version 2
+```
+
 ### _Duck
 
 also known as `_Interface`, `_Protocol`, `_RespondingTo`
@@ -295,6 +315,39 @@ object = Struct.new(:foo, :bar).new('foo', 'bar')
 _Duck.responding_to(:foo, :bar) === object # => true
 _Duck.responding_to(:foo) === object # => true
 _Duck.responding_to(:foo).not_responding_to(:bar) === object # => false
+```
+
+### _EmailAddress
+
+also known as `_Email`, `_EmailAddress?`, `_Email?`
+
+> [!TIP]
+> Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
+> Checkout the documentation for
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> and
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> for the full list of available methods and aliases!
+
+The `_EmailAddress` type validates email addresses according to RFC 5321 and 5322 standards. It includes comprehensive
+validation for all parts of an email address and supports all string constraints:
+
+```ruby
+_EmailAddress === 'user@example.com' # => true
+_EmailAddress === 'invalid@@email' # => false
+
+# Available Email-specific Constraints
+_EmailAddress.having_hostname('example.com') # Constrains to specific domain
+_EmailAddress.having_local_matching(/^[a-z]+$/) # Constrains local part format
+_EmailAddress.not_having_hostname('blocked.com') # Excludes specific domains
+_EmailAddress.not_having_local_matching(/^admin/) # Prevents specific local parts
+
+# Available String Constraints
+_EmailAddress.being_ascii # Enforces ASCII-only characters
+_EmailAddress.being_lowercase # Enforces lowercase format
+_EmailAddress.containing('specific.text') # Must contain substring
+_EmailAddress.having_maximum_size(255) # Max length constraint
+_EmailAddress.matching(/^[a-z]+@domain\.com$/) # Pattern matching
 ```
 
 ### _Enum
@@ -380,6 +433,50 @@ _Hash.having_size(size) # Constrains the hash to have a specific size
 _Hash.having_size_between(minimum, maximum) # Constrains the hash to have a size between the specified min and max
 _Hash.of(key_type => value_type) # Constrains the hash to contain only values of the specified type
 _Hash.starting_with(value) # Constrains the hash to start with the specified value
+```
+
+### _Hostname
+
+also known as `_Hostname?`
+
+> [!TIP]
+> Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
+> Checkout the documentation for
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> and
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> for the full list of available methods and aliases!
+
+The `_Hostname` type validates hostnames according to RFC 1034 and 1123 standards. It supports all string constraints in
+addition to hostname-specific validation:
+
+```ruby
+_Hostname === 'example.com' # => true
+_Hostname === 'invalid@hostname' # => false
+
+# Available Hostname-specific Constraints
+_Hostname.matching('example.com') # Constrains to exact hostname
+_Hostname.not_matching('blocked.com') # Excludes specific hostname
+
+# Available String Constraints
+_Hostname.being_ascii # Enforces ASCII-only characters
+_Hostname.being_lowercase # Enforces lowercase format
+_Hostname.having_size_between(1, 253) # Length constraints
+_Hostname.matching(/^[a-z0-9-]+\.[a-z]+$/) # Pattern matching
+_Hostname.not_matching(/^www\./) # Pattern exclusion
+```
+
+### _ID
+
+also known as `_ID?`
+
+The `_ID` type combines common identifier types into a single union, accepting integers, UUIDs, and CUIDs:
+
+```ruby
+_ID === 1234567890 # => true
+_ID === '123e4567-e89b-42d3-a456-426614174000' # => true
+_ID === 'clh3am1f30000udocbhqg4151' # => true
+_ID === 'not-an-id' # => false
 ```
 
 ### _Instance
@@ -519,6 +616,26 @@ _Symbol
   .having_maximum_size(63)
 ```
 
+### _UUID
+
+also known as `_Uuid`, `_UUID?`, `_Uuid?`
+
+The `_UUID` type validates UUIDs according to RFC 4122 standards, supporting all UUID versions and both standard and
+compact formats:
+
+```ruby
+_UUID === '123e4567-e89b-12d3-a456-426614174000' # => true
+_UUID === 'not-a-uuid' # => false
+
+# Available Constraints
+_UUID.being_compact # Constrains to compact format (no hyphens)
+_UUID.being_standard # Constrains to standard format (with hyphens)
+_UUID.being_version(4) # Constrains to specific UUID version
+_UUID.being_version_four # Constrains to version 4 (most common)
+_UUID.being_version_one # Constrains to version 1 (time-based)
+_UUID.being_version_seven # Constrains to version 7 (Unix Epoch time-based)
+```
+
 ### _Union
 
 also known as `_Either`
@@ -543,6 +660,40 @@ _Union(
   _Hash.of(_Symbol => _Integer),
   _Nilable(_Boolean)
 ) === { foo: 42 } # => true
+```
+
+### _Uri
+
+also known as `_Url`, `_Uri?`, `_Url?`
+
+> [!TIP]
+> Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
+> Checkout the documentation for
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> and
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.0.2/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> for the full list of available methods and aliases!
+
+The `_URI` type validates URIs according to RFC 3986 standards. In addition to URI-specific validation, it supports all
+string constraints:
+
+```ruby
+_URI === 'https://example.com' # => true
+_URI === 'not-a-url' # => false
+
+# Available URI-specific Constraints
+_URI.having_hostname('example.com') # Constrains to specific hostname
+_URI.having_path('/api/v1') # Constrains path component
+_URI.having_scheme('https') # Constrains to specific scheme
+_URI.not_having_hostname('blocked.com') # Excludes specific hostname
+_URI.not_having_path('/admin') # Excludes specific paths
+_URI.not_having_scheme('ftp') # Excludes specific schemes
+
+# Available String Constraints
+_URI.being_ascii # Enforces ASCII-only characters
+_URI.having_maximum_size(2000) # Common max URL length
+_URI.matching(/^https:\/\/api\./) # Pattern matching
+_URI.not_matching(/\s/) # No whitespace allowed
 ```
 
 ### _Void

--- a/docs/experiments/domainic-type-alpha-3/README.md
+++ b/docs/experiments/domainic-type-alpha-3/README.md
@@ -96,18 +96,26 @@ numbers.validate!(["1", 2, 3])  # Is the error helpful?
 
 Currently supported types:
 
-* `_String`
-* `_Integer`
-* `_Float`
-* `_Array`
-* `_Hash`
-* `_Symbol`
-* `_Boolean`
-* `_Union`
-* `_Enum`
-* `_Duck`
 * `_Anything`
+* `_Array`
+* `_Boolean`
+* `_CUID`
+* `_Duck`
+* `_EmailAddress`
+* `_Enum`
+* `_Float`
+* `_Hash`
+* `_Hostname`
+* `_ID`
+* `_Instance`
+* `_Integer`
 * `_Nilable`
+* `_String`
+* `_Symbol`
+* `_UUID`
+* `_Union`
+* `_Uri`
+* `_Void`
 
 Try them out! What types are missing? What would make existing types more useful?
 

--- a/domainic-type/domainic-type.gemspec
+++ b/domainic-type/domainic-type.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.0.2'
-DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.0.2'
+DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.1.0'
+DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.1.0'
 DOMAINIC_TYPE_REPO_URL = 'https://github.com/domainic/domainic'
 DOMAINIC_TYPE_HOME_URL = "#{DOMAINIC_TYPE_REPO_URL}/tree/domainic-type-v" \
                          "#{DOMAINIC_TYPE_SEMVER}/domainic-type".freeze

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -14,7 +14,7 @@ gems:
   source:
     type: rubygems
 - name: domainic-type
-  version: 0.1.0.alpha.3.0.2
+  version: 0.1.0.alpha.3.1.0
   source:
     type: rubygems
 - name: fileutils


### PR DESCRIPTION
This release continues our experiment with flexible type validation in Ruby! 
We're adding network and identifier types to help validate common data 
formats, while also improving API clarity by shifting toward more explicit 
method names.

### What's New

- Network types:
  - EmailAddress - RFC 5321/5322 compliant email validation
  - Hostname - RFC 1034/1123 compliant domain validation  
  - URI - RFC 3986 compliant URI/URL validation

- Identifier types:
  - CUID - Collision-resistant identifier validation
  - UUID - RFC 4122 UUID validation with version support
  - ID - Combined integer/UUID/CUID validation

### Breaking Changes

- Deprecated `Behavior.intrinsic` in favor of the more explicit `Behavior.intrinsically_constrain`

### Documentation

The full documentation has been updated at https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.1.0/docs/experiments/domainic-type-alpha-3/EXAMPLES.md

### Feedback Welcome!

Please try out these new types and let us know how they work for your use cases. Your feedback helps shape the future of domain-driven design in Ruby!