### PR TITLE
Release domainic-attributer v0.2.0

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -46,8 +46,8 @@ If you have suggestions on how this process could be improved, please submit a p
 
 |  Version  | Support |
 |:---------:|:-------:|
-|  `0.1.0`  |    ✅   |
-| `> 0.1.0` |    ❌   |
+|  `0.2.0`  |    ✅   |
+| `> 0.2.0` |    ❌   |
 
 ### domainic-boundary
 

--- a/docs/projects/domainic-v0.1.0/README.md
+++ b/docs/projects/domainic-v0.1.0/README.md
@@ -35,6 +35,8 @@ on domain modeling, clean architecture, and type safety.
   * [Announcing Domainic::Command v0.1.0!](./updates/2024-12-29-01.md)
 * **December 30, 2024**
   * [Domainic::Type Experiment Name Change](./updates/2024-12-30-01.md)
+* **January 1, 2025**
+  * [domainic-attributer v0.2.0 Released](./updates/2025-01-01-01.md)
 
 ## Key Components
 

--- a/docs/projects/domainic-v0.1.0/updates/2025-01-01-01.md
+++ b/docs/projects/domainic-v0.1.0/updates/2025-01-01-01.md
@@ -1,0 +1,50 @@
+# domainic-attributer v0.2.0 Released! 🎉
+
+We're excited to announce the release of domainic-attributer v0.2.0! This release focuses on improved error handling
+and dependency management.
+
+## What's New in v0.2.0
+
+### Enhanced Error Handling
+
+* New specialized error classes for clearer error reporting:
+  * `ValidationExecutionError`
+  * `CallbackExecutionError`
+  * `CoercionExecutionError`
+
+### Other Improvements
+
+* Improved nil value handling in coercion
+* Removed implicit RSpec dependency
+* Documentation improvements
+* Various bug fixes
+
+> [!NOTE]
+> view the full [changelog](https://github.com/domainic/domainic/blob/domainic-attributer-v0.2.0/domainic-attributer/CHANGELOG.md)
+> for more details.
+
+## What's Next
+
+Work is already underway on domainic-attributer v0.3.0, which will bring several exciting improvements:
+
+* Custom validation error messages for better error reporting
+* Support for immutable attributes
+* Configurable feature toggles for initialization and validation
+* Default attribute configurations at both global and class levels
+* Improved error backtraces for easier debugging
+
+Follow our progress or get involved:
+
+* [View Milestone](https://github.com/domainic/domainic/milestone/8)
+* [Open Tasks](https://github.com/domainic/domainic/issues?q=is%3Aopen+milestone%3A%22domainic-attributer+v0.3.0%22)
+* [Project Board](https://github.com/domainic/domainic/projects/13)
+
+## Feedback Welcome
+
+We'd love to hear from you! Try out domainic-attributer v0.2.0 and:
+
+* [Report issues](https://github.com/domainic/domainic/issues)
+* [Contribute](https://github.com/domainic/domainic/wiki/CONTRIBUTING)
+* [Star us on GitHub](https://github.com/domainic/domainic)
+
+Thank you to everyone who provided feedback and helped shape this release!

--- a/domainic-attributer/CHANGELOG.md
+++ b/domainic-attributer/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+## [v0.2.0] - 2025-01-01
+
 ### Added
 
 * [#22](https://github.com/domainic/domainic/pull/22) Specialized error classes (`ValidationExecutionError`,
@@ -38,5 +40,6 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 <!-- versions -->
 
-[Unreleased]: https://github.com/domainic/domainic/compare/domainic-attributer-v0.1.0...HEAD
+[Unreleased]: https://github.com/domainic/domainic/compare/domainic-attributer-v0.2.0...HEAD
+[v0.2.0]: https://github.com/domainic/domainic/compare/domainic-attributer-v0.1.0...domainic-attributer-v0.2.0
 [v0.1.0]: https://github.com/domainic/domainic/compare/53f3e992ab0e3f0092fd842c4cf89c22e41afa8a...domainic-attributer-v0.1.0

--- a/domainic-attributer/docs/USAGE.md
+++ b/domainic-attributer/docs/USAGE.md
@@ -125,7 +125,7 @@ The following errors are raised by Domainic::Attributer when internal processing
 * `CoercionExecutionError` - Raised when a coercion handler raises an error
 * `CallbackExecutionError` - Raised when a change callback raises an error
 
-These errors can be rescued for debugging or error handling:
+These errors can be caught and handled for debugging or error recovery:
 
 ```ruby
 class TimeMachine
@@ -152,6 +152,8 @@ rescue Domainic::Attributer::CallbackExecutionError => e
   puts "Time travel failed: #{e.message}"
 end
 ```
+
+[![Return to Top](https://img.shields.io/badge/%E2%96%B2%20Return%20to%20Top-blue?style=for-the-badge)](#table-of-contents)
 
 ## Features
 
@@ -560,6 +562,8 @@ class StrictConfig
 end
 ```
 
+[![Return to Top](https://img.shields.io/badge/%E2%96%B2%20Return%20to%20Top-blue?style=for-the-badge)](#table-of-contents)
+
 ## Best Practices
 
 ### Validation vs Coercion
@@ -621,6 +625,8 @@ class BattleMech
   end
 end
 ```
+
+[![Return to Top](https://img.shields.io/badge/%E2%96%B2%20Return%20to%20Top-blue?style=for-the-badge)](#table-of-contents)
 
 ## Advanced Topics
 
@@ -713,3 +719,5 @@ end
 
 This completes our comprehensive guide to Domainic::Attributer. Remember that the key to effective use is finding the
 right balance of validation, coercion, and error handling for your specific needs.
+
+[![Return to Top](https://img.shields.io/badge/%E2%96%B2%20Return%20to%20Top-blue?style=for-the-badge)](#table-of-contents)

--- a/domainic-attributer/lib/domainic/attributer/attribute/callback.rb
+++ b/domainic-attributer/lib/domainic/attributer/attribute/callback.rb
@@ -10,7 +10,7 @@ module Domainic
       #
       # This class handles the execution of callbacks that are triggered when an
       # attribute's value changes. Each callback must be a Proc that accepts two
-      # arguments: the old value and the new value
+      # arguments: the old value, and the new value
       #
       # @api private
       # @!visibility private

--- a/domainic-attributer/sig/domainic/attributer/attribute/callback.rbs
+++ b/domainic-attributer/sig/domainic/attributer/attribute/callback.rbs
@@ -5,7 +5,7 @@ module Domainic
       #
       # This class handles the execution of callbacks that are triggered when an
       # attribute's value changes. Each callback must be a Proc that accepts two
-      # arguments: the old value and the new value
+      # arguments: the old value, and the new value
       #
       # @api private
       # @!visibility private


### PR DESCRIPTION
This releases domainic-attributer v0.2.0

Key Changes in v0.2.0:
* New specialized error classes for validation, callback, and coercion failures
* Improved nil value handling in coercion
* Removed implicit RSpec dependency
* Various bug fixes and documentation improvements