### PR TITLE
Fix `Domainic::Type::NorConstraint`

### DIFF
--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### [Unreleased]
 
+#### Fixed
+
+* [#164](https://github.com/domainic/domainic/pull/164) fixed `Domainic::Type::Constraint::NorConstraint` now prefixes
+  "not" to it's short description when only one constraint is given.
+
 ### [0.1.0-alpha.3.3.0] - 2024-12-27
 
 #### Added

--- a/domainic-type/lib/domainic/type/constraint/constraints/nor_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/nor_constraint.rb
@@ -39,7 +39,7 @@ module Domainic
         # @rbs override
         def short_description
           descriptions = @expected.map(&:short_description)
-          return descriptions.first if descriptions.size == 1
+          return "not #{descriptions.first}" if descriptions.size == 1
 
           *first, last = descriptions
           "#{first.join(', ')} nor #{last}"

--- a/domainic-type/spec/domainic/type/constraint/nor_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/nor_constraint_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Domainic::Type::Constraint::NorConstraint do
 
       it 'is expected to add the constraints to the list' do
         expecting
-        expect(constraint.short_description).to eq('be a string')
+        expect(constraint.short_description).to eq('not be a string')
       end
 
       context 'when adding another valid constraint' do
@@ -136,7 +136,7 @@ RSpec.describe Domainic::Type::Constraint::NorConstraint do
       let(:constraint) { described_class.new(:self).expecting([string_constraint]) }
 
       it 'is expected to return the single constraint short_description' do
-        expect(short_description).to eq('be a string')
+        expect(short_description).to eq('not be a string')
       end
     end
   end


### PR DESCRIPTION
Updated the `NorConstraint` to prepend "not" to the short description when a single constraint is applied, clarifying error messages for negated validations.

This addresses a bug where the error message for constraints like `not_matching` was ambiguous and suggested the opposite behavior.

Changes include:

* Updated `NorConstraint#short_description` to prepend "not" for single constraints.
* Adjusted specs to reflect the new behavior for single constraints.

Changelog:

* fixed `Domainic::Type::Constraint::NorConstraint#short_description` to prepend "not" for single constraints.

fixes #163