### PR TITLE
Domainic command/feature/add and then method

### DIFF
--- a/domainic-command/docs/USAGE.md
+++ b/domainic-command/docs/USAGE.md
@@ -199,6 +199,18 @@ result.errors.full_messages # => Array of formatted messages
 result.status_code # => 0 for success, other codes for failures
 ```
 
+### Chaining Commands with `and_then`
+
+You can chain multiple commands using the `and_then` method. This allows for sequential execution where each command depends on the success of the previous one:
+
+```ruby
+CreateUser.call(name: "John")
+  .and_then { |r| SendWelcomeEmail.call(user_id: r.user.id) }
+  .and_then { |r| NotifyAdmin.call(user_id: r.user.id) }
+```
+
+In this example, `SendWelcomeEmail` will only be executed if `CreateUser` is successful, and `NotifyAdmin` will only run if `SendWelcomeEmail` is also successful. The results from each command can be passed to the next command in the chain.
+
 ## Advanced Features
 
 ### Type Safety with Domainic::Type

--- a/domainic-command/docs/USAGE.md
+++ b/domainic-command/docs/USAGE.md
@@ -201,7 +201,8 @@ result.status_code # => 0 for success, other codes for failures
 
 ### Chaining Commands with `and_then`
 
-You can chain multiple commands using the `and_then` method. This allows for sequential execution where each command depends on the success of the previous one:
+You can chain multiple commands using the `and_then` method.
+This allows for sequential execution where each command depends on the success of the previous one:
 
 ```ruby
 CreateUser.call(name: "John")
@@ -209,7 +210,10 @@ CreateUser.call(name: "John")
   .and_then { |r| NotifyAdmin.call(user_id: r.user.id) }
 ```
 
-In this example, `SendWelcomeEmail` will only be executed if `CreateUser` is successful, and `NotifyAdmin` will only run if `SendWelcomeEmail` is also successful. The results from each command can be passed to the next command in the chain.
+In this example, `SendWelcomeEmail` will only be executed if `CreateUser` is successful,
+and `NotifyAdmin` will only run if `SendWelcomeEmail` is also successful.
+
+The results from each command can be passed to the next command in the chain.
 
 ## Advanced Features
 

--- a/domainic-command/lib/domainic/command/result.rb
+++ b/domainic-command/lib/domainic/command/result.rb
@@ -121,29 +121,6 @@ module Domainic
       end
       private_class_method :new
 
-      # Chains the execution of another command based on the current result's success.
-      #
-      # This method allows you to conditionally execute further logic or commands
-      # if the current result is successful. If the current result is a failure,
-      # it is returned immediately without invoking the provided block.
-      #
-      # @example Chaining commands with and_then
-      #   result = CreateUser.call(name: "John")
-      #              .and_then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
-      #              .and_then { |r| NotifyAdmin.call(user_id: r.user[:id]) }
-      #
-      # @yield [result] Provides the current successful result to the block.
-      # @yieldparam [Result] result The current successful result object.
-      # @yieldreturn [Object] Any object resulting from the block.
-      #
-      # @return [Object] The new result or output object, or the current result if failed.
-      # @rbs () { (self) -> self } -> self
-      def and_then
-        return self if failure?
-
-        yield(self)
-      end
-
       # Indicates whether the command failed
       #
       # @return [Boolean] true if the command failed; false otherwise
@@ -152,7 +129,6 @@ module Domainic
         status_code != STATUS::SUCCESS
       end
       alias failed? failure?
-
       # Indicates whether the command succeeded
       #
       # @return [Boolean] true if the command succeeded; false otherwise
@@ -161,6 +137,30 @@ module Domainic
         status_code == STATUS::SUCCESS
       end
       alias success? successful?
+
+      # Chains the execution of another command based on the current result's success.
+      #
+      # This method allows you to conditionally execute further logic or commands
+      # if the current result is successful. If the current result is a failure,
+      # it is returned immediately without invoking the provided block.
+      #
+      # @example Chaining commands with then
+      #   result = CreateUser.call(name: "John")
+      #              .then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
+      #              .then { |r| NotifyAdmin.call(user_id: r.user[:id]) }
+      #
+      # @yield [result] Provides the current successful result to the block.
+      # @yieldparam [Result] result The current successful result object.
+      # @yieldreturn [Object] Any object resulting from the block.
+      #
+      # @return [Object] The new result or output object, or the current result if failed.
+      # @rbs () { (self) -> untyped } -> untyped
+      def then
+        return self if failure?
+
+        yield(self)
+      end
+      alias and_then then
 
       private
 

--- a/domainic-command/lib/domainic/command/result.rb
+++ b/domainic-command/lib/domainic/command/result.rb
@@ -136,17 +136,17 @@ module Domainic
       # @yieldreturn [Result] A new Result object from the executed command.
       #
       # @return [Result] The new result object if successful, or the current result if failed.
-      # @rbs def and_then: () { (self) -> Result } -> Result
+      # @rbs () { (self) -> self } -> self
       def and_then
         return self if failure?
 
         new_result = yield(self)
 
-        if new_result.is_a?(Result)
-          new_result
-        else
-          self
+        unless new_result.is_a?(self.class)
+          raise TypeError, "Block must return a #{self.class}, got #{new_result.class}"
         end
+
+        new_result
       end
 
       # Indicates whether the command failed

--- a/domainic-command/lib/domainic/command/result.rb
+++ b/domainic-command/lib/domainic/command/result.rb
@@ -130,23 +130,18 @@ module Domainic
       # @example Chaining commands with and_then
       #   result = CreateUser.call(name: "John")
       #              .and_then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
+      #              .and_then { |r| NotifyAdmin.call(user_id: r.user[:id]) }
       #
       # @yield [result] Provides the current successful result to the block.
       # @yieldparam [Result] result The current successful result object.
-      # @yieldreturn [Result] A new Result object from the executed command.
+      # @yieldreturn [Object] Any object resulting from the block.
       #
-      # @return [Result] The new result object if successful, or the current result if failed.
+      # @return [Object] The new result or output object, or the current result if failed.
       # @rbs () { (self) -> self } -> self
       def and_then
         return self if failure?
 
-        new_result = yield(self)
-
-        unless new_result.is_a?(self.class)
-          raise TypeError, "Block must return a #{self.class}, got #{new_result.class}"
-        end
-
-        new_result
+        yield(self)
       end
 
       # Indicates whether the command failed

--- a/domainic-command/lib/domainic/command/result.rb
+++ b/domainic-command/lib/domainic/command/result.rb
@@ -121,6 +121,34 @@ module Domainic
       end
       private_class_method :new
 
+      # Chains the execution of another command based on the current result's success.
+      #
+      # This method allows you to conditionally execute further logic or commands
+      # if the current result is successful. If the current result is a failure,
+      # it is returned immediately without invoking the provided block.
+      #
+      # @example Chaining commands with and_then
+      #   result = CreateUser.call(name: "John")
+      #              .and_then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
+      #
+      # @yield [result] Provides the current successful result to the block.
+      # @yieldparam [Result] result The current successful result object.
+      # @yieldreturn [Result] A new Result object from the executed command.
+      #
+      # @return [Result] The new result object if successful, or the current result if failed.
+      # @rbs def and_then: () { (self) -> Result } -> Result
+      def and_then
+        return self if failure?
+
+        new_result = yield(self)
+
+        if new_result.is_a?(Result)
+          new_result
+        else
+          self
+        end
+      end
+
       # Indicates whether the command failed
       #
       # @return [Boolean] true if the command failed; false otherwise

--- a/domainic-command/sig/domainic/command/result.rbs
+++ b/domainic-command/sig/domainic/command/result.rbs
@@ -109,12 +109,13 @@ module Domainic
       # @example Chaining commands with and_then
       #   result = CreateUser.call(name: "John")
       #              .and_then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
+      #              .and_then { |r| NotifyAdmin.call(user_id: r.user[:id]) }
       #
       # @yield [result] Provides the current successful result to the block.
       # @yieldparam [Result] result The current successful result object.
-      # @yieldreturn [Result] A new Result object from the executed command.
+      # @yieldreturn [Object] Any object resulting from the block.
       #
-      # @return [Result] The new result object if successful, or the current result if failed.
+      # @return [Object] The new result or output object, or the current result if failed.
       def and_then: () { (self) -> self } -> self
 
       # Indicates whether the command failed

--- a/domainic-command/sig/domainic/command/result.rbs
+++ b/domainic-command/sig/domainic/command/result.rbs
@@ -100,24 +100,6 @@ module Domainic
       # @return [void]
       def initialize: (Integer status, ?context: Hash[String | Symbol, untyped], ?errors: untyped) -> void
 
-      # Chains the execution of another command based on the current result's success.
-      #
-      # This method allows you to conditionally execute further logic or commands
-      # if the current result is successful. If the current result is a failure,
-      # it is returned immediately without invoking the provided block.
-      #
-      # @example Chaining commands with and_then
-      #   result = CreateUser.call(name: "John")
-      #              .and_then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
-      #              .and_then { |r| NotifyAdmin.call(user_id: r.user[:id]) }
-      #
-      # @yield [result] Provides the current successful result to the block.
-      # @yieldparam [Result] result The current successful result object.
-      # @yieldreturn [Object] Any object resulting from the block.
-      #
-      # @return [Object] The new result or output object, or the current result if failed.
-      def and_then: () { (self) -> self } -> self
-
       # Indicates whether the command failed
       #
       # @return [Boolean] true if the command failed; false otherwise
@@ -131,6 +113,26 @@ module Domainic
       def successful?: () -> bool
 
       alias success? successful?
+
+      # Chains the execution of another command based on the current result's success.
+      #
+      # This method allows you to conditionally execute further logic or commands
+      # if the current result is successful. If the current result is a failure,
+      # it is returned immediately without invoking the provided block.
+      #
+      # @example Chaining commands with then
+      #   result = CreateUser.call(name: "John")
+      #              .then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
+      #              .then { |r| NotifyAdmin.call(user_id: r.user[:id]) }
+      #
+      # @yield [result] Provides the current successful result to the block.
+      # @yieldparam [Result] result The current successful result object.
+      # @yieldreturn [Object] Any object resulting from the block.
+      #
+      # @return [Object] The new result or output object, or the current result if failed.
+      def then: () { (self) -> untyped } -> untyped
+
+      alias and_then then
 
       private
 

--- a/domainic-command/sig/domainic/command/result.rbs
+++ b/domainic-command/sig/domainic/command/result.rbs
@@ -100,6 +100,23 @@ module Domainic
       # @return [void]
       def initialize: (Integer status, ?context: Hash[String | Symbol, untyped], ?errors: untyped) -> void
 
+      # Chains the execution of another command based on the current result's success.
+      #
+      # This method allows you to conditionally execute further logic or commands
+      # if the current result is successful. If the current result is a failure,
+      # it is returned immediately without invoking the provided block.
+      #
+      # @example Chaining commands with and_then
+      #   result = CreateUser.call(name: "John")
+      #              .and_then { |r| SendWelcomeEmail.call(user_id: r.user[:id]) }
+      #
+      # @yield [result] Provides the current successful result to the block.
+      # @yieldparam [Result] result The current successful result object.
+      # @yieldreturn [Result] A new Result object from the executed command.
+      #
+      # @return [Result] The new result object if successful, or the current result if failed.
+      def and_then: () { (self) -> self } -> self
+
       # Indicates whether the command failed
       #
       # @return [Boolean] true if the command failed; false otherwise

--- a/domainic-command/spec/domainic/command/result_spec.rb
+++ b/domainic-command/spec/domainic/command/result_spec.rb
@@ -41,36 +41,19 @@ RSpec.describe Domainic::Command::Result do
     subject(:result) { initial_result.and_then(&block) }
 
     let(:initial_result) { described_class.success(value: 42) }
-    let(:block) { ->(r) { described_class.success(value: r.value * 2) } }
+    let(:block) { ->(r) { r.value * 2 } }
 
     context 'when the initial result is successful' do
-      it 'is expected to execute the block and return a successful result' do
-        expect(result).to be_successful
-      end
-
-      it 'is expected to return the correct transformed value' do
-        expect(result.value).to eq(84)
+      it 'is expected to execute the block and return the block result' do
+        expect(result).to eq(84)
       end
     end
 
     context 'when the initial result is a failure' do
       let(:initial_result) { described_class.failure({ base: 'error' }) }
 
-      it 'is expected to return a failure result' do
-        expect(result).to be_failure
-      end
-
-      it 'is expected to preserve the original error' do
-        expect(result.errors[:base]).to eq(['error'])
-      end
-    end
-
-    context 'when the block does not return a Result' do
-      let(:block) { ->(_r) { 'not a result' } }
-
-      it 'is expected to raise a TypeError' do
-        expect { result }
-          .to raise_error(TypeError, /Block must return a Domainic::Command::Result/)
+      it 'is expected to return the original failure result' do
+        expect(result).to eq(initial_result)
       end
     end
 

--- a/domainic-command/spec/domainic/command/result_spec.rb
+++ b/domainic-command/spec/domainic/command/result_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Domainic::Command::Result do
     end
   end
 
-  describe '#and_then', rbs: :skip do
+  describe '#and_then' do
     subject(:result) { initial_result.and_then(&block) }
 
     let(:initial_result) { described_class.success(value: 42) }

--- a/domainic-command/spec/domainic/command/result_spec.rb
+++ b/domainic-command/spec/domainic/command/result_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Domainic::Command::Result do
     end
   end
 
-  describe '#and_then' do
+  describe '#and_then', rbs: :skip do
     subject(:result) { initial_result.and_then(&block) }
 
     let(:initial_result) { described_class.success(value: 42) }
@@ -68,8 +68,9 @@ RSpec.describe Domainic::Command::Result do
     context 'when the block does not return a Result' do
       let(:block) { ->(_r) { 'not a result' } }
 
-      it 'is expected to return the original result' do
-        expect(result).to eq(initial_result)
+      it 'is expected to raise a TypeError' do
+        expect { result }
+          .to raise_error(TypeError, /Block must return a Domainic::Command::Result/)
       end
     end
 


### PR DESCRIPTION
## Description
This PR adds the and_then method to the Domainic::Command::Result class, enabling a functional and chainable approach to handling command results. This simplifies the process of chaining commands and reduces boilerplate code for error handling.
<!-- Provide a brief, clear description of the changes introduced by this PR -->

## Related Issues
Fixes #176
<!-- Link to any related issues using the format: "Fixes #123" or "Related to #456" -->

## Changes Made

<!-- List the key changes made in this PR -->

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed

## Additional Notes
<!-- Any additional information that reviewers should know -->

**Implementation Details**
- The and_then method ensures a safe and predictable flow of command chaining.
- If the block does not return a Result, the chain is terminated with the original result.

**Functional Validation**
The following example was tested successfully in irb:
```rb
result = Domainic::Command::Result.success(value: 42)
chained_result = result
  .and_then { |r| Domainic::Command::Result.success(value: r.value * 2) }
  .and_then { |r| Domainic::Command::Result.success(value: r.value + 10) }

puts chained_result.successful? # => true
puts chained_result.value       # => 94
```

**Failure Handling Validation**
```rb
result = Domainic::Command::Result.failure({ error: 'initial failure' })
chained_result = result.and_then { |r| Domainic::Command::Result.success(value: r.value * 2) }

puts chained_result.failure?          # => true
puts chained_result.errors[:error]    # => ["initial failure"]
```

**Exception in Block:**
```rb
result = Domainic::Command::Result.success(value: 42)

# Chain with a block that raises an exception
begin
  result.and_then { |_r| raise "Unexpected error" }
rescue => e
  puts e.message  # => "Unexpected error"
end
```