### PR TITLE
Fix gem generator templates and milestone formatting

### DIFF
--- a/docs/milestones/domainic-command-v0.2.0.md
+++ b/docs/milestones/domainic-command-v0.2.0.md
@@ -1,4 +1,4 @@
-# domainic-command-v0.2.0
+# domainic-command v0.2.0
 
 ![Milestone Status](https://img.shields.io/badge/In%20Progress-orange?style=for-the-badge&label=Status)
 [![Milestone Progress](https://img.shields.io/github/milestones/progress-percent/domainic/domainic/10?style=for-the-badge&label=Progress)](https://github.com/domainic/domainic/milestone/10)

--- a/domainic-dev/lib/domainic/dev/generator/gem_generator.rb
+++ b/domainic-dev/lib/domainic/dev/generator/gem_generator.rb
@@ -127,7 +127,7 @@ module Domainic
         # @return [void]
         # @rbs () -> void
         def create_yardopts
-          template('.yardopts', "#{name}/.yardopts") # steep:ignore NoMethod
+          template('.yardopts.erb', "#{name}/.yardopts") # steep:ignore NoMethod
         end
 
         # Generate RBS signatures for the new gem.

--- a/domainic-dev/lib/domainic/dev/generator/templates/gem/gemspec.erb
+++ b/domainic-dev/lib/domainic/dev/generator/templates/gem/gemspec.erb
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     'bug_tracker_uri' => "#{<%= constant_name %>_REPO_URL}/issues",
     'changelog_uri' => "#{<%= constant_name %>_REPO_URL}/releases/tag/<%= name %>-v" \
                        "#{<%= constant_name %>_SEMVER}",
-    'documentation_uri' => "https://rubydoc.info/gems/<%= name %>/<%= constant_name %>_GEM_VERSION",
+    'documentation_uri' => "https://rubydoc.info/gems/<%= name %>/#{<%= constant_name %>_GEM_VERSION}",
     'homepage_uri' => <%= constant_name %>_HOME_URL,
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => "#{<%= constant_name %>_REPO_URL}/tree/<%= name %>-v" \


### PR DESCRIPTION
Update gem generator templates to fix interpolation and naming issues:
* Fix documentation_uri in gemspec.erb to properly interpolate version
* Fix "Could not find ".yardopts" in any of your source paths." error

Changelog:

* changed `Generator::GemGenerator#create_yardopts`
* fixed gemspec.erb template
* updated milestone formatting in docs/milestones/domainic-command-v0.2.0.md