### PR TITLE
Release domainic-type v0.1.0.alpha.3.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       domainic-type (~> 0.1.0.alpha.3)
     domainic-attributer (0.2.0)
     domainic-command (0.1.0)
-    domainic-type (0.1.0.alpha.3.4.0)
+    domainic-type (0.1.0.alpha.3.4.1)
 
 PATH
   remote: domainic-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ documentation across the Domainic ecosystem.
 ### Experimental
 
 * [**domainic-type**](../domainic-type/README.md) - Flexible type validation system
-  * **Current Version**: 0.1.0-alpha.3.4.0
+  * **Current Version**: 0.1.0-alpha.3.4.1
   * [Experiment Details](./experiments/domainic-type-v0.1.0-alpha/README.md)
 
 ### In Development

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,8 +65,8 @@ If you have suggestions on how this process could be improved, please submit a p
 
 |        Version        | Support |
 |:---------------------:|:-------:|
-|  `0.1.0-alpha.3.4.0`  |   🧪    |
-| `> 0.1.0-alpha.3.4.0` |    ❌   |
+|  `0.1.0-alpha.3.4.1`  |   🧪    |
+| `> 0.1.0-alpha.3.4.1` |    ❌   |
 
 ### Key
 

--- a/docs/experiments/domainic-type-v0.1.0-alpha/CHANGELOG.md
+++ b/docs/experiments/domainic-type-v0.1.0-alpha/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### [Unreleased]
 
+### [v0.1.0-alpha.3.4.1] - 2024-12-31
+
 #### Deprecated
 
 * [#186](https://github.com/domainic/domainic/pull/186) deprecated description methods in
@@ -91,9 +93,10 @@
 
 > [!NOTE]
 > As this is an experimental release, features may change significantly based on feedback. Refer to
-> docs/experiments/domainic-type-v0.1.0-alpha.3/README.md for full details and current testing focus.
+> [Domainic::Type v0.1.0 Alpha](README.md) for full details and current testing focus.
 
-[Unreleased]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.4.0...HEAD
+[Unreleased]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.4.1...HEAD
+[v0.1.0-alpha.3.4.1]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.4.0...domainic-type-v0.1.0-alpha.3.4.1
 [v0.1.0-alpha.3.4.0]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.3.0...domainic-type-v0.1.0-alpha.3.4.0
 [v0.1.0-alpha.3.3.0]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.2.0...domainic-type-v0.1.0-alpha.3.3.0
 [v0.1.0-alpha.3.2.0]: https://github.com/domainic/domainic/compare/domainic-type-v0.1.0-alpha.3.1.0...domainic-type-v0.1.0-alpha.3.2.0

--- a/docs/experiments/domainic-type-v0.1.0-alpha/CHANGELOG.md
+++ b/docs/experiments/domainic-type-v0.1.0-alpha/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### [Unreleased]
 
-#### [v0.1.0-alpha.3.4.0] - 2024-12-30
+#### Deprecated
+
+* [#186](https://github.com/domainic/domainic/pull/186) deprecated description methods in
+  `Domainic::Type::Constraint::Behavior` and `Domainic::Type::Constraint::Set` as we will be moving description logic
+  out of constraints in the alpha 4 release. Use `RUBYOPT="-W0"` to suppress warnings.
+
+### [v0.1.0-alpha.3.4.0] - 2024-12-30
 
 #### Added
 

--- a/docs/experiments/domainic-type-v0.1.0-alpha/EXAMPLES.md
+++ b/docs/experiments/domainic-type-v0.1.0-alpha/EXAMPLES.md
@@ -364,9 +364,9 @@ also known as `_List`, `_Array?`, `_List?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Array` type provides comprehensive validation for array values with constraints for content, ordering, and size.
@@ -403,7 +403,7 @@ also known as `_BigDecimal?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_BigDecimal` type provides precise decimal arithmetic validation with comprehensive numeric constraints:
@@ -477,7 +477,7 @@ also known as `_Date?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
+> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Date` type validates date values with comprehensive constraints for range:
@@ -502,7 +502,7 @@ also known as `_DateTime?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
+> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_DateTime` type validates datetime values with comprehensive constraints for range:
@@ -527,7 +527,7 @@ also known as `_DateString`, `_DateTimeString?`, `_DateString?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
+> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_DateTimeString` type validates strings containing date and time information in various formats. It inherits all
@@ -570,9 +570,9 @@ also known as `_Email`, `_EmailAddress?`, `_Email?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_EmailAddress` type validates email addresses according to RFC 5321 and 5322 standards. It includes comprehensive
@@ -616,7 +616,7 @@ also known as `_Decimal`, `_Real`, `_Float?`, `_Decimal?`, `_Real?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Float` type validates floating-point numbers with comprehensive numeric constraints:
@@ -650,9 +650,9 @@ also known as `_Map`, `_Hash?`, `_Map?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb),
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb),
-> and [HashType](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/types/core/hash_type.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb),
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb),
+> and [HashType](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/types/core/hash_type.rb)
 > for the full list of available methods and aliases!
 
 The `_Hash` type provides validation for hash structures with constraints for keys, values, and overall composition:
@@ -688,9 +688,9 @@ also known as `_Hostname?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Hostname` type validates hostnames according to RFC 1034 and 1123 standards. It supports all string constraints in
@@ -749,7 +749,7 @@ also known as `_Int`, `_Integer?`, `_Int?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Integer` type validates integer values with comprehensive numeric constraints:
@@ -801,7 +801,7 @@ also known as `_Range?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Range` type validates Ruby Range objects:
@@ -825,7 +825,7 @@ also known as `_Rational?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
+> [NumericBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/numeric_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Rational` type validates rational numbers with comprehensive numeric constraints:
@@ -850,7 +850,7 @@ also known as `_Set?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
+> [EnumerableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Set` type validates Ruby Set objects:
@@ -876,9 +876,9 @@ also known as `_Text`, `_String?`, `_Text?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_String` type validates string values with comprehensive text manipulation constraints:
@@ -915,9 +915,9 @@ also known as `_Interned`, `_Symbol?`, `_Interned?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizeableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Symbol` type validates symbols and supports all string-like constraints applied to the symbol's name:
@@ -944,7 +944,7 @@ also known as `_Time?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
+> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Time` type validates time values with comprehensive constraints for range:
@@ -969,7 +969,7 @@ also known as `_Timestamp?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
+> [DateTimeBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/date_time_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_Timestamp` type validates Unix timestamps:
@@ -1038,9 +1038,9 @@ also known as `_URL`, `_Uri`, `_Url`, `URI?`, `_URL?`, `_Uri?`, `_Url?`
 > [!TIP]
 > Many constraints have aliases to allow you to express your intent in a way that best maps to your mental model.
 > Checkout the documentation for
-> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
+> [StringBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/string_behavior.rb)
 > and
-> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.0/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
+> [SizableBehavior](https://github.com/domainic/domainic/blob/domainic-type-v0.1.0-alpha.3.4.1/domainic-type/lib/domainic/type/behavior/sizeable_behavior.rb)
 > for the full list of available methods and aliases!
 
 The `_URI` type validates URIs according to RFC 3986 standards. In addition to URI-specific validation, it supports all

--- a/domainic-type/domainic-type.gemspec
+++ b/domainic-type/domainic-type.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.4.0'
-DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.4.0'
+DOMAINIC_TYPE_GEM_VERSION = '0.1.0.alpha.3.4.1'
+DOMAINIC_TYPE_SEMVER = '0.1.0-alpha.3.4.1'
 DOMAINIC_TYPE_REPO_URL = 'https://github.com/domainic/domainic'
 DOMAINIC_TYPE_HOME_URL = "#{DOMAINIC_TYPE_REPO_URL}/tree/domainic-type-v" \
                          "#{DOMAINIC_TYPE_SEMVER}/domainic-type".freeze

--- a/domainic-type/lib/domainic/type/constraint/behavior.rb
+++ b/domainic-type/lib/domainic/type/constraint/behavior.rb
@@ -53,6 +53,9 @@ module Domainic
         # @rbs!
         #   type options = { ?abort_on_failure: bool, ?coerce_with: Array[Proc] | Proc }
 
+        # @rbs skip
+        extend Gem::Deprecate
+
         # @rbs @accessor: Type::accessor
         # @rbs @actual: Actual
         # @rbs @expected: Expected
@@ -120,19 +123,25 @@ module Domainic
 
         # The full description of the constraint.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String, nil] The full description of the constraint.
         # @rbs () -> String?
         def full_description
           full_description_for(short_description)
         end
+        deprecate :full_description, :none, 2025, 3 # steep:ignore
 
         # The full description of the violations that caused the constraint to be unsatisfied.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String, nil] The full description of the constraint when it fails.
         # @rbs () -> String?
         def full_violation_description
           full_description_for(short_violation_description)
         end
+        deprecate :full_violation_description, :none, 2025, 3 # steep:ignore
 
         # Whether the constraint is satisfied.
         #
@@ -161,22 +170,28 @@ module Domainic
         # Implementing classes should override this to provide meaningful descriptions of their
         # constraint behavior.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] The description of the constraint.
         # @rbs () -> String
         def short_description
           @expected.to_s
         end
+        deprecate :short_description, :none, 2025, 3 # steep:ignore
 
         # The short description of the violations that caused the constraint to be unsatisfied.
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] The description of the constraint when it fails.
         # @rbs () -> String
         def short_violation_description
           @actual.to_s
         end
+        deprecate :short_violation_description, :none, 2025, 3 # steep:ignore
 
         # Whether the constraint is a success.
         #
@@ -309,6 +324,8 @@ module Domainic
         private
 
         # Generate the full description for the corresponding short description.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @param description [String] The short description to expand.
         #

--- a/domainic-type/lib/domainic/type/constraint/constraints/all_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/all_constraint.rb
@@ -30,6 +30,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] the constraint description
         # @rbs override
         def short_description
@@ -40,6 +42,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/and_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/and_constraint.rb
@@ -33,6 +33,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions with 'and'
         # @rbs override
         def short_description
@@ -50,6 +52,8 @@ module Domainic
         #
         # This method provides detailed feedback about which constraints failed,
         # listing all violations that prevented validation from succeeding.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all constraints
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/any_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/any_constraint.rb
@@ -32,6 +32,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions
         # @rbs override
         def short_description
@@ -42,6 +44,8 @@ module Domainic
         #
         # This method provides detailed feedback when no constraints are satisfied,
         # listing all the ways in which the value failed validation.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all constraints
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/attribute_presence_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/attribute_presence_constraint.rb
@@ -50,6 +50,8 @@ module Domainic
 
         # Get a description of what the constraint expects
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] the constraint description
         # @rbs override
         def short_description
@@ -57,6 +59,8 @@ module Domainic
         end
 
         # Get a description of why the constraint was violated
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] the violation description
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/case_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/case_constraint.rb
@@ -43,6 +43,8 @@ module Domainic
 
         # Get a human-readable description of the case requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = CaseConstraint.new(:self, :upper)
         #   constraint.short_description # => "upper case"
@@ -54,6 +56,8 @@ module Domainic
         end
 
         # Get a human-readable description of why case validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = CaseConstraint.new(:self, :upper)

--- a/domainic-type/lib/domainic/type/constraint/constraints/character_set_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/character_set_constraint.rb
@@ -51,6 +51,8 @@ module Domainic
 
         # Get a human-readable description of the character set requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = CharacterSetConstraint.new(:self, :numeric)
         #   constraint.short_description # => "only numeric characters"
@@ -62,6 +64,8 @@ module Domainic
         end
 
         # Get a human-readable description of why character validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = CharacterSetConstraint.new(:self, :numeric)

--- a/domainic-type/lib/domainic/type/constraint/constraints/divisibility_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/divisibility_constraint.rb
@@ -44,6 +44,8 @@ module Domainic
 
         # Get a human-readable description of the divisibility requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = DivisibilityConstraint.new(:self, 5)
         #   constraint.short_description # => "divisible by 5"
@@ -55,6 +57,8 @@ module Domainic
         end
 
         # Get a human-readable description of why divisibility validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example With non-numeric value
         #   constraint = DivisibilityConstraint.new(:self, 5)

--- a/domainic-type/lib/domainic/type/constraint/constraints/emptiness_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/emptiness_constraint.rb
@@ -28,6 +28,8 @@ module Domainic
 
         # Get a human-readable description of the emptiness requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = EmptinessConstraint.new(:self)
         #   constraint.description # => "empty"
@@ -39,6 +41,8 @@ module Domainic
         end
 
         # Get a human-readable description of why emptiness validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = EmptinessConstraint.new(:self)

--- a/domainic-type/lib/domainic/type/constraint/constraints/equality_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/equality_constraint.rb
@@ -34,6 +34,8 @@ module Domainic
 
         # Get a human-readable description of the equality requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = EqualityConstraint.new(:self, 42)
         #   constraint.description # => "equal to 42"
@@ -45,6 +47,8 @@ module Domainic
         end
 
         # Get a human-readable description of why equality validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = EqualityConstraint.new(:self, 42)

--- a/domainic-type/lib/domainic/type/constraint/constraints/finiteness_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/finiteness_constraint.rb
@@ -31,6 +31,8 @@ module Domainic
 
         # Get a human-readable description of the finiteness requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] Description of the finiteness requirement
         # @rbs override
         def short_description
@@ -38,6 +40,8 @@ module Domainic
         end
 
         # Get a human-readable description of why finiteness validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] Description of the validation failure
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/inclusion_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/inclusion_constraint.rb
@@ -33,6 +33,8 @@ module Domainic
 
         # Get a human-readable description of the inclusion requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = InclusionConstraint.new(:self, 42)
         #   constraint.short_description # => "including 42"
@@ -44,6 +46,8 @@ module Domainic
         end
 
         # Get a human-readable description of why inclusion validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = InclusionConstraint.new(:self, 42)

--- a/domainic-type/lib/domainic/type/constraint/constraints/instance_of_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/instance_of_constraint.rb
@@ -28,6 +28,8 @@ module Domainic
 
         # Get a human-readable description of the instance requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = InstanceOfConstraint.new(:self, String)
         #   constraint.description # => "instance of String"
@@ -39,6 +41,8 @@ module Domainic
         end
 
         # Get a human-readable description of why instance validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = InstanceOfConstraint.new(:self, String)

--- a/domainic-type/lib/domainic/type/constraint/constraints/match_pattern_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/match_pattern_constraint.rb
@@ -28,6 +28,8 @@ module Domainic
 
         # Get a human-readable description of the pattern requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = MatchPatternConstraint.new(:self, /\d+/)
         #   constraint.short_description # => "matches /\\d+/"
@@ -39,6 +41,8 @@ module Domainic
         end
 
         # Get a human-readable description of why pattern validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = MatchPatternConstraint.new(:self, /\d+/)

--- a/domainic-type/lib/domainic/type/constraint/constraints/method_presence_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/method_presence_constraint.rb
@@ -22,6 +22,8 @@ module Domainic
 
         # Get a short description of what this constraint expects
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] description of the expected method
         # @rbs override
         def short_description
@@ -29,6 +31,8 @@ module Domainic
         end
 
         # Get a short description of why the constraint was violated
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] description of the missing method
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/none_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/none_constraint.rb
@@ -32,6 +32,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description negating the expected constraint description
         # @rbs override
         def short_description
@@ -42,6 +44,8 @@ module Domainic
         #
         # This method provides detailed feedback when any constraints are satisfied,
         # listing all the ways in which the value failed validation.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all violating elements
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/nor_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/nor_constraint.rb
@@ -35,6 +35,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions with 'nor'
         # @rbs override
         def short_description
@@ -49,6 +51,8 @@ module Domainic
         #
         # This method provides detailed feedback about which constraints were satisfied,
         # listing all violations that caused the validation to fail.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all satisfied constraints
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/not_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/not_constraint.rb
@@ -31,6 +31,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] the negated constraint description
         # @rbs override
         def short_description
@@ -41,6 +43,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/or_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/or_constraint.rb
@@ -33,6 +33,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions with 'or'
         # @rbs override
         def short_description
@@ -46,6 +48,8 @@ module Domainic
         # @rbs! def expecting: (Behavior[untyped, untyped, untyped]) -> self
 
         # The description of the violations that caused the constraint to be unsatisfied.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # This method provides detailed feedback when no constraints are satisfied,
         # listing all the ways in which the value failed validation. Uses 'and' in the

--- a/domainic-type/lib/domainic/type/constraint/constraints/ordering_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/ordering_constraint.rb
@@ -34,6 +34,8 @@ module Domainic
 
         # Get a human-readable description of the ordering requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = OrderingConstraint.new(:self)
         #   constraint.description # => "ordered"
@@ -45,6 +47,8 @@ module Domainic
         end
 
         # Get a human-readable description of why ordering validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = OrderingConstraint.new(:self)

--- a/domainic-type/lib/domainic/type/constraint/constraints/parity_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/parity_constraint.rb
@@ -27,6 +27,8 @@ module Domainic
 
         # Get a human-readable description of the parity requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = ParityConstraint.new(:self).expecting(:even)
         #   constraint.short_description  # => "even"
@@ -38,6 +40,8 @@ module Domainic
         end
 
         # Get a human-readable description of why parity validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = ParityConstraint.new(:self).expecting(:positive)

--- a/domainic-type/lib/domainic/type/constraint/constraints/polarity_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/polarity_constraint.rb
@@ -37,6 +37,8 @@ module Domainic
 
         # Get a human-readable description of the polarity requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = PolarityConstraint.new(:self).expecting(:positive)
         #   constraint.short_description  # => "positive"
@@ -48,6 +50,8 @@ module Domainic
         end
 
         # Get a human-readable description of why polarity validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = PolarityConstraint.new(:self).expecting(:positive)

--- a/domainic-type/lib/domainic/type/constraint/constraints/predicate_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/predicate_constraint.rb
@@ -33,6 +33,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @note This constraint type does not provide a description as predicates are arbitrary.
         #
         # @return [String] an empty string
@@ -40,6 +42,8 @@ module Domainic
         def short_description = ''
 
         # Get a description of why the predicate validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] the custom violation description if provided
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/range_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/range_constraint.rb
@@ -58,6 +58,8 @@ module Domainic
 
         # Get a human-readable description of the range constraint.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example With both bounds
         #   constraint = RangeConstraint.new(:self, { minimum: 1, maximum: 10 })
         #   constraint.description
@@ -85,6 +87,8 @@ module Domainic
         end
 
         # The description of the violations that caused the constraint to be unsatisfied.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.

--- a/domainic-type/lib/domainic/type/constraint/constraints/type_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/type_constraint.rb
@@ -45,6 +45,8 @@ module Domainic
 
         # Get a human-readable description of the expected type.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = TypeConstraint.new(:self, Float)
         #   constraint.description # => "Float"
@@ -62,6 +64,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/constraints/uniqueness_constraint.rb
+++ b/domainic-type/lib/domainic/type/constraint/constraints/uniqueness_constraint.rb
@@ -29,6 +29,8 @@ module Domainic
 
         # Get a human-readable description of the uniqueness requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = UniquenessConstraint.new(:self)
         #   constraint.description # => "unique"
@@ -43,6 +45,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         # @rbs override

--- a/domainic-type/lib/domainic/type/constraint/set.rb
+++ b/domainic-type/lib/domainic/type/constraint/set.rb
@@ -34,6 +34,9 @@ module Domainic
       class Set
         extend Forwardable
 
+        # @rbs skip
+        extend Gem::Deprecate
+
         # @rbs @lookup: Hash[Type::accessor, Hash[Symbol, Behavior]]
 
         # Initialize a new empty constraint set.
@@ -121,6 +124,8 @@ module Domainic
 
         # The aggregate description of all constraints in the set.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] The description of all constraints
         # @rbs () -> String
         def description
@@ -128,6 +133,7 @@ module Domainic
             @lookup[accessor].values.filter_map(&:full_description)
           end.join(', ').strip
         end
+        deprecate :description, :none, 2025, 3 # steep:ignore
 
         # @!method each
         #   Iterate over each constraint in the set.
@@ -221,6 +227,8 @@ module Domainic
 
         # The aggregate violation description of all constraints in the set.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] The description of all constraints
         # @rbs () -> String
         def violation_description
@@ -228,6 +236,7 @@ module Domainic
             @lookup[accessor].values.reject(&:successful?).filter_map(&:full_violation_description)
           end.join(', ').strip
         end
+        deprecate :violation_description, :none, 2025, 3 # steep:ignore
 
         private
 

--- a/domainic-type/sig/domainic/type/constraint/behavior.rbs
+++ b/domainic-type/sig/domainic/type/constraint/behavior.rbs
@@ -97,10 +97,14 @@ module Domainic
 
         # The full description of the constraint.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String, nil] The full description of the constraint.
         def full_description: () -> String?
 
         # The full description of the violations that caused the constraint to be unsatisfied.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String, nil] The full description of the constraint when it fails.
         def full_violation_description: () -> String?
@@ -124,6 +128,8 @@ module Domainic
         # Implementing classes should override this to provide meaningful descriptions of their
         # constraint behavior.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] The description of the constraint.
         def short_description: () -> String
 
@@ -131,6 +137,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         def short_violation_description: () -> String
@@ -239,6 +247,8 @@ module Domainic
         private
 
         # Generate the full description for the corresponding short description.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @param description [String] The short description to expand.
         #

--- a/domainic-type/sig/domainic/type/constraint/constraints/all_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/all_constraint.rbs
@@ -26,6 +26,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] the constraint description
         def short_description: ...
 
@@ -33,6 +35,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/and_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/and_constraint.rbs
@@ -29,6 +29,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions with 'and'
         def short_description: ...
 
@@ -38,6 +40,8 @@ module Domainic
         #
         # This method provides detailed feedback about which constraints failed,
         # listing all violations that prevented validation from succeeding.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all constraints
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/any_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/any_constraint.rbs
@@ -28,6 +28,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions
         def short_description: ...
 
@@ -35,6 +37,8 @@ module Domainic
         #
         # This method provides detailed feedback when no constraints are satisfied,
         # listing all the ways in which the value failed validation.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all constraints
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/attribute_presence_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/attribute_presence_constraint.rbs
@@ -45,10 +45,14 @@ module Domainic
 
         # Get a description of what the constraint expects
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] the constraint description
         def short_description: ...
 
         # Get a description of why the constraint was violated
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] the violation description
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/case_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/case_constraint.rbs
@@ -38,6 +38,8 @@ module Domainic
 
         # Get a human-readable description of the case requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = CaseConstraint.new(:self, :upper)
         #   constraint.short_description # => "upper case"
@@ -46,6 +48,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why case validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = CaseConstraint.new(:self, :upper)

--- a/domainic-type/sig/domainic/type/constraint/constraints/character_set_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/character_set_constraint.rbs
@@ -40,6 +40,8 @@ module Domainic
 
         # Get a human-readable description of the character set requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = CharacterSetConstraint.new(:self, :numeric)
         #   constraint.short_description # => "only numeric characters"
@@ -48,6 +50,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why character validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = CharacterSetConstraint.new(:self, :numeric)

--- a/domainic-type/sig/domainic/type/constraint/constraints/divisibility_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/divisibility_constraint.rbs
@@ -39,6 +39,8 @@ module Domainic
 
         # Get a human-readable description of the divisibility requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = DivisibilityConstraint.new(:self, 5)
         #   constraint.short_description # => "divisible by 5"
@@ -47,6 +49,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why divisibility validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example With non-numeric value
         #   constraint = DivisibilityConstraint.new(:self, 5)

--- a/domainic-type/sig/domainic/type/constraint/constraints/emptiness_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/emptiness_constraint.rbs
@@ -24,6 +24,8 @@ module Domainic
 
         # Get a human-readable description of the emptiness requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = EmptinessConstraint.new(:self)
         #   constraint.description # => "empty"
@@ -32,6 +34,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why emptiness validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = EmptinessConstraint.new(:self)

--- a/domainic-type/sig/domainic/type/constraint/constraints/equality_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/equality_constraint.rbs
@@ -30,6 +30,8 @@ module Domainic
 
         # Get a human-readable description of the equality requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = EqualityConstraint.new(:self, 42)
         #   constraint.description # => "equal to 42"
@@ -38,6 +40,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why equality validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = EqualityConstraint.new(:self, 42)

--- a/domainic-type/sig/domainic/type/constraint/constraints/finiteness_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/finiteness_constraint.rbs
@@ -26,10 +26,14 @@ module Domainic
 
         # Get a human-readable description of the finiteness requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] Description of the finiteness requirement
         def short_description: ...
 
         # Get a human-readable description of why finiteness validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] Description of the validation failure
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/inclusion_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/inclusion_constraint.rbs
@@ -29,6 +29,8 @@ module Domainic
 
         # Get a human-readable description of the inclusion requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = InclusionConstraint.new(:self, 42)
         #   constraint.short_description # => "including 42"
@@ -37,6 +39,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why inclusion validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = InclusionConstraint.new(:self, 42)

--- a/domainic-type/sig/domainic/type/constraint/constraints/instance_of_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/instance_of_constraint.rbs
@@ -24,6 +24,8 @@ module Domainic
 
         # Get a human-readable description of the instance requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = InstanceOfConstraint.new(:self, String)
         #   constraint.description # => "instance of String"
@@ -32,6 +34,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why instance validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = InstanceOfConstraint.new(:self, String)

--- a/domainic-type/sig/domainic/type/constraint/constraints/match_pattern_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/match_pattern_constraint.rbs
@@ -24,6 +24,8 @@ module Domainic
 
         # Get a human-readable description of the pattern requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = MatchPatternConstraint.new(:self, /\d+/)
         #   constraint.short_description # => "matches /\\d+/"
@@ -32,6 +34,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why pattern validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = MatchPatternConstraint.new(:self, /\d+/)

--- a/domainic-type/sig/domainic/type/constraint/constraints/method_presence_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/method_presence_constraint.rbs
@@ -18,10 +18,14 @@ module Domainic
 
         # Get a short description of what this constraint expects
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] description of the expected method
         def short_description: ...
 
         # Get a short description of why the constraint was violated
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] description of the missing method
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/none_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/none_constraint.rbs
@@ -28,6 +28,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description negating the expected constraint description
         def short_description: ...
 
@@ -35,6 +37,8 @@ module Domainic
         #
         # This method provides detailed feedback when any constraints are satisfied,
         # listing all the ways in which the value failed validation.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all violating elements
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/nor_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/nor_constraint.rbs
@@ -31,6 +31,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions with 'nor'
         def short_description: ...
 
@@ -38,6 +40,8 @@ module Domainic
         #
         # This method provides detailed feedback about which constraints were satisfied,
         # listing all violations that caused the validation to fail.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The combined violation descriptions from all satisfied constraints
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/not_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/not_constraint.rbs
@@ -27,6 +27,8 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] the negated constraint description
         def short_description: ...
 
@@ -34,6 +36,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/or_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/or_constraint.rbs
@@ -29,12 +29,16 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] a description combining all constraint descriptions with 'or'
         def short_description: ...
 
         def expecting: (Behavior[untyped, untyped, untyped]) -> self
 
         # The description of the violations that caused the constraint to be unsatisfied.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # This method provides detailed feedback when no constraints are satisfied,
         # listing all the ways in which the value failed validation. Uses 'and' in the

--- a/domainic-type/sig/domainic/type/constraint/constraints/ordering_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/ordering_constraint.rbs
@@ -30,6 +30,8 @@ module Domainic
 
         # Get a human-readable description of the ordering requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = OrderingConstraint.new(:self)
         #   constraint.description # => "ordered"
@@ -38,6 +40,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why ordering validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = OrderingConstraint.new(:self)

--- a/domainic-type/sig/domainic/type/constraint/constraints/parity_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/parity_constraint.rbs
@@ -22,6 +22,8 @@ module Domainic
 
         # Get a human-readable description of the parity requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = ParityConstraint.new(:self).expecting(:even)
         #   constraint.short_description  # => "even"
@@ -30,6 +32,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why parity validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = ParityConstraint.new(:self).expecting(:positive)

--- a/domainic-type/sig/domainic/type/constraint/constraints/polarity_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/polarity_constraint.rbs
@@ -32,6 +32,8 @@ module Domainic
 
         # Get a human-readable description of the polarity requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = PolarityConstraint.new(:self).expecting(:positive)
         #   constraint.short_description  # => "positive"
@@ -40,6 +42,8 @@ module Domainic
         def short_description: ...
 
         # Get a human-readable description of why polarity validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @example
         #   constraint = PolarityConstraint.new(:self).expecting(:positive)

--- a/domainic-type/sig/domainic/type/constraint/constraints/predicate_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/predicate_constraint.rbs
@@ -28,12 +28,16 @@ module Domainic
 
         # Get a description of what the constraint expects.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @note This constraint type does not provide a description as predicates are arbitrary.
         #
         # @return [String] an empty string
         def short_description: ...
 
         # Get a description of why the predicate validation failed.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] the custom violation description if provided
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/range_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/range_constraint.rbs
@@ -53,6 +53,8 @@ module Domainic
 
         # Get a human-readable description of the range constraint.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example With both bounds
         #   constraint = RangeConstraint.new(:self, { minimum: 1, maximum: 10 })
         #   constraint.description
@@ -70,6 +72,8 @@ module Domainic
         def short_description: ...
 
         # The description of the violations that caused the constraint to be unsatisfied.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.

--- a/domainic-type/sig/domainic/type/constraint/constraints/type_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/type_constraint.rbs
@@ -40,6 +40,8 @@ module Domainic
 
         # Get a human-readable description of the expected type.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = TypeConstraint.new(:self, Float)
         #   constraint.description # => "Float"
@@ -54,6 +56,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/constraints/uniqueness_constraint.rbs
+++ b/domainic-type/sig/domainic/type/constraint/constraints/uniqueness_constraint.rbs
@@ -25,6 +25,8 @@ module Domainic
 
         # Get a human-readable description of the uniqueness requirement.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @example
         #   constraint = UniquenessConstraint.new(:self)
         #   constraint.description # => "unique"
@@ -36,6 +38,8 @@ module Domainic
         #
         # This is used to help compose a error message when the constraint is not satisfied.
         # Implementing classes can override this to provide more specific failure messages.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of the constraint when it fails.
         def short_violation_description: ...

--- a/domainic-type/sig/domainic/type/constraint/set.rbs
+++ b/domainic-type/sig/domainic/type/constraint/set.rbs
@@ -79,6 +79,8 @@ module Domainic
 
         # The aggregate description of all constraints in the set.
         #
+        # @deprecated this method will be removed in version 0.1.0
+        #
         # @return [String] The description of all constraints
         def description: () -> String
 
@@ -132,6 +134,8 @@ module Domainic
         def prepare: (Type::accessor accessor, String | Symbol constraint_type, ?untyped expectation, **untyped options) -> Behavior
 
         # The aggregate violation description of all constraints in the set.
+        #
+        # @deprecated this method will be removed in version 0.1.0
         #
         # @return [String] The description of all constraints
         def violation_description: () -> String

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -30,7 +30,7 @@ gems:
   source:
     type: rubygems
 - name: domainic-type
-  version: 0.1.0.alpha.3.4.0
+  version: 0.1.0.alpha.3.4.1
   source:
     type: rubygems
 - name: fileutils


### PR DESCRIPTION
This release updates the `domainic-type` gem to version `0.1.0.alpha.3.4.1`, reflecting the following changes:

* Updated `Gemfile.lock` to reference the new version.
* Updated documentation references (`README.md`, `SECURITY.md`, and experimental examples) to reflect the version bump.
* Updated hyperlinks in examples to point to `v0.1.0.alpha.3.4.1`.
* Updated `domainic-type.gemspec` to set the gem version and semantic version to `0.1.0.alpha.3.4.1`.

This release prepares for continued testing and feedback as part of the alpha phase of `domainic-type`.