### PR TITLE
Fix/alias typos enumerable behavior

### DIFF
--- a/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
@@ -254,7 +254,7 @@ module Domainic
           # @type self: Object & Behavior
           constrain :first, :equality, literal, concerning: :first_entry_value, description: 'with first entry'
         end
-        alias begining_with starting_with
+        alias beginning_with starting_with
         alias leading_with starting_with
       end
     end

--- a/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
+++ b/domainic-type/lib/domainic/type/behavior/enumerable_behavior.rb
@@ -128,10 +128,10 @@ module Domainic
           # @type self: Object & Behavior
           constrain :entries, :ordering, description: 'being'
         end
-        alias being_aranged being_sorted
+        alias being_arranged being_sorted
         alias being_ordered being_sorted
         alias being_sequential being_sorted
-        alias aranged being_sorted
+        alias arranged being_sorted
         alias ordered being_sorted
         alias sorted being_sorted
         alias sequential being_sorted

--- a/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
@@ -229,7 +229,7 @@ module Domainic
         # @return [self] self for method chaining
         def starting_with: (untyped literal) -> Behavior
 
-        alias begining_with starting_with
+        alias beginning_with starting_with
 
         alias leading_with starting_with
       end

--- a/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
+++ b/domainic-type/sig/domainic/type/behavior/enumerable_behavior.rbs
@@ -119,13 +119,13 @@ module Domainic
         # @return [self] self for method chaining
         def being_sorted: () -> Behavior
 
-        alias being_aranged being_sorted
+        alias being_arranged being_sorted
 
         alias being_ordered being_sorted
 
         alias being_sequential being_sorted
 
-        alias aranged being_sorted
+        alias arranged being_sorted
 
         alias ordered being_sorted
 


### PR DESCRIPTION
## Description

<!-- Provide a brief, clear description of the changes introduced by this PR -->
This PR fixes alias typos in `EnumerableBehavior` related to sorting and arrangement methods.  
The misspellings `aranged` → `arranged` and `being_aranged` → `being_arranged` have been corrected.

## Related Issues
Fixes #187

<!-- Link to any related issues using the format: "Fixes #123" or "Related to #456" -->

## Changes Made
- Renamed `being_aranged` to `being_arranged`
- Renamed `aranged` to `arranged`

<!-- List the key changes made in this PR -->

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [ ] I have added/updated tests that prove my fix/feature works
* [ ] I have added/updated documentation as needed

## Additional Notes

<!-- Any additional information that reviewers should know -->
- This is not a breaking change unless other projects explicitly rely on the old, misspelled aliases.
- If needed, we can mark the old aliases as deprecated instead of removing them, but for now, this change simply replaces them with correctly spelled aliases.