### PR TITLE
Enhance GemGenerator to create additional configuration files

### DIFF
--- a/domainic-dev/.gitignore
+++ b/domainic-dev/.gitignore
@@ -1,0 +1,56 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*

--- a/domainic-dev/.yardopts
+++ b/domainic-dev/.yardopts
@@ -1,0 +1,11 @@
+--title Domainic::Dev
+--readme README.md
+--no-private
+--protected
+--markup markdown
+--markup-provider redcarpet
+--embed-mixins
+--tag rbs
+--hide-tag rbs
+--files LICENSE
+'lib/**/*.rb'

--- a/domainic-dev/domainic-dev.gemspec
+++ b/domainic-dev/domainic-dev.gemspec
@@ -14,10 +14,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.1'
 
-  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == File.basename(__FILE__)) || f.start_with?(*%w[bin/ test/ spec/ features/ .git appveyor Gemfile])
-    end
+  spec.files = Dir.chdir(__dir__) do
+    Dir['{exe,lib,sig}/**/*', '.yardopts', 'LICENSE', 'README.md'].reject { |f| File.directory?(f) }
   end
 
   spec.bindir        = 'exe'

--- a/domainic-dev/lib/domainic/dev/generator/gem_generator.rb
+++ b/domainic-dev/lib/domainic/dev/generator/gem_generator.rb
@@ -53,6 +53,14 @@ module Domainic
           template('gemspec.erb', "#{name}/#{name}.gemspec") # steep:ignore NoMethod
         end
 
+        # Create the gem's gitignore file.
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_gitignore
+          template('.gitignore', "#{name}/.gitignore") # steep:ignore NoMethod
+        end
+
         # Create the gem's LICENSE file.
         #
         # @return [void]
@@ -112,6 +120,14 @@ module Domainic
         # @rbs () -> void
         def create_spec_helper
           template('spec/spec_helper.rb.erb', "#{name}/spec/spec_helper.rb") # steep:ignore NoMethod
+        end
+
+        # Create the gem's .yardopts file.
+        #
+        # @return [void]
+        # @rbs () -> void
+        def create_yardopts
+          template('.yardopts', "#{name}/.yardopts") # steep:ignore NoMethod
         end
 
         # Generate RBS signatures for the new gem.

--- a/domainic-dev/lib/domainic/dev/generator/templates/gem/.gitignore
+++ b/domainic-dev/lib/domainic/dev/generator/templates/gem/.gitignore
@@ -1,0 +1,56 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*

--- a/domainic-dev/lib/domainic/dev/generator/templates/gem/.yardopts.erb
+++ b/domainic-dev/lib/domainic/dev/generator/templates/gem/.yardopts.erb
@@ -1,0 +1,11 @@
+--title <%= module_name %>
+--readme README.md
+--no-private
+--protected
+--markup markdown
+--markup-provider redcarpet
+--embed-mixins
+--tag rbs
+--hide-tag rbs
+--files CHANGELOG.md,LICENSE
+'lib/**/*.rb'

--- a/domainic-dev/lib/domainic/dev/generator/templates/gem/gemspec.erb
+++ b/domainic-dev/lib/domainic/dev/generator/templates/gem/gemspec.erb
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   spec.files = Dir.chdir(__dir__) do
-    Dir['{lib,sig}/**/*', 'LICENSE', 'README.md', 'CHANGELOG.md'].reject { |f| File.directory?(f) }
+    Dir['{lib,sig}/**/*', '.yardopts', 'LICENSE', 'README.md', 'CHANGELOG.md'].reject { |f| File.directory?(f) }
   end
   spec.require_paths = ['lib']
 
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
     'bug_tracker_uri' => "#{<%= constant_name %>_REPO_URL}/issues",
     'changelog_uri' => "#{<%= constant_name %>_REPO_URL}/releases/tag/<%= name %>-v" \
                        "#{<%= constant_name %>_SEMVER}",
+    'documentation_uri' => "https://rubydoc.info/gems/<%= name %>/<%= constant_name %>_GEM_VERSION",
     'homepage_uri' => <%= constant_name %>_HOME_URL,
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => "#{<%= constant_name %>_REPO_URL}/tree/<%= name %>-v" \

--- a/domainic-dev/sig/domainic/dev/generator/gem_generator.rbs
+++ b/domainic-dev/sig/domainic/dev/generator/gem_generator.rbs
@@ -36,6 +36,11 @@ module Domainic
         # @return [void]
         def create_gemspec: () -> void
 
+        # Create the gem's gitignore file.
+        #
+        # @return [void]
+        def create_gitignore: () -> void
+
         # Create the gem's LICENSE file.
         #
         # @return [void]
@@ -70,6 +75,11 @@ module Domainic
         #
         # @return [void]
         def create_spec_helper: () -> void
+
+        # Create the gem's .yardopts file.
+        #
+        # @return [void]
+        def create_yardopts: () -> void
 
         # Generate RBS signatures for the new gem.
         #

--- a/domainic-type/.gitignore
+++ b/domainic-type/.gitignore
@@ -1,0 +1,56 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*

--- a/domainic-type/.yardopts
+++ b/domainic-type/.yardopts
@@ -1,0 +1,11 @@
+--title Domainic::Type
+--readme README.md
+--no-private
+--protected
+--markup markdown
+--markup-provider redcarpet
+--embed-mixins
+--tag rbs
+--hide-tag rbs
+--files CHANGELOG.md,LICENSE,docs/USAGE.md
+'lib/**/*.rb'

--- a/domainic-type/domainic-type.gemspec
+++ b/domainic-type/domainic-type.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   spec.files = Dir.chdir(__dir__) do
-    Dir['{docs,lib,sig}/**/*', 'LICENSE', 'README.md', 'CHANGELOG.md'].reject { |f| File.directory?(f) }
+    Dir['{docs,lib,sig}/**/*', '.yardopts', 'LICENSE', 'README.md', 'CHANGELOG.md'].reject { |f| File.directory?(f) }
   end
   spec.require_paths = ['lib']
 
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
     'bug_tracker_uri' => "#{DOMAINIC_TYPE_REPO_URL}/issues",
     'changelog_uri' => "#{DOMAINIC_TYPE_REPO_URL}/releases/tag/domainic-type-v" \
                        "#{DOMAINIC_TYPE_SEMVER}",
+    'documentation_uri' => "https://rubydoc.info/gems/domainic-type/#{DOMAINIC_TYPE_GEM_VERSION}",
     'homepage_uri' => DOMAINIC_TYPE_HOME_URL,
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => "#{DOMAINIC_TYPE_REPO_URL}/tree/domainic-type-v" \


### PR DESCRIPTION
Update GemGenerator to create .gitignore and .yardopts files for new gems, ensuring consistent configuration across the project. Also updates the gemspec template to include documentation_uri and properly package documentation files.

Related gemspecs updated to match the new structure for consistency.