### PR TITLE
Fix docs/USAGE.md not included in gem package

### DIFF
--- a/domainic-command/domainic-command.gemspec
+++ b/domainic-command/domainic-command.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   spec.files = Dir.chdir(__dir__) do
-    Dir['{lib,sig}/**/*', '.yardopts', 'LICENSE', 'README.md', 'CHANGELOG.md'].reject { |f| File.directory?(f) }
+    Dir['{docs,lib,sig}/**/*', '.yardopts', 'LICENSE', 'README.md', 'CHANGELOG.md'].reject { |f| File.directory?(f) }
   end
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
## Description

This ensures docs/USAGE.md is included with the distributed gem.

## Related Issues

* fixes #173

## Changes Made

* added docs to the gemspec files

## Checklist

Before submitting this PR, please ensure:
* [x] I have run `bin/dev ci` and all checks pass
* [x] I have added/updated tests that prove my fix/feature works
* [x] I have added/updated documentation as needed