### PR TITLE
Add `Domainic::Type::Constraint::PredicateConstraint` and satisfies method

### DIFF
--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### [Unreleased]
 
+#### Added
+
+* [#165](https://github.com/domainic/domainic/pull/165) added `Domainic::Type::Constraint::PredicateConstraint` and
+  `Domainic::Type::Behavior#satisfies` to allow for custom constraints.
+
 #### Fixed
 
 * [#164](https://github.com/domainic/domainic/pull/164) fixed `Domainic::Type::Constraint::NorConstraint` now prefixes

--- a/domainic-type/lib/domainic/type/behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior.rb
@@ -186,6 +186,22 @@ module Domainic
         end
       end
 
+      # Add a custom constraint to this type.
+      #
+      # @param proc [Proc] the constraint to add
+      # @param accessor [Type::Accessor] the accessor to constrain
+      # @param options [Hash{Symbol => Object}] additional constraint options
+      #
+      # @return [self] for chaining constraints
+      # @rbs (
+      #   Proc proc,
+      #   ?accessor: Type::accessor,
+      #   **untyped options
+      #   ) -> Behavior
+      def satisfies(proc, accessor: :self, **options)
+        constrain accessor, :predicate, proc, **options
+      end
+
       # Convert the type to a String representation.
       #
       # @return [String] The type as a String

--- a/domainic-type/lib/domainic/type/config/registry.yml
+++ b/domainic-type/lib/domainic/type/config/registry.yml
@@ -62,6 +62,9 @@ constraints:
   polarity:
     constant: Domainic::Type::Constraint::PolarityConstraint
     require_path: domainic/type/constraint/constraints/polarity_constraint
+  predicate:
+    constant: Domainic::Type::Constraint::PredicateConstraint
+    require_path: domainic/type/constraint/constraints/predicate_constraint
   range:
     constant: Domainic::Type::Constraint::RangeConstraint
     require_path: domainic/type/constraint/constraints/range_constraint

--- a/domainic-type/lib/domainic/type/constraint/constraints/predicate_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/predicate_constraint.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'domainic/type/constraint/behavior'
+
+module Domainic
+  module Type
+    module Constraint
+      # A constraint for validating values using a custom predicate function.
+      #
+      # This constraint allows for custom validation logic through a Proc that returns
+      # a boolean value. It enables users to create arbitrary validation rules when
+      # the built-in constraints don't cover their specific needs.
+      #
+      # @example Basic usage
+      #   constraint = PredicateConstraint.new(:self, ->(x) { x > 0 })
+      #   constraint.satisfied?(1)   # => true
+      #   constraint.satisfied?(-1)  # => false
+      #
+      # @example With custom violation description
+      #   constraint = PredicateConstraint.new(:self, ->(x) { x > 0 }, violation_description: 'not greater than zero')
+      #   constraint.satisfied?(-1)  # => false
+      #   constraint.short_violation_description  # => "not greater than zero"
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class PredicateConstraint
+        # @rbs!
+        #   type expected = ^(untyped value) -> bool
+        #
+        #   type options = { ?violation_description: String}
+
+        include Behavior #[expected, untyped, options]
+
+        # Get a description of what the constraint expects.
+        #
+        # @note This constraint type does not provide a description as predicates are arbitrary.
+        #
+        # @return [String] an empty string
+        # @rbs override
+        def short_description = ''
+
+        # Get a description of why the predicate validation failed.
+        #
+        # @return [String] the custom violation description if provided
+        # @rbs override
+        def short_violation_description
+          # @type ivar @options: { ?violation_description: String }
+          @options.fetch(:violation_description, '')
+        end
+
+        protected
+
+        # Check if the value satisfies the predicate function.
+        #
+        # @return [Boolean] true if the predicate returns true
+        # @rbs override
+        def satisfies_constraint?
+          @expected.call(@actual)
+        end
+
+        # Validate that the expectation is a Proc.
+        #
+        # @param expectation [Object] the expectation to validate
+        #
+        # @raise [ArgumentError] if the expectation is not a Proc
+        # @return [void]
+        # @rbs override
+        def validate_expectation!(expectation)
+          return if expectation.is_a?(Proc)
+
+          raise ArgumentError, 'Expectation must be a Proc'
+        end
+      end
+    end
+  end
+end

--- a/domainic-type/sig/domainic/type/behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior.rbs
@@ -125,6 +125,15 @@ module Domainic
       # @return [void]
       def initialize: (**untyped) -> void
 
+      # Add a custom constraint to this type.
+      #
+      # @param proc [Proc] the constraint to add
+      # @param accessor [Type::Accessor] the accessor to constrain
+      # @param options [Hash{Symbol => Object}] additional constraint options
+      #
+      # @return [self] for chaining constraints
+      def satisfies: (Proc proc, ?accessor: Type::accessor, **untyped options) -> Behavior
+
       # Convert the type to a String representation.
       #
       # @return [String] The type as a String

--- a/domainic-type/sig/domainic/type/constraint/constraints/predicate_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/predicate_constraint.rbs
@@ -1,0 +1,56 @@
+module Domainic
+  module Type
+    module Constraint
+      # A constraint for validating values using a custom predicate function.
+      #
+      # This constraint allows for custom validation logic through a Proc that returns
+      # a boolean value. It enables users to create arbitrary validation rules when
+      # the built-in constraints don't cover their specific needs.
+      #
+      # @example Basic usage
+      #   constraint = PredicateConstraint.new(:self, ->(x) { x > 0 })
+      #   constraint.satisfied?(1)   # => true
+      #   constraint.satisfied?(-1)  # => false
+      #
+      # @example With custom violation description
+      #   constraint = PredicateConstraint.new(:self, ->(x) { x > 0 }, violation_description: 'not greater than zero')
+      #   constraint.satisfied?(-1)  # => false
+      #   constraint.short_violation_description  # => "not greater than zero"
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      class PredicateConstraint
+        type expected = ^(untyped value) -> bool
+
+        type options = { ?violation_description: String }
+
+        include Behavior[expected, untyped, options]
+
+        # Get a description of what the constraint expects.
+        #
+        # @note This constraint type does not provide a description as predicates are arbitrary.
+        #
+        # @return [String] an empty string
+        def short_description: ...
+
+        # Get a description of why the predicate validation failed.
+        #
+        # @return [String] the custom violation description if provided
+        def short_violation_description: ...
+
+        # Check if the value satisfies the predicate function.
+        #
+        # @return [Boolean] true if the predicate returns true
+        def satisfies_constraint?: ...
+
+        # Validate that the expectation is a Proc.
+        #
+        # @param expectation [Object] the expectation to validate
+        #
+        # @raise [ArgumentError] if the expectation is not a Proc
+        # @return [void]
+        def validate_expectation!: ...
+      end
+    end
+  end
+end

--- a/domainic-type/spec/domainic/type/behavior_spec.rb
+++ b/domainic-type/spec/domainic/type/behavior_spec.rb
@@ -150,6 +150,59 @@ RSpec.describe Domainic::Type::Behavior do
     end
   end
 
+  describe '#satisfies' do
+    subject(:satisfies) { type.satisfies(predicate, **options) }
+
+    let(:type) { TestType.new }
+    let(:options) { {} }
+
+    before do
+      allow(Domainic::Type::Constraint::Resolver).to receive(:resolve!)
+        .with(:predicate)
+        .and_return(TestConstraint)
+    end
+
+    context 'with a basic predicate' do
+      let(:predicate) { lambda(&:positive?) }
+
+      it 'is expected to add a predicate constraint' do
+        expect(satisfies).to be_a(TestType)
+      end
+
+      it 'is expected to constrain with the :predicate type' do
+        allow(type).to receive(:constrain).and_call_original
+        satisfies
+
+        expect(type).to have_received(:constrain).with(:self, :predicate, predicate)
+      end
+    end
+
+    context 'with custom accessor' do
+      let(:predicate) { lambda(&:positive?) }
+      let(:options) { { accessor: :length } }
+
+      it 'is expected to constrain the specified accessor' do
+        allow(type).to receive(:constrain).and_call_original
+        satisfies
+
+        expect(type).to have_received(:constrain).with(:length, :predicate, predicate)
+      end
+    end
+
+    context 'with additional options' do
+      let(:predicate) { lambda(&:positive?) }
+      let(:options) { { violation_description: 'not positive' } }
+
+      it 'is expected to pass options to constrain' do
+        allow(type).to receive(:constrain).and_call_original
+        satisfies
+
+        expect(type).to have_received(:constrain)
+          .with(:self, :predicate, predicate, violation_description: 'not positive')
+      end
+    end
+  end
+
   describe '#to_s' do
     subject(:to_string) { type.to_s }
 

--- a/domainic-type/spec/domainic/type/constraint/predicate_constraint_spec.rb
+++ b/domainic-type/spec/domainic/type/constraint/predicate_constraint_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'domainic/type/constraint/constraints/predicate_constraint'
+
+RSpec.describe Domainic::Type::Constraint::PredicateConstraint do
+  describe '.expecting' do
+    subject(:expecting) { described_class.new(:self).expecting(expectation) }
+
+    context 'when given a Proc' do
+      let(:expectation) { lambda(&:positive?) }
+
+      it 'is expected not to raise an error' do
+        expect { expecting }.not_to raise_error
+      end
+    end
+
+    context 'when given something other than a Proc', rbs: :skip do
+      let(:expectation) { 'not a proc' }
+
+      it 'is expected to raise an ArgumentError' do
+        expect { expecting }
+          .to raise_error(ArgumentError, 'Expectation must be a Proc')
+      end
+    end
+  end
+
+  describe '#satisfied?' do
+    subject(:satisfied?) { constraint.satisfied?(actual_value) }
+
+    let(:constraint) { described_class.new(:self).expecting(predicate) }
+
+    context 'with a simple numeric predicate' do
+      let(:predicate) { lambda(&:positive?) }
+
+      context 'when the predicate returns true' do
+        let(:actual_value) { 1 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the predicate returns false' do
+        let(:actual_value) { -1 }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with a complex object predicate' do
+      let(:point_class) { Struct.new(:x, :y) }
+      let(:predicate) { ->(point) { point.x == point.y } }
+
+      context 'when the predicate returns true' do
+        let(:actual_value) { point_class.new(1, 1) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the predicate returns false' do
+        let(:actual_value) { point_class.new(1, 2) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#short_description' do
+    subject(:short_description) { constraint.short_description }
+
+    let(:constraint) { described_class.new(:self) }
+
+    it { is_expected.to eq('') }
+  end
+
+  describe '#short_violation_description' do
+    subject(:short_violation_description) { constraint.short_violation_description }
+
+    let(:constraint) do
+      described_class.new(:self).with_options(**options)
+    end
+
+    context 'when a violation description is provided' do
+      let(:options) { { violation_description: 'not greater than zero' } }
+
+      it { is_expected.to eq('not greater than zero') }
+    end
+
+    context 'when no violation description is provided' do
+      let(:options) { {} }
+
+      it { is_expected.to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
## Description

This introduces a new custom validation mechanism through two key components:

1. A `PredicateConstraint` class that enables custom validation using Procs
2. A `satisfies` method on `Type::Behavior` that provides a natural API for using these custom validations

This addition gives users an escape hatch for complex validation scenarios that aren't covered by the built-in constraints, while maintaining the type system's ergonomics and error handling.

## Changes Made

* Added `PredicateConstraint` class for custom Proc-based validation
* Added `satisfies` method to `Type::Behavior` for ergonomic predicate constraints
* Added comprehensive specs for both components
* Added RBS type signatures
* Updated constraint registry to include PredicateConstraint

Example usage:

```ruby
# Basic predicate validation
_Integer.satisfies(->(x) { x.prime? })

# With custom accessors
_Array.satisfies(->(x) { x.ascending? }, accessor: :values)

# With violation descriptions
_String.satisfies(->(x) { x.valid_xml? }, 
  violation_description: 'invalid XML')
```

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed