### PR TITLE
Fix codacy error for external collaborators

### DIFF
--- a/.github/actions/test/ruby/action.yml
+++ b/.github/actions/test/ruby/action.yml
@@ -6,4 +6,8 @@ runs:
   steps:
     - name: Run rspec
       shell: bash
-      run: bin/dev test && bash <(curl -Ls https://coverage.codacy.com/get.sh)
+      run: bin/dev test
+    - name: Report Coverage
+      if: env.CODACY_PROJECT_TOKEN != ''
+      shell: bash
+      run: bash <(curl -Ls https://coverage.codacy.com/get.sh)


### PR DESCRIPTION
## Description

This fixes an error where the Test action would fail for external collaborators because github actions will not pass secrets to the runner unless the pull request author is a member of the Domainic organization.

## Related Issues

* see #192 
* see #193 
* see [build #263](https://github.com/domainic/domainic/actions/runs/12579657433)
* see [build #264](https://github.com/domainic/domainic/actions/runs/12579763662)

## Changes Made

* Updated the test/ruby action to not report coverage for external collaborators. This will cause the test action to stop raising errors for the missing codacy token as a side effect.

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [ ] I have added/updated tests that prove my fix/feature works
* [ ] I have added/updated documentation as needed