### PR TITLE
Rename _Uri to _URI for proper acronym casing

### DIFF
--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### [Unreleased]
 
+#### Fixed
+
+* [#153](https://github.com/domainic/domainic/pull/153) renamed `Domainic::Type::Behavior._Uri` to
+  `Domainic::Type::Behavior._URI` to follow standard naming conventions.
+
 ### [0.1.0-alpha.3.1.0] - 2024-12-25
 
 #### Added

--- a/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
+++ b/docs/experiments/domainic-type-alpha-3/EXAMPLES.md
@@ -289,7 +289,7 @@ _Boolean? === nil # => true
 
 ### _CUID
 
-also know as `_Cuid`, `_CUID?`, `_Cuid?`
+also known as `_Cuid`, `_CUID?`, `_Cuid?`
 
 The `_CUID` type validates values against the CUID format, a collision-resistant alternative to UUIDs:
 
@@ -662,9 +662,9 @@ _Union(
 ) === { foo: 42 } # => true
 ```
 
-### _Uri
+### _URI
 
-also known as `_Url`, `_Uri?`, `_Url?`
+also known as `_URL`, `_Uri`, `_Url`, `URI?`, `_URL?`, `_Uri?`, `_Url?`
 
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.

--- a/docs/experiments/domainic-type-alpha-3/README.md
+++ b/docs/experiments/domainic-type-alpha-3/README.md
@@ -58,7 +58,7 @@ config = _Hash
 
 This experiment focuses on three main areas:
 
-### 1. Error Message Composition 🎯
+### 1. Error Message Composition
 
 We're particularly interested in how error messages compose when using multiple constraints. Try these scenarios:
 

--- a/domainic-type/lib/domainic/type/definitions.rb
+++ b/domainic-type/lib/domainic/type/definitions.rb
@@ -475,6 +475,42 @@ module Domainic
       end
       alias _Interned? _Symbol?
 
+      # Creates a URIType instance.
+      #
+      # URIType restricts values to valid URIs.
+      #
+      # @example
+      #   type = _URI.having_scheme('https')
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::URIType] the created type
+      # @rbs (**__todo__ options) -> URIType
+      def _URI(**options)
+        require 'domainic/type/types/network/uri_type'
+        Domainic::Type::URIType.new(**options)
+      end
+      alias _URL _URI
+      alias _Url _URI
+      alias _Uri _URI
+
+      # Creates a nilable URIType instance.
+      #
+      # @example
+      #   _Uri?.validate("https://example.com") # => true
+      #   _Uri?.validate(nil)                   # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (URIType or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _URI?(**options)
+        _Nilable(_Uri(**options))
+      end
+      alias _URL? _URI?
+      alias _Url? _URI?
+      alias _Uri? _URI?
+
       # Creates a UUIDType instance
       #
       # @example
@@ -522,38 +558,6 @@ module Domainic
         Domainic::Type::UnionType.new(*types, **options)
       end
       alias _Either _Union
-
-      # Creates a URIType instance.
-      #
-      # URIType restricts values to valid URIs.
-      #
-      # @example
-      #   type = _URI.having_scheme('https')
-      #
-      # @param options [Hash] additional configuration options
-      #
-      # @return [Domainic::Type::URIType] the created type
-      # @rbs (**__todo__ options) -> URIType
-      def _Uri(**options)
-        require 'domainic/type/types/network/uri_type'
-        Domainic::Type::URIType.new(**options)
-      end
-      alias _Url _Uri
-
-      # Creates a nilable URIType instance.
-      #
-      # @example
-      #   _Uri?.validate("https://example.com") # => true
-      #   _Uri?.validate(nil)                   # => true
-      #
-      # @param options [Hash] additional configuration options
-      #
-      # @return [Domainic::Type::UnionType] the created type (URIType or NilClass)
-      # @rbs (**__todo__ options) -> UnionType
-      def _Uri?(**options)
-        _Nilable(_Uri(**options))
-      end
-      alias _Url? _Uri?
 
       # Creates a VoidType instance.
       #

--- a/domainic-type/sig/domainic/type/definitions.rbs
+++ b/domainic-type/sig/domainic/type/definitions.rbs
@@ -395,6 +395,41 @@ module Domainic
 
       alias _Interned? _Symbol?
 
+      # Creates a URIType instance.
+      #
+      # URIType restricts values to valid URIs.
+      #
+      # @example
+      #   type = _URI.having_scheme('https')
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::URIType] the created type
+      def _URI: (**__todo__ options) -> URIType
+
+      alias _URL _URI
+
+      alias _Url _URI
+
+      alias _Uri _URI
+
+      # Creates a nilable URIType instance.
+      #
+      # @example
+      #   _Uri?.validate("https://example.com") # => true
+      #   _Uri?.validate(nil)                   # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (URIType or NilClass)
+      def _URI?: (**__todo__ options) -> UnionType
+
+      alias _URL? _URI?
+
+      alias _Url? _URI?
+
+      alias _Uri? _URI?
+
       # Creates a UUIDType instance
       #
       # @example
@@ -434,33 +469,6 @@ module Domainic
       def _Union: (*Class | Module | Behavior[untyped, untyped, untyped] types, **__todo__ options) -> UnionType
 
       alias _Either _Union
-
-      # Creates a URIType instance.
-      #
-      # URIType restricts values to valid URIs.
-      #
-      # @example
-      #   type = _URI.having_scheme('https')
-      #
-      # @param options [Hash] additional configuration options
-      #
-      # @return [Domainic::Type::URIType] the created type
-      def _Uri: (**__todo__ options) -> URIType
-
-      alias _Url _Uri
-
-      # Creates a nilable URIType instance.
-      #
-      # @example
-      #   _Uri?.validate("https://example.com") # => true
-      #   _Uri?.validate(nil)                   # => true
-      #
-      # @param options [Hash] additional configuration options
-      #
-      # @return [Domainic::Type::UnionType] the created type (URIType or NilClass)
-      def _Uri?: (**__todo__ options) -> UnionType
-
-      alias _Url? _Uri?
 
       # Creates a VoidType instance.
       #

--- a/domainic-type/spec/domainic/type/definitions_spec.rb
+++ b/domainic-type/spec/domainic/type/definitions_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe Domainic::Type::Definitions do
     end
   end
 
-  describe '._Uri' do
-    subject(:uri_type) { definitions._Uri }
+  describe '._URI' do
+    subject(:uri_type) { definitions._URI }
 
     it 'is expected to return a UriType' do
       expect(uri_type).to be_a(Domainic::Type::URIType)


### PR DESCRIPTION
## Description

Renames the URI type definition method from `_Uri` to `_URI` to follow
Ruby conventions for acronym casing. Maintains backward compatibility
by keeping `_Uri` as an alias.

This change aligns the implementation with our documentation and
matches Ruby conventions where URI (Uniform Resource Identifier) should
be capitalized as an acronym.

## Related Issues

fixes #152

## Changes Made

* renamed `Domainic::Type::Definitions#_Uri` to `#_URI`
* Fix typo in _CUID aliases ("know" -> "known")
* Update URI type documentation to reflect new URI/URL acronym casing
* Remove emoji from README section header for consistency

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed