### PR TITLE
Fix date parsing ambiguity in DateTimeBehavior

### DIFF
--- a/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
+++ b/docs/experiments/domainic-type-alpha-3/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * [#164](https://github.com/domainic/domainic/pull/164) fixed `Domainic::Type::Constraint::NorConstraint` now prefixes
   "not" to it's short description when only one constraint is given.
+* [#179](https://github.com/domainic/domainic/pull/179) fixed date parsing ambiguity in DateTimeBehavior
 
 ### [0.1.0-alpha.3.3.0] - 2024-12-27
 

--- a/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb
@@ -103,10 +103,14 @@ module Domainic
             Time.at(value).to_datetime
           when String
             DATETIME_PATTERNS.each do |pattern|
-              return DateTime.strptime(value, pattern)
+              result = DateTime.strptime(value, pattern)
+              # Validate the parsing preserved the original values by reformatting
+              # the result with the same pattern and comparing
+              return result if value == result.strftime(pattern)
             rescue ArgumentError
               next
             end
+            DateTime.parse(value) # Fallback to Ruby's built-in parser and allow it to raise.
           else
             DateTime.parse(value) # Fallback to Ruby's built-in parser and allow it to raise.
           end

--- a/domainic-type/spec/domainic/type/behavior/date_time_behavior_spec.rb
+++ b/domainic-type/spec/domainic/type/behavior/date_time_behavior_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe Domainic::Type::Behavior::DateTimeBehavior do
 
     described_class::DATETIME_PATTERNS.each do |pattern|
       context "when given a string matching #{pattern}" do
-        subject(:validation) { type.being_between(reference_before_date, reference_after_date).validate(value) }
+        subject(:validation) { type.being_between(reference_after_date, reference_before_date).validate(value) }
 
-        let(:reference_before_date) { DateTime.now.strftime(pattern) }
-        let(:reference_after_date) { (DateTime.now + 2).strftime(pattern) }
+        let(:reference_after_date) { DateTime.now.strftime(pattern) }
+        let(:reference_before_date) { (DateTime.now + 2).strftime(pattern) }
         let(:value) { (DateTime.now + 1).strftime(pattern) }
 
         it { is_expected.to be true }


### PR DESCRIPTION
Fixes an issue where the TO_DATETIME_COERCER would incorrectly parse dates by validating pattern matches using a reversible format check. This ensures the parsed date maintains the values from the original string.

The bug was particularly visible at the end of months where the day number could be misinterpreted as a year when using the wrong date pattern (e.g.,"29-12-2024" being parsed as year 29, month 12, day 20).

Changelog:

  * fixed `Domainic::Type::Behavior::DateTimeBehavio::TO_DATETIME_COERCER` now validates pattern matches by comparing the reformatted result against the original input