### PR TITLE
Remove implicit RSpec dependency from `BelongsToAttribute`

### DIFF
--- a/domainic-attributer/CHANGELOG.md
+++ b/domainic-attributer/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 * [#18](https://github.com/domainic/domainic/pull/18) `Domainic::Attributer::Attribute::Coercer#call` will no longer
   attempt to coerce nil values when the attribute is not nilable. While small this is technically a breaking change.
+* [#169](https://github.com/domainic/domainic/pull/169) removed implicit dependency on RSpec from
+  `Domainic::Attributer::Attribute::BelongsToAttribute`
 
 ### Fixed
 

--- a/domainic-attributer/lib/domainic/attributer/attribute/mixin/belongs_to_attribute.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute/mixin/belongs_to_attribute.rb
@@ -60,7 +60,6 @@ module Domainic
         # @rbs (Attribute attribute) -> void
         def validate_attribute!(attribute)
           return if attribute.is_a?(Attribute)
-          return if defined?(RSpec::Mocks::TestDouble) && attribute.is_a?(RSpec::Mocks::TestDouble)
 
           raise TypeError,
                 "invalid attribute: #{attribute.inspect}. Must be an Domainic::Attributer::Attribute instance"

--- a/domainic-attributer/spec/domainic/attributer/attribute/callback_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/attribute/callback_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Domainic::Attributer::Attribute::Callback do
   let(:attribute) { instance_double(Domainic::Attributer::Attribute, base: Class.new, name: :test) }
   let(:handlers) { [] }
 
+  before do
+    allow(attribute).to receive(:is_a?).with(Domainic::Attributer::Attribute).and_return(true)
+  end
+
   describe '.new' do
     subject(:callback) { described_class.new(attribute, handlers) }
 

--- a/domainic-attributer/spec/domainic/attributer/attribute/coercer_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/attribute/coercer_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Domainic::Attributer::Attribute::Coercer do
     end
   end
 
+  before do
+    allow(attribute).to receive(:is_a?).with(Domainic::Attributer::Attribute).and_return(true)
+  end
+
   describe '.new' do
     subject(:coercer) { described_class.new(attribute, handlers) }
 

--- a/domainic-attributer/spec/domainic/attributer/attribute/signature_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/attribute/signature_spec.rb
@@ -5,6 +5,10 @@ require 'spec_helper'
 RSpec.describe Domainic::Attributer::Attribute::Signature do
   let(:attribute) { instance_double(Domainic::Attributer::Attribute, base: Class.new, name: :test) }
 
+  before do
+    allow(attribute).to receive(:is_a?).with(Domainic::Attributer::Attribute).and_return(true)
+  end
+
   describe '.new' do
     subject(:signature) { described_class.new(attribute, **options) }
 

--- a/domainic-attributer/spec/domainic/attributer/attribute/validator_spec.rb
+++ b/domainic-attributer/spec/domainic/attributer/attribute/validator_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Domainic::Attributer::Attribute::Validator do
   let(:attribute) { instance_double(Domainic::Attributer::Attribute, base: test_class, name: :test) }
   let(:test_class) { Class.new }
 
+  before do
+    allow(attribute).to receive(:is_a?).with(Domainic::Attributer::Attribute).and_return(true)
+  end
+
   describe '.new' do
     subject(:validator) { described_class.new(attribute, handlers) }
 


### PR DESCRIPTION
Removes special case handling of RSpec test doubles in the BelongsToAttribute#validate_attribute! method, eliminating an implicit dependency on RSpec. Updates related specs to properly stub the is_a? check instead.

This change improves the separation between production and test code by removing test framework specific code from the core library.

Changelog:
  * removed RSpec::Mocks::TestDouble check from `Domainic::Attributer::Attribute::BelongsToAttribute#validate_attribute!`