### PR TITLE
Fix identifier types and network types now abort_on_failure for type

### DIFF
--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * [#153](https://github.com/domainic/domainic/pull/153) renamed `Domainic::Type::Behavior._Uri` to
   `Domainic::Type::Behavior._URI` to follow standard naming conventions.
+* [#156](https://github.com/domainic/domainic/pull/156) fixed Instance, Identifier and Network types now properly fail
+  fast when not given the appropriate type.
 
 ### [0.1.0-alpha.3.1.0] - 2024-12-25
 

--- a/domainic-type/lib/domainic/type/types/identifier/cuid_type.rb
+++ b/domainic-type/lib/domainic/type/types/identifier/cuid_type.rb
@@ -60,7 +60,7 @@ module Domainic
       end
 
       # Core CUID constraints
-      intrinsically_constrain :self, :type, String, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
 
       # Accept either v1 or v2 format by default
       intrinsically_constrain :self, :match_pattern, CUID::ALL_REGEXP,

--- a/domainic-type/lib/domainic/type/types/identifier/uuid_type.rb
+++ b/domainic-type/lib/domainic/type/types/identifier/uuid_type.rb
@@ -176,7 +176,7 @@ module Domainic
       end
 
       # Core UUID constraints based on RFC 4122
-      intrinsically_constrain :self, :type, String, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
 
       # The base UUID type should accept either standard or compact format
       intrinsically_constrain :self, :match_pattern,

--- a/domainic-type/lib/domainic/type/types/network/email_address_type.rb
+++ b/domainic-type/lib/domainic/type/types/network/email_address_type.rb
@@ -47,7 +47,7 @@ module Domainic
       include Behavior::URIBehavior
 
       # Core email constraints based on RFCs 5321 and 5322
-      intrinsically_constrain :self, :type, String, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
       intrinsically_constrain :self, :match_pattern, URI::MailTo::EMAIL_REGEXP, description: :not_described
       intrinsically_constrain :length, :range, { maximum: 254 }, description: :not_described, concerning: :size
       intrinsically_constrain :self, :character_set, :ascii, description: :not_described

--- a/domainic-type/lib/domainic/type/types/network/hostname_type.rb
+++ b/domainic-type/lib/domainic/type/types/network/hostname_type.rb
@@ -60,7 +60,7 @@ module Domainic
       \z/x #: Regexp
 
       # Core hostname constraints based on RFC standards
-      intrinsically_constrain :self, :type, String, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
       intrinsically_constrain :self, :match_pattern, RFC_HOSTNAME_REGEXP, description: :not_described
       intrinsically_constrain :length, :range, { maximum: 253 }, description: :not_described, concerning: :size
       intrinsically_constrain :self, :character_set, :ascii, description: :not_described

--- a/domainic-type/lib/domainic/type/types/network/uri_type.rb
+++ b/domainic-type/lib/domainic/type/types/network/uri_type.rb
@@ -52,7 +52,7 @@ module Domainic
       URI_REGEXP = /\A#{URI::DEFAULT_PARSER.make_regexp}\z/ #: Regexp
 
       # Core URI constraints based on RFC standards
-      intrinsically_constrain :self, :type, String, description: :not_described
+      intrinsically_constrain :self, :type, String, abort_on_failure: true, description: :not_described
       intrinsically_constrain :self, :match_pattern, URI_REGEXP, description: :not_described
       intrinsically_constrain :self, :character_set, :ascii, description: :not_described
 

--- a/domainic-type/lib/domainic/type/types/specialized/instance_type.rb
+++ b/domainic-type/lib/domainic/type/types/specialized/instance_type.rb
@@ -66,7 +66,7 @@ module Domainic
       # @return [self] self for method chaining
       # @rbs (Class | Module | Behavior type) -> self
       def of(type)
-        constrain :self, :instance_of, type, description: 'of'
+        constrain :self, :instance_of, type, abort_on_failure: true, description: 'of'
       end
     end
   end


### PR DESCRIPTION
This ensures identifier and network types abort on failure when given the wrong type (i.e. EmailAddressType should abort on failure if it is given anything other than a String)

Specific changes include:

* Applied abort_on_failure: true for String type constraints in:
* CUIDType
* UUIDType
* EmailAddressType
* HostnameType
* URIType
* Updated InstanceType to enforce abort_on_failure: true in the of method for instance validation.

Changelog:

* fixed CUIDType to use abort_on_failure in intrinsic :type constraint
* fixed UUIDType to use abort_on_failure in intrinsic :type constraint
* fixed EmailAddressType to use abort_on_failure in intrinsic :type constraint
* fixed HostnameType to use abort_on_failure in intrinsic :type constraint
* fixed URIType to use abort_on_failure in intrinsic :type constraint
* fixed InstanceType#of to enforce abort_on_failure