### PR TITLE
Add various core types

### DIFF
--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -9,6 +9,9 @@
 * [#158](https://github.com/domainic/domainic/pull/158) added `README.md` and `docs/USAGE.md`
 * [#159](https://github.com/domainic/domainic/pull/159) added `Domainic::Type::DateTimeStringType`
 * [#160](https://github.com/domainic/domainic/pull/160) added `Domainic::Type::TimestampType`
+* [#161](https://github.com/domainic/domainic/pull/161) added `Domainic::Type::BigDecimalType`,
+  `Domainic::Type::ComplexType`, `Domainic::Type::RangeType`, `Domainic::Type::RationalType`, and
+  `Domainic::Type::SetType`
 
 #### Changed
 

--- a/domainic-type/lib/domainic/type/accessors.rb
+++ b/domainic-type/lib/domainic/type/accessors.rb
@@ -4,12 +4,12 @@ module Domainic
   module Type
     # @rbs!
     #   type accessor = :abs | :begin | :chars | :class | :count | :end | :entries | :first | :keys | :last | :length |
-    #                   :self | :size | :values
+    #                   :real | :self | :size | :values
 
     # A list of valid access methods that can be used to retrieve values for constraint validation.
     # These methods represent common Ruby interfaces for accessing collection sizes, ranges, and values.
     #
-    # - :abs                       - For absolute values
+    # - :abs, :real                - For absolute values
     # - :begin, :end               - For Range-like objects
     # - :class                     - For type checking
     # - :count, :length, :size     - For measuring collections
@@ -27,6 +27,7 @@ module Domainic
       entries
       chars
       abs
+      real
       count
       size
       length

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -123,6 +123,9 @@ types:
   range:
     constant: Domainic::Type::RangeType
     require_path: domainic/type/types/core/range_type
+  rational:
+    constant: Domainic::Type::RationalType
+    require_path: domainic/type/types/core/rational_type
   set:
     constant: Domainic::Type::SetType
     require_path: domainic/type/types/core_extended/set_type

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -117,6 +117,9 @@ types:
   range:
     constant: Domainic::Type::RangeType
     require_path: domainic/type/types/core/range_type
+  set:
+    constant: Domainic::Type::SetType
+    require_path: domainic/type/types/core_extended/set_type
   string:
     constant: Domainic::Type::StringType
     require_path: domainic/type/types/core/string_type

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -114,6 +114,9 @@ types:
   integer:
     constant: Domainic::Type::IntegerType
     require_path: domainic/type/types/core/integer_type
+  range:
+    constant: Domainic::Type::RangeType
+    require_path: domainic/type/types/core/range_type
   string:
     constant: Domainic::Type::StringType
     require_path: domainic/type/types/core/string_type

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -81,6 +81,9 @@ types:
   big_decimal:
     constant: Domainic::Type::BigDecimalType
     require_path: domainic/type/types/core_extended/big_decimal_type
+  complex:
+    constant: Domainic::Type::ComplexType
+    require_path: domainic/type/types/core/complex_type
   cuid:
     constant: Domainic::Type::CUIDType
     require_path: domainic/type/types/identifier/cuid_type

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -78,6 +78,9 @@ types:
   anything:
     constant: Domainic::Type::AnythingType
     require_path: domainic/type/types/specification/anything_type
+  big_decimal:
+    constant: Domainic::Type::BigDecimalType
+    require_path: domainic/type/types/core_extended/big_decimal_type
   cuid:
     constant: Domainic::Type::CUIDType
     require_path: domainic/type/types/identifier/cuid_type

--- a/domainic-type/lib/domainic/type/definitions.rb
+++ b/domainic-type/lib/domainic/type/definitions.rb
@@ -77,6 +77,36 @@ module Domainic
       end
       alias _List? _Array?
 
+      # Creates a BigDecimalType instance.
+      #
+      # @example
+      #   type = _BigDecimal
+      #   type.validate(BigDecimal('123.45')) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::BigDecimalType] the created type
+      # @rbs (**__todo__ options) -> BigDecimalType
+      def _BigDecimal(**options)
+        require 'domainic/type/types/core_extended/big_decimal_type'
+        Domainic::Type::BigDecimalType.new(**options)
+      end
+
+      # Creates a nilable BigDecimalType instance.
+      #
+      # @example
+      #   type = _BigDecimal?
+      #   type.validate(BigDecimal('123.45')) # => true
+      #   type.validate(nil)                  # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (BigDecimal or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _BigDecimal?(**options)
+        _Nilable(_BigDecimal(**options))
+      end
+
       # Creates a Boolean type.
       #
       # Represents a union of TrueClass and FalseClass.
@@ -132,6 +162,35 @@ module Domainic
         _Nilable(_CUID(**options))
       end
       alias _Cuid? _CUID?
+
+      # Creates a ComplexType instance.
+      #
+      # @example
+      #   type = _Complex
+      #   type.validate(Complex(1, 2)) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::ComplexType] the created type
+      # @rbs (**__todo__ options) -> ComplexType
+      def _Complex(**options)
+        require 'domainic/type/types/core/complex_type'
+        Domainic::Type::ComplexType.new(**options)
+      end
+
+      # Creates a nilable ComplexType instance.
+      #
+      # @example
+      #   type = _Complex?
+      #   type.validate(Complex(1, 2)) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Complex or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Complex?(**options)
+        _Nilable(_Complex(**options))
+      end
 
       # Creates a DateType instance.
       #
@@ -509,6 +568,95 @@ module Domainic
         _Union(NilClass, *types, **options)
       end
       alias _Nullable _Nilable
+
+      # Creates a RangeType instance.
+      #
+      # @example
+      #   type = _Range
+      #   type.validate(1..10) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::RangeType] the created type
+      # @rbs (**__todo__ options) -> RangeType
+      def _Range(**options)
+        require 'domainic/type/types/core/range_type'
+        Domainic::Type::RangeType.new(**options)
+      end
+
+      # Creates a nilable RangeType instance.
+      #
+      # @example
+      #   type = _Range?
+      #   type.validate(1..10) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Range or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Range?(**options)
+        _Nilable(_Range(**options))
+      end
+
+      # Creates a RationalType instance.
+      #
+      # @example
+      #   type = _Rational
+      #   type.validate(Rational(1, 2)) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::RationalType] the created type
+      # @rbs (**__todo__ options) -> RationalType
+      def _Rational(**options)
+        require 'domainic/type/types/core/rational_type'
+        Domainic::Type::RationalType.new(**options)
+      end
+
+      # Creates a nilable RationalType instance.
+      #
+      # @example
+      #   type = _Rational?
+      #   type.validate(Rational(1, 2)) # => true
+      #   type.validate(nil)            # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Rational or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Rational?(**options)
+        _Nilable(_Rational(**options))
+      end
+
+      # Creates a SetType instance.
+      #
+      # @example
+      #   type = _Set
+      #   type.validate(Set[1, 2, 3]) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::SetType] the created type
+      # @rbs (**__todo__ options) -> SetType
+      def _Set(**options)
+        require 'domainic/type/types/core_extended/set_type'
+        Domainic::Type::SetType.new(**options)
+      end
+
+      # Creates a nilable SetType instance.
+      #
+      # @example
+      #   type = _Set?
+      #   type.validate(Set[1, 2, 3]) # => true
+      #   type.validate(nil)          # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Set or NilClass)
+      # @rbs (**__todo__ options) -> UnionType
+      def _Set?(**options)
+        _Nilable(_Set(**options))
+      end
 
       # Creates a StringType instance.
       #

--- a/domainic-type/lib/domainic/type/types/core/complex_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/complex_type.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+require 'domainic/type/behavior/numeric_behavior'
+
+module Domainic
+  module Type
+    # A type for validating and constraining `Complex` numbers.
+    #
+    # This type extends `NumericBehavior` to provide a fluent interface for numeric-specific validations such as
+    # polarity and divisibility checks.
+    #
+    # @example Validating a `Complex` value
+    #   type = Domainic::Type::ComplexType.new
+    #   type.validate!(Complex(3, 4)) # => true
+    #
+    # @example Enforcing constraints
+    #   type = Domainic::Type::ComplexType.new
+    #   type.being_positive.validate!(Complex(42, 0)) # => raises TypeError
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class ComplexType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+      include Behavior::NumericBehavior
+
+      intrinsically_constrain :self, :type, Complex, abort_on_failure: true, description: :not_described
+
+      # Constrain the Complex real to be divisible by a given divisor.
+      #
+      # @param arguments [Array<Numeric>] a list of arguments, typically one divisor
+      # @param options [Hash] additional options such as tolerance for floating-point checks
+      # @option options [Numeric] :divisor the divisor to check for divisibility
+      # @option options [Numeric] :tolerance the tolerance for floating-point checks
+      #
+      # @return [self] the current instance for chaining
+      # @rbs (*Numeric arguments, ?divisor: Numeric, ?tolerance: Numeric) -> Behavior
+      def being_divisible_by(*arguments, **options)
+        if arguments.size > 1 || (arguments.empty? && !options.key?(:divisor))
+          raise ArgumentError, "wrong number of arguments (given #{arguments.size}, expected 1)"
+        end
+
+        divisor = arguments.first || options[:divisor]
+        constrain :real, :divisibility, divisor, description: 'being', **options.except(:divisor)
+      end
+      alias being_multiple_of being_divisible_by
+      alias divisible_by being_divisible_by
+      alias multiple_of being_divisible_by
+
+      # Constrain the Complex real to be even.
+      #
+      # @return [self] the current instance for chaining
+      # @rbs () -> Behavior
+      def being_even
+        # @type self: Object & Behavior
+        constrain :real, :parity, :even, description: 'being'
+      end
+      alias even being_even
+      alias not_being_odd being_even
+
+      # Constrain the Complex real to be negative.
+      #
+      # @return [self] the current instance for chaining
+      # @rbs () -> Behavior
+      def being_negative
+        # @type self: Object & Behavior
+        constrain :real, :polarity, :negative, description: 'being'
+      end
+      alias negative being_negative
+      alias not_being_positive being_negative
+
+      # Constrain the Complex real value to be odd.
+      #
+      # @return [self] the current instance for chaining
+      # @rbs () -> Behavior
+      def being_odd
+        # @type self: Object & Behavior
+        constrain :real, :parity, :odd, description: 'being'
+      end
+      alias odd being_odd
+      alias not_being_even being_odd
+
+      # Constrain the Complex real to be positive.
+      #
+      # @return [self] the current instance for chaining
+      # @rbs () -> Behavior
+      def being_positive
+        # @type self: Object & Behavior
+        constrain :real, :polarity, :positive, description: 'being'
+      end
+      alias positive being_positive
+      alias not_being_negative being_positive
+
+      # Constrain the Complex real to not be divisible by a specific divisor.
+      #
+      # @note the divisor MUST be provided as an argument or in the options Hash.
+      #
+      # @param arguments [Array<Numeric>] a list of arguments, typically one divisor
+      # @param options [Hash] additional options such as tolerance for floating-point checks
+      # @option options [Numeric] :divisor the divisor to check for divisibility
+      # @option options [Numeric] :tolerance the tolerance for floating-point checks
+      #
+      # @return [self] the current instance for chaining
+      # @rbs (*Numeric arguments, ?divisor: Numeric, ?tolerance: Numeric) -> Behavior
+      def not_being_divisible_by(*arguments, **options)
+        if arguments.size > 1 || (arguments.empty? && !options.key?(:divisor))
+          raise ArgumentError, "wrong number of arguments (given #{arguments.size}, expected 1)"
+        end
+
+        # @type self: Object & Behavior
+        divisor = arguments.first || options[:divisor]
+        divisible_by = @constraints.prepare :self, :divisibility, divisor, **options.except(:divisor)
+        constrain :real, :not, divisible_by, concerning: :divisibility, description: 'being'
+      end
+      alias not_being_multiple_of not_being_divisible_by
+      alias not_divisible_by not_being_divisible_by
+      alias not_multiple_of not_being_divisible_by
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/types/core/range_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/range_type.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+require 'domainic/type/behavior/enumerable_behavior'
+
+module Domainic
+  module Type
+    # A type for validating `Range` objects with comprehensive constraints.
+    #
+    # This class allows flexible validation of ranges, supporting type checks,
+    # inclusion/exclusion of values, and range-specific behaviors such as bounds validation.
+    # It integrates with `EnumerableBehavior` for enumerable-style validations
+    # (e.g., size constraints, element presence).
+    #
+    # Key features:
+    # - Ensures the value is a `Range`.
+    # - Supports constraints for range boundaries (`begin` and `end`).
+    # - Provides validations for inclusion and exclusion of values.
+    # - Leverages `EnumerableBehavior` for size and collection-style constraints.
+    #
+    # @example Basic usage
+    #   type = RangeType.new
+    #   type.having_bounds(1, 10)         # Validates range bounds (inclusive or exclusive).
+    #   type.containing(5)               # Ensures value is within the range.
+    #   type.not_containing(15)          # Ensures value is not within the range.
+    #
+    # @example Integration with EnumerableBehavior
+    #   type = RangeType.new
+    #   type.having_size(10)             # Validates size (total elements in the range).
+    #   type.containing_exactly(3, 7)    # Validates specific values within the range.
+    #
+    # @example Flexible boundaries
+    #   type = RangeType.new
+    #   type.having_bounds(1, 10, exclusive: true)  # Upper and lower bounds are exclusive.
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class RangeType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+      include Behavior::EnumerableBehavior
+
+      intrinsically_constrain :self, :type, Range, abort_on_failure: true, description: :not_described
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/types/core/rational_type.rb
+++ b/domainic-type/lib/domainic/type/types/core/rational_type.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+require 'domainic/type/behavior/numeric_behavior'
+
+module Domainic
+  module Type
+    # A type for validating Rational numbers.
+    #
+    # This type ensures values are of type `Rational` and supports a range of
+    # constraints for numerical validation, such as positivity, negativity,
+    # and divisibility. It integrates with `NumericBehavior` to provide a
+    # consistent and fluent interface for numeric constraints.
+    #
+    # @example Validating a positive Rational number
+    #   type = Domainic::Type::RationalType.new
+    #   type.being_positive.validate!(Rational(3, 4)) # => true
+    #
+    # @example Validating divisibility
+    #   type = Domainic::Type::RationalType.new
+    #   type.being_divisible_by(1).validate!(Rational(3, 1)) # => true
+    #
+    # @example Using constraints with chaining
+    #   type = Domainic::Type::RationalType.new
+    #   type.being_greater_than(0).being_less_than(1).validate!(Rational(1, 2)) # => true
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class RationalType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+      include Behavior::NumericBehavior
+
+      intrinsically_constrain :self, :type, Rational, abort_on_failure: true, description: :not_described
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/types/core_extended/big_decimal_type.rb
+++ b/domainic-type/lib/domainic/type/types/core_extended/big_decimal_type.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+require 'domainic/type/behavior'
+require 'domainic/type/behavior/numeric_behavior'
+
+module Domainic
+  module Type
+    # A type for validating and constraining `BigDecimal` objects.
+    #
+    # This type extends `NumericBehavior` to provide a fluent interface for numeric-specific validations such as being
+    # positive, being within a range, or satisfying divisibility rules.
+    #
+    # @example Validating a `BigDecimal` value
+    #   type = Domainic::Type::BigDecimalType.new
+    #   type.validate!(BigDecimal('3.14')) # => true
+    #
+    # @example Enforcing constraints
+    #   type = Domainic::Type::BigDecimalType.new
+    #   type.being_positive.validate!(BigDecimal('42')) # => true
+    #   type.being_positive.validate!(BigDecimal('-42')) # raises TypeError
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class BigDecimalType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+      include Behavior::NumericBehavior
+
+      intrinsically_constrain :self, :type, BigDecimal, abort_on_failure: true, description: :not_described
+    end
+  end
+end

--- a/domainic-type/lib/domainic/type/types/core_extended/set_type.rb
+++ b/domainic-type/lib/domainic/type/types/core_extended/set_type.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'domainic/type/behavior'
+require 'domainic/type/behavior/enumerable_behavior'
+require 'set'
+
+module Domainic
+  module Type
+    # A type for validating and constraining `Set` objects.
+    #
+    # This type extends `EnumerableBehavior` to support validations and constraints
+    # such as being empty, containing specific elements, or having a minimum or maximum count.
+    #
+    # @example Validating a `Set` object
+    #   type = Domainic::Type::SetType.new
+    #   type.validate!(Set.new([1, 2, 3])) # => true
+    #
+    # @example Enforcing constraints
+    #   type = Domainic::Type::SetType.new
+    #   type.being_empty.validate!(Set.new) # => true
+    #   type.being_empty.validate!(Set.new([1])) # raises TypeError
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class SetType
+      # @rbs! extend Behavior::ClassMethods
+
+      include Behavior
+      include Behavior::EnumerableBehavior
+
+      intrinsically_constrain :self, :type, Set, abort_on_failure: true, description: :not_described
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/accessors.rbs
+++ b/domainic-type/sig/domainic/type/accessors.rbs
@@ -1,11 +1,11 @@
 module Domainic
   module Type
-    type accessor = :abs | :begin | :chars | :class | :count | :end | :entries | :first | :keys | :last | :length | :self | :size | :values
+    type accessor = :abs | :begin | :chars | :class | :count | :end | :entries | :first | :keys | :last | :length | :real | :self | :size | :values
 
     # A list of valid access methods that can be used to retrieve values for constraint validation.
     # These methods represent common Ruby interfaces for accessing collection sizes, ranges, and values.
     #
-    # - :abs                       - For absolute values
+    # - :abs, :real                - For absolute values
     # - :begin, :end               - For Range-like objects
     # - :class                     - For type checking
     # - :count, :length, :size     - For measuring collections

--- a/domainic-type/sig/domainic/type/definitions.rbs
+++ b/domainic-type/sig/domainic/type/definitions.rbs
@@ -64,6 +64,29 @@ module Domainic
 
       alias _List? _Array?
 
+      # Creates a BigDecimalType instance.
+      #
+      # @example
+      #   type = _BigDecimal
+      #   type.validate(BigDecimal('123.45')) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::BigDecimalType] the created type
+      def _BigDecimal: (**__todo__ options) -> BigDecimalType
+
+      # Creates a nilable BigDecimalType instance.
+      #
+      # @example
+      #   type = _BigDecimal?
+      #   type.validate(BigDecimal('123.45')) # => true
+      #   type.validate(nil)                  # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (BigDecimal or NilClass)
+      def _BigDecimal?: (**__todo__ options) -> UnionType
+
       # Creates a Boolean type.
       #
       # Represents a union of TrueClass and FalseClass.
@@ -110,6 +133,28 @@ module Domainic
       def _CUID?: (**__todo__ options) -> UnionType
 
       alias _Cuid? _CUID?
+
+      # Creates a ComplexType instance.
+      #
+      # @example
+      #   type = _Complex
+      #   type.validate(Complex(1, 2)) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::ComplexType] the created type
+      def _Complex: (**__todo__ options) -> ComplexType
+
+      # Creates a nilable ComplexType instance.
+      #
+      # @example
+      #   type = _Complex?
+      #   type.validate(Complex(1, 2)) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Complex or NilClass)
+      def _Complex?: (**__todo__ options) -> UnionType
 
       # Creates a DateType instance.
       #
@@ -422,6 +467,74 @@ module Domainic
       def _Nilable: (*Class | Module | Behavior[untyped, untyped, untyped] types, **__todo__ options) -> UnionType
 
       alias _Nullable _Nilable
+
+      # Creates a RangeType instance.
+      #
+      # @example
+      #   type = _Range
+      #   type.validate(1..10) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::RangeType] the created type
+      def _Range: (**__todo__ options) -> RangeType
+
+      # Creates a nilable RangeType instance.
+      #
+      # @example
+      #   type = _Range?
+      #   type.validate(1..10) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Range or NilClass)
+      def _Range?: (**__todo__ options) -> UnionType
+
+      # Creates a RationalType instance.
+      #
+      # @example
+      #   type = _Rational
+      #   type.validate(Rational(1, 2)) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::RationalType] the created type
+      def _Rational: (**__todo__ options) -> RationalType
+
+      # Creates a nilable RationalType instance.
+      #
+      # @example
+      #   type = _Rational?
+      #   type.validate(Rational(1, 2)) # => true
+      #   type.validate(nil)            # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Rational or NilClass)
+      def _Rational?: (**__todo__ options) -> UnionType
+
+      # Creates a SetType instance.
+      #
+      # @example
+      #   type = _Set
+      #   type.validate(Set[1, 2, 3]) # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::SetType] the created type
+      def _Set: (**__todo__ options) -> SetType
+
+      # Creates a nilable SetType instance.
+      #
+      # @example
+      #   type = _Set?
+      #   type.validate(Set[1, 2, 3]) # => true
+      #   type.validate(nil)          # => true
+      #
+      # @param options [Hash] additional configuration options
+      #
+      # @return [Domainic::Type::UnionType] the created type (Set or NilClass)
+      def _Set?: (**__todo__ options) -> UnionType
 
       # Creates a StringType instance.
       #

--- a/domainic-type/sig/domainic/type/types/core/complex_type.rbs
+++ b/domainic-type/sig/domainic/type/types/core/complex_type.rbs
@@ -1,0 +1,96 @@
+module Domainic
+  module Type
+    # A type for validating and constraining `Complex` numbers.
+    #
+    # This type extends `NumericBehavior` to provide a fluent interface for numeric-specific validations such as
+    # polarity and divisibility checks.
+    #
+    # @example Validating a `Complex` value
+    #   type = Domainic::Type::ComplexType.new
+    #   type.validate!(Complex(3, 4)) # => true
+    #
+    # @example Enforcing constraints
+    #   type = Domainic::Type::ComplexType.new
+    #   type.being_positive.validate!(Complex(42, 0)) # => raises TypeError
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class ComplexType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      include Behavior::NumericBehavior
+
+      # Constrain the Complex real to be divisible by a given divisor.
+      #
+      # @param arguments [Array<Numeric>] a list of arguments, typically one divisor
+      # @param options [Hash] additional options such as tolerance for floating-point checks
+      # @option options [Numeric] :divisor the divisor to check for divisibility
+      # @option options [Numeric] :tolerance the tolerance for floating-point checks
+      #
+      # @return [self] the current instance for chaining
+      def being_divisible_by: (*Numeric arguments, ?divisor: Numeric, ?tolerance: Numeric) -> Behavior
+
+      alias being_multiple_of being_divisible_by
+
+      alias divisible_by being_divisible_by
+
+      alias multiple_of being_divisible_by
+
+      # Constrain the Complex real to be even.
+      #
+      # @return [self] the current instance for chaining
+      def being_even: () -> Behavior
+
+      alias even being_even
+
+      alias not_being_odd being_even
+
+      # Constrain the Complex real to be negative.
+      #
+      # @return [self] the current instance for chaining
+      def being_negative: () -> Behavior
+
+      alias negative being_negative
+
+      alias not_being_positive being_negative
+
+      # Constrain the Complex real value to be odd.
+      #
+      # @return [self] the current instance for chaining
+      def being_odd: () -> Behavior
+
+      alias odd being_odd
+
+      alias not_being_even being_odd
+
+      # Constrain the Complex real to be positive.
+      #
+      # @return [self] the current instance for chaining
+      def being_positive: () -> Behavior
+
+      alias positive being_positive
+
+      alias not_being_negative being_positive
+
+      # Constrain the Complex real to not be divisible by a specific divisor.
+      #
+      # @note the divisor MUST be provided as an argument or in the options Hash.
+      #
+      # @param arguments [Array<Numeric>] a list of arguments, typically one divisor
+      # @param options [Hash] additional options such as tolerance for floating-point checks
+      # @option options [Numeric] :divisor the divisor to check for divisibility
+      # @option options [Numeric] :tolerance the tolerance for floating-point checks
+      #
+      # @return [self] the current instance for chaining
+      def not_being_divisible_by: (*Numeric arguments, ?divisor: Numeric, ?tolerance: Numeric) -> Behavior
+
+      alias not_being_multiple_of not_being_divisible_by
+
+      alias not_divisible_by not_being_divisible_by
+
+      alias not_multiple_of not_being_divisible_by
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/types/core/range_type.rbs
+++ b/domainic-type/sig/domainic/type/types/core/range_type.rbs
@@ -1,0 +1,41 @@
+module Domainic
+  module Type
+    # A type for validating `Range` objects with comprehensive constraints.
+    #
+    # This class allows flexible validation of ranges, supporting type checks,
+    # inclusion/exclusion of values, and range-specific behaviors such as bounds validation.
+    # It integrates with `EnumerableBehavior` for enumerable-style validations
+    # (e.g., size constraints, element presence).
+    #
+    # Key features:
+    # - Ensures the value is a `Range`.
+    # - Supports constraints for range boundaries (`begin` and `end`).
+    # - Provides validations for inclusion and exclusion of values.
+    # - Leverages `EnumerableBehavior` for size and collection-style constraints.
+    #
+    # @example Basic usage
+    #   type = RangeType.new
+    #   type.having_bounds(1, 10)         # Validates range bounds (inclusive or exclusive).
+    #   type.containing(5)               # Ensures value is within the range.
+    #   type.not_containing(15)          # Ensures value is not within the range.
+    #
+    # @example Integration with EnumerableBehavior
+    #   type = RangeType.new
+    #   type.having_size(10)             # Validates size (total elements in the range).
+    #   type.containing_exactly(3, 7)    # Validates specific values within the range.
+    #
+    # @example Flexible boundaries
+    #   type = RangeType.new
+    #   type.having_bounds(1, 10, exclusive: true)  # Upper and lower bounds are exclusive.
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class RangeType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      include Behavior::EnumerableBehavior
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/types/core/rational_type.rbs
+++ b/domainic-type/sig/domainic/type/types/core/rational_type.rbs
@@ -1,0 +1,32 @@
+module Domainic
+  module Type
+    # A type for validating Rational numbers.
+    #
+    # This type ensures values are of type `Rational` and supports a range of
+    # constraints for numerical validation, such as positivity, negativity,
+    # and divisibility. It integrates with `NumericBehavior` to provide a
+    # consistent and fluent interface for numeric constraints.
+    #
+    # @example Validating a positive Rational number
+    #   type = Domainic::Type::RationalType.new
+    #   type.being_positive.validate!(Rational(3, 4)) # => true
+    #
+    # @example Validating divisibility
+    #   type = Domainic::Type::RationalType.new
+    #   type.being_divisible_by(1).validate!(Rational(3, 1)) # => true
+    #
+    # @example Using constraints with chaining
+    #   type = Domainic::Type::RationalType.new
+    #   type.being_greater_than(0).being_less_than(1).validate!(Rational(1, 2)) # => true
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class RationalType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      include Behavior::NumericBehavior
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/types/core_extended/big_decimal_type.rbs
+++ b/domainic-type/sig/domainic/type/types/core_extended/big_decimal_type.rbs
@@ -1,0 +1,27 @@
+module Domainic
+  module Type
+    # A type for validating and constraining `BigDecimal` objects.
+    #
+    # This type extends `NumericBehavior` to provide a fluent interface for numeric-specific validations such as being
+    # positive, being within a range, or satisfying divisibility rules.
+    #
+    # @example Validating a `BigDecimal` value
+    #   type = Domainic::Type::BigDecimalType.new
+    #   type.validate!(BigDecimal('3.14')) # => true
+    #
+    # @example Enforcing constraints
+    #   type = Domainic::Type::BigDecimalType.new
+    #   type.being_positive.validate!(BigDecimal('42')) # => true
+    #   type.being_positive.validate!(BigDecimal('-42')) # raises TypeError
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class BigDecimalType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      include Behavior::NumericBehavior
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/types/core_extended/set_type.rbs
+++ b/domainic-type/sig/domainic/type/types/core_extended/set_type.rbs
@@ -1,0 +1,27 @@
+module Domainic
+  module Type
+    # A type for validating and constraining `Set` objects.
+    #
+    # This type extends `EnumerableBehavior` to support validations and constraints
+    # such as being empty, containing specific elements, or having a minimum or maximum count.
+    #
+    # @example Validating a `Set` object
+    #   type = Domainic::Type::SetType.new
+    #   type.validate!(Set.new([1, 2, 3])) # => true
+    #
+    # @example Enforcing constraints
+    #   type = Domainic::Type::SetType.new
+    #   type.being_empty.validate!(Set.new) # => true
+    #   type.being_empty.validate!(Set.new([1])) # raises TypeError
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    class SetType
+      extend Behavior::ClassMethods
+
+      include Behavior
+
+      include Behavior::EnumerableBehavior
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/big_decimal_type_spec.rb
+++ b/domainic-type/spec/domainic/type/big_decimal_type_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/core_extended/big_decimal_type'
+
+RSpec.describe Domainic::Type::BigDecimalType do
+  subject(:type) { described_class.new }
+
+  describe '.validate' do
+    context 'when validating a valid BigDecimal value' do
+      subject(:validation) { type.validate(BigDecimal('3.14')) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid type' do
+      subject(:validation) { type.validate(3.14) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.validate!' do
+    context 'when validating a valid BigDecimal value' do
+      subject(:validation) { type.validate!(BigDecimal('3.14')) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid type' do
+      it { expect { type.validate!(3.14) }.to raise_error(TypeError, /Expected BigDecimal, but got Float/) }
+    end
+  end
+
+  describe '#being_positive' do
+    context 'when the value is positive' do
+      subject(:validation) { type.being_positive.validate(BigDecimal('3.14')) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is negative' do
+      subject(:validation) { type.being_positive.validate(BigDecimal('-3.14')) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_divisible_by' do
+    context 'when the value is divisible by the specified number' do
+      subject(:validation) { type.being_divisible_by(BigDecimal('1.57')).validate(BigDecimal('3.14')) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not divisible by the specified number' do
+      subject(:validation) { type.being_divisible_by(BigDecimal('1.57')).validate(BigDecimal('3.15')) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_negative' do
+    context 'when the value is negative' do
+      subject(:validation) { type.being_negative.validate(BigDecimal('-3.14')) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is positive' do
+      subject(:validation) { type.being_negative.validate(BigDecimal('3.14')) }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/complex_type_spec.rb
+++ b/domainic-type/spec/domainic/type/complex_type_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/core/complex_type'
+
+RSpec.describe Domainic::Type::ComplexType do
+  subject(:type) { described_class.new }
+
+  describe '.validate' do
+    context 'when validating a valid Complex number' do
+      subject(:validation) { type.validate(Complex(3, 4)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid type' do
+      subject(:validation) { type.validate(3.14) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.validate!' do
+    context 'when validating a valid Complex number' do
+      subject(:validation) { type.validate!(Complex(3, 4)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid type' do
+      it { expect { type.validate!(3.14) }.to raise_error(TypeError, /Expected Complex, but got Float/) }
+    end
+  end
+
+  describe '#being_positive' do
+    context 'when the value is positive (Real part > 0)' do
+      subject(:validation) { type.being_positive.validate(Complex(3, 0)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not positive (Real part <= 0)' do
+      subject(:validation) { type.being_positive.validate(Complex(-3, 0)) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_divisible_by' do
+    context 'when the real part of the value is divisible by the divisor' do
+      subject(:validation) { type.being_divisible_by(2).validate(Complex(4, 3)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the real part of the value is not divisible by the divisor' do
+      subject(:validation) { type.being_divisible_by(3).validate(Complex(4, 3)) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the real part is zero and divisor is non-zero' do
+      subject(:validation) { type.being_divisible_by(2).validate(Complex(0, 3)) }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#being_negative' do
+    context 'when the value is negative (Real part < 0)' do
+      subject(:validation) { type.being_negative.validate(Complex(-3, 0)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not negative (Real part >= 0)' do
+      subject(:validation) { type.being_negative.validate(Complex(3, 0)) }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/definitions_spec.rb
+++ b/domainic-type/spec/domainic/type/definitions_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Domainic::Type::Definitions do
     end
   end
 
+  describe '._BigDecimal' do
+    subject(:big_decimal_type) { definitions._BigDecimal }
+
+    it 'is expected to return a BigDecimalType' do
+      expect(big_decimal_type).to be_a(Domainic::Type::BigDecimalType)
+    end
+  end
+
   describe '._Boolean' do
     subject(:boolean_type) { definitions._Boolean }
 
@@ -65,6 +73,14 @@ RSpec.describe Domainic::Type::Definitions do
 
     it 'is expected to return an CUIDType' do
       expect(cuid_type).to be_a(Domainic::Type::CUIDType)
+    end
+  end
+
+  describe '._Complex' do
+    subject(:complex_type) { definitions._Complex }
+
+    it 'is expected to return a ComplexType' do
+      expect(complex_type).to be_a(Domainic::Type::ComplexType)
     end
   end
 
@@ -161,6 +177,30 @@ RSpec.describe Domainic::Type::Definitions do
 
     it 'is expected to validate values of the specified type' do
       expect(nilable_type.validate('test')).to be true
+    end
+  end
+
+  describe '._Range' do
+    subject(:range_type) { definitions._Range }
+
+    it 'is expected to return a RangeType' do
+      expect(range_type).to be_a(Domainic::Type::RangeType)
+    end
+  end
+
+  describe '._Rational' do
+    subject(:rational_type) { definitions._Rational }
+
+    it 'is expected to return a RationalType' do
+      expect(rational_type).to be_a(Domainic::Type::RationalType)
+    end
+  end
+
+  describe '._Set' do
+    subject(:set_type) { definitions._Set }
+
+    it 'is expected to return a SetType' do
+      expect(set_type).to be_a(Domainic::Type::SetType)
     end
   end
 

--- a/domainic-type/spec/domainic/type/range_type_spec.rb
+++ b/domainic-type/spec/domainic/type/range_type_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/core/range_type'
+
+RSpec.describe Domainic::Type::RangeType do
+  subject(:type) { described_class.new }
+
+  describe '.validate' do
+    context 'when validating a valid range' do
+      subject(:validation) { described_class.validate(1..10) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid range' do
+      subject(:validation) { described_class.validate('not a range') }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.validate!' do
+    context 'when validating a valid range' do
+      subject(:validation) { described_class.validate!(1..10) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid range' do
+      it {
+        expect do
+          described_class.validate!('not a range')
+        end.to raise_error(TypeError, /Expected Range, but got String/)
+      }
+    end
+  end
+
+  describe '#being_empty' do
+    context 'when the range is empty' do
+      subject(:validation) { type.being_empty.validate(1...1) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the range is not empty' do
+      subject(:validation) { type.being_empty.validate(1..10) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#having_minimum_count' do
+    context 'when the range size meets the minimum count' do
+      subject(:validation) { type.having_minimum_count(5).validate(1..5) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the range size is below the minimum count' do
+      subject(:validation) { type.having_minimum_count(5).validate(1..3) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#having_maximum_count' do
+    context 'when the range size is within the maximum count' do
+      subject(:validation) { type.having_maximum_count(10).validate(1..10) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the range size exceeds the maximum count' do
+      subject(:validation) { type.having_maximum_count(10).validate(1..20) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#containing' do
+    context 'when the range includes all specified elements' do
+      subject(:validation) { type.containing(3, 5).validate(1..10) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the range does not include all specified elements' do
+      subject(:validation) { type.containing(11).validate(1..10) }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/rational_type_spec.rb
+++ b/domainic-type/spec/domainic/type/rational_type_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/core/rational_type'
+
+RSpec.describe Domainic::Type::RationalType do
+  subject(:type) { described_class.new }
+
+  describe 'intrinsic constraints' do
+    describe 'type constraint' do
+      context 'when value is a Rational number' do
+        subject(:validation) { type.validate(Rational(3, 4)) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when value is not a Rational number' do
+        subject(:validation) { type.validate(0.75) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#being_positive' do
+    context 'when the value is positive' do
+      subject(:validation) { type.being_positive.validate(Rational(3, 4)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not positive' do
+      subject(:validation) { type.being_positive.validate(Rational(-3, 4)) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_negative' do
+    context 'when the value is negative' do
+      subject(:validation) { type.being_negative.validate(Rational(-3, 4)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not negative' do
+      subject(:validation) { type.being_negative.validate(Rational(3, 4)) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_divisible_by' do
+    context 'when the value is divisible by the divisor' do
+      subject(:validation) { type.being_divisible_by(1).validate(Rational(3, 1)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not divisible by the divisor' do
+      subject(:validation) { type.being_divisible_by(2).validate(Rational(3, 1)) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#being_greater_than' do
+    context 'when the value is greater than the boundary' do
+      subject(:validation) { type.being_greater_than(Rational(1, 2)).validate(Rational(3, 4)) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the value is not greater than the boundary' do
+      subject(:validation) { type.being_greater_than(Rational(1, 2)).validate(Rational(1, 4)) }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/set_type_spec.rb
+++ b/domainic-type/spec/domainic/type/set_type_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/types/core_extended/set_type'
+
+RSpec.describe Domainic::Type::SetType do
+  subject(:type) { described_class.new }
+
+  describe '.validate' do
+    context 'when validating a valid set' do
+      subject(:validation) { type.validate(Set.new([1, 2, 3])) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid type' do
+      subject(:validation) { type.validate([1, 2, 3]) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '.validate!' do
+    context 'when validating a valid set' do
+      subject(:validation) { type.validate!(Set.new([1, 2, 3])) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when validating an invalid type' do
+      it { expect { type.validate!([1, 2, 3]) }.to raise_error(TypeError, /Expected Set, but got Array/) }
+    end
+  end
+
+  describe '#being_empty' do
+    context 'when the set is empty' do
+      subject(:validation) { type.being_empty.validate(Set.new) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the set is not empty' do
+      subject(:validation) { type.being_empty.validate(Set.new([1])) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#having_minimum_count' do
+    context 'when the set size meets the minimum count' do
+      subject(:validation) { type.having_minimum_count(2).validate(Set.new([1, 2])) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the set size is below the minimum count' do
+      subject(:validation) { type.having_minimum_count(2).validate(Set.new([1])) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#having_maximum_count' do
+    context 'when the set size is within the maximum count' do
+      subject(:validation) { type.having_maximum_count(3).validate(Set.new([1, 2])) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the set size exceeds the maximum count' do
+      subject(:validation) { type.having_maximum_count(3).validate(Set.new([1, 2, 3, 4])) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#containing' do
+    context 'when the set includes all specified elements' do
+      subject(:validation) { type.containing(1, 2).validate(Set.new([1, 2, 3])) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the set does not include all specified elements' do
+      subject(:validation) { type.containing(4).validate(Set.new([1, 2, 3])) }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Description

This introduces type definitions for `BigDecimal`, `Complex`, `Range`, `Rational`, and `Set`, providing flexible validation for these specialized data types. These types are seamlessly integrated into `Domainic::Type::Definitions`, allowing for robust and extensible constraint handling. Each type is also supported by optional validation methods for nilable values.

## Changes Made

### New Type Definitions

* `_BigDecimal`: Creates a `BigDecimalType` for validating `BigDecimal` objects.
* `_Complex`: Creates a `ComplexType` for validating `Complex` numbers.
* `_Range`: Creates a `RangeType` for validating `Range` objects.
* `_Rational`: Creates a `RationalType` for validating `Rational` numbers.
* `_Set`: Creates a `SetType` for validating `Set` objects.

### Nilable Versions

* `_BigDecimal?`: Optional validation for `BigDecimal`.
* `_Complex?`: Optional validation for `Complex`.
* `_Range?`: Optional validation for `Range`.
* `_Rational?`: Optional validation for `Rational`.
* `_Set?`: Optional validation for `Set`.

## Key Features

* Consistent type definitions for specialized data types.
* Robust and extensible validations with nilable options.
* Seamless integration with existing Domainic type patterns.
* User-friendly constraints for enhanced validation scenarios.

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass.
* [x] I have added/updated tests that prove my fix/feature works.
* [x] I have added/updated documentation as needed.

## Additional Notes

These additions significantly enhance Domainic's type validation system, providing a flexible and consistent interface for specialized data types like `BigDecimal`, `Complex`, `Range`, `Rational`, and `Set`. The integration ensures compatibility with Domainic's extensible and robust type system.